### PR TITLE
Introducing event builder v2

### DIFF
--- a/optimizely/event_builder.py
+++ b/optimizely/event_builder.py
@@ -261,7 +261,7 @@ class EventBuilderV2(EventBuilderV1):
     SOURCE_SDK_TYPE = 'clientEngine'
     SOURCE_SDK_VERSION = 'clientVersion'
     ACTION_TRIGGERED = 'actionTriggered'
-    IS_GLOBAL_HOLDBACK = 'isLayerHoldback'
+    IS_GLOBAL_HOLDBACK = 'isGlobalHoldback'
     IS_LAYER_HOLDBACK = 'isLayerHoldback'
     
   def _add_attributes(self, attributes):
@@ -295,11 +295,11 @@ class EventBuilderV2(EventBuilderV1):
     self.params[self.EventParams.IS_GLOBAL_HOLDBACK] = False
     self.params[self.EventParams.USER_FEATURES] = []
     # TODO(ali): Implement this
-    self.params[self.EventParams.LAYER_ID] = None
+    self.params[self.EventParams.LAYER_ID] = ''
     self.params[self.EventParams.DECISION] = {
-      self.params[self.EventParams.EXPERIMENT_ID]: self.config.get_experiment_id(experiment_key),
-      self.params[self.EventParams.VARIATION_ID]: variation_id,
-      self.params[self.EventParams.IS_LAYER_HOLDBACK]: False
+      self.EventParams.EXPERIMENT_ID: self.config.get_experiment_id(experiment_key),
+      self.EventParams.VARIATION_ID: variation_id,
+      self.EventParams.IS_LAYER_HOLDBACK: False
     }
 
   def _add_required_params_for_conversion(self, event_key, user_id, event_value, valid_experiments):
@@ -329,12 +329,12 @@ class EventBuilderV2(EventBuilderV1):
       if variation_id:
         self.params[self.EventParams.LAYER_STATES].append({
           # TODO(ali): Implement this
-          self.params[self.EventParams.LAYER_ID]: None,
-          self.params[self.EventParams.ACTION_TRIGGERED]: True,
-          self.params[self.EventParams.DECISION]: {
-            self.params[self.EventParams.EXPERIMENT_ID]: experiment[1],
-            self.params[self.EventParams.VARIATION_ID]: variation_id,
-            self.params[self.EventParams.IS_LAYER_HOLDBACK]: False
+          self.EventParams.LAYER_ID: '',
+          self.EventParams.ACTION_TRIGGERED: True,
+          self.EventParams.DECISION: {
+            self.EventParams.EXPERIMENT_ID: experiment[0],
+            self.EventParams.VARIATION_ID: variation_id,
+            self.EventParams.IS_LAYER_HOLDBACK: False
           }
         })
 

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -116,9 +116,9 @@ class Optimizely(object):
     impression_event = self.event_builder.create_impression_event(experiment_key, variation_id, user_id, attributes)
     self.logger.log(enums.LogLevels.INFO, 'Activating user "%s" in experiment "%s".' % (user_id, experiment_key))
     self.logger.log(enums.LogLevels.DEBUG,
-                    'Dispatching impression event to URL %s with params %s.' % (impression_event.get_url(),
-                                                                                impression_event.get_params()))
-    self.event_dispatcher.dispatch_event(impression_event.get_url(), impression_event.get_params())
+                    'Dispatching impression event to URL %s with params %s.' % (impression_event.url,
+                                                                                impression_event.params))
+    self.event_dispatcher.dispatch_event(impression_event.url, impression_event.params)
 
     return self.config.get_variation_key_from_id(experiment_key, variation_id)
 
@@ -157,9 +157,9 @@ class Optimizely(object):
                                                                     valid_experiments)
       self.logger.log(enums.LogLevels.INFO, 'Tracking event "%s" for user "%s".' % (event_key, user_id))
       self.logger.log(enums.LogLevels.DEBUG,
-                      'Dispatching conversion event to URL %s with params %s.' % (conversion_event.get_url(),
-                                                                                  conversion_event.get_params()))
-      self.event_dispatcher.dispatch_event(conversion_event.get_url(), conversion_event.get_params())
+                      'Dispatching conversion event to URL %s with params %s.' % (conversion_event.url,
+                                                                                  conversion_event.params))
+      self.event_dispatcher.dispatch_event(conversion_event.url, conversion_event.params)
 
   def get_variation(self, experiment_key, user_id, attributes=None):
     """ Gets variation where visitor will be bucketed.

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -34,7 +34,7 @@ class Optimizely(object):
 
     self.config = project_config.ProjectConfig(datafile, self.logger, self.error_handler)
     self.bucketer = bucketer.Bucketer(self.config)
-    self.event_builder = event_builder.EventBuilder(self.config, self.bucketer)
+    self.event_builder = event_builder.EventBuilderV1(self.config, self.bucketer)
 
   def _validate_inputs(self, datafile, skip_json_validation):
     """ Helper method to validate all input parameters.

--- a/tests/test_event_builder.py
+++ b/tests/test_event_builder.py
@@ -31,6 +31,14 @@ class EventBuilderV1Test(base.BaseTest):
     base.BaseTest.setUp(self)
     self.event_builder = self.optimizely.event_builder
 
+  def _validate_event_object(self, event_obj, expected_url, expected_params, expected_verb, expected_headers):
+    """ Helper method to validate properties of the event object. """
+
+    self.assertEqual(expected_url, event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_verb, event_obj.http_verb)
+    self.assertEqual(expected_headers, event_obj.headers)
+
   def test_create_impression_event(self):
     """ Test that create_impression_event creates Event object with right params. """
 
@@ -46,10 +54,9 @@ class EventBuilderV1Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user', None)
-    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual('GET', event_obj.http_verb)
-    self.assertIsNone(event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'),
+                                expected_params, 'GET', None)
 
   def test_create_impression_event__with_attributes(self):
     """ Test that create_impression_event creates Event object
@@ -69,10 +76,9 @@ class EventBuilderV1Test(base.BaseTest):
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user',
                                                              {'test_attribute': 'test_value'})
-    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual('GET', event_obj.http_verb)
-    self.assertIsNone(event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'),
+                                expected_params, 'GET', None)
 
   def test_create_conversion_event__with_attributes(self):
     """ Test that create_conversion_event creates Event object
@@ -93,10 +99,9 @@ class EventBuilderV1Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, None,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual('GET', event_obj.http_verb)
-    self.assertIsNone(event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'),
+                                expected_params, 'GET', None)
 
   def test_create_conversion_event__with_attributes_no_match(self):
     """ Test that create_conversion_event creates Event object with right params if attributes do not match. """
@@ -112,10 +117,9 @@ class EventBuilderV1Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user', None, None, [])
-    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual('GET', event_obj.http_verb)
-    self.assertIsNone(event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'),
+                                expected_params, 'GET', None)
 
   def test_create_conversion_event__with_event_value(self):
     """ Test that create_conversion_event creates Event object
@@ -137,10 +141,9 @@ class EventBuilderV1Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, 4200,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual('GET', event_obj.http_verb)
-    self.assertIsNone(event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'),
+                                expected_params, 'GET', None)
 
 
 class EventBuilderV2Test(base.BaseTest):
@@ -148,6 +151,14 @@ class EventBuilderV2Test(base.BaseTest):
   def setUp(self):
     base.BaseTest.setUp(self)
     self.event_builder = event_builder.EventBuilderV2(self.optimizely.config, self.optimizely.bucketer)
+
+  def _validate_event_object(self, event_obj, expected_url, expected_params, expected_verb, expected_headers):
+    """ Helper method to validate properties of the event object. """
+
+    self.assertEqual(expected_url, event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_verb, event_obj.http_verb)
+    self.assertEqual(expected_headers, event_obj.headers)
 
   def test_create_impression_event(self):
     """ Test that create_impression_event creates Event object with right params. """
@@ -170,10 +181,11 @@ class EventBuilderV2Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user', None)
-    self.assertEqual(event_builder.EventBuilderV2.IMPRESSION_ENDPOINT, event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV2.IMPRESSION_ENDPOINT,
+                                expected_params,
+                                event_builder.EventBuilderV2.HTTP_VERB,
+                                event_builder.EventBuilderV2.HTTP_HEADERS)
 
   def test_create_impression_event__with_attributes(self):
     """ Test that create_impression_event creates Event object
@@ -198,10 +210,11 @@ class EventBuilderV2Test(base.BaseTest):
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user',
                                                              {'test_attribute': 'test_value'})
-    self.assertEqual(event_builder.EventBuilderV2.IMPRESSION_ENDPOINT, event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV2.IMPRESSION_ENDPOINT,
+                                expected_params,
+                                event_builder.EventBuilderV2.HTTP_VERB,
+                                event_builder.EventBuilderV2.HTTP_HEADERS)
 
   def test_create_conversion_event__with_attributes(self):
     """ Test that create_conversion_event creates Event object
@@ -235,10 +248,11 @@ class EventBuilderV2Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, None,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(event_builder.EventBuilderV2.CONVERSION_ENDPOINT, event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV2.CONVERSION_ENDPOINT,
+                                expected_params,
+                                event_builder.EventBuilderV2.HTTP_VERB,
+                                event_builder.EventBuilderV2.HTTP_HEADERS)
 
   def test_create_conversion_event__with_attributes_no_match(self):
     """ Test that create_conversion_event creates Event object with right params if attributes do not match. """
@@ -260,10 +274,11 @@ class EventBuilderV2Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user', None, None, [])
-    self.assertEqual(event_builder.EventBuilderV2.CONVERSION_ENDPOINT, event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV2.CONVERSION_ENDPOINT,
+                                expected_params,
+                                event_builder.EventBuilderV2.HTTP_VERB,
+                                event_builder.EventBuilderV2.HTTP_HEADERS)
 
   def test_create_conversion_event__with_event_value(self):
     """ Test that create_conversion_event creates Event object
@@ -300,7 +315,8 @@ class EventBuilderV2Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, 4200,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(event_builder.EventBuilderV2.CONVERSION_ENDPOINT, event_obj.url)
-    self.assertEqual(expected_params, event_obj.params)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
-    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
+    self._validate_event_object(event_obj,
+                                event_builder.EventBuilderV2.CONVERSION_ENDPOINT,
+                                expected_params,
+                                event_builder.EventBuilderV2.HTTP_VERB,
+                                event_builder.EventBuilderV2.HTTP_HEADERS)

--- a/tests/test_event_builder.py
+++ b/tests/test_event_builder.py
@@ -8,34 +8,40 @@ from . import base
 
 class EventTest(unittest.TestCase):
 
-  def test_get_url(self):
-    """ Test that get_url returns URL as expected. """
-
-    params = {
+  def setUp(self):
+    self.url = 'event.optimizely.com'
+    self.params = {
       'a': '111001',
       'n': 'test_event',
       'g': '111028',
       'u': 'oeutest_user'
     }
+    self.http_verb = 'POST'
+    self.headers = {'Content-Type': 'application/json'}
+    self.event_obj = event_builder.Event(self.url, self.params, self.http_verb, self.headers)
 
-    event_obj = event_builder.Event(params)
-    self.assertEqual('https://111001.log.optimizely.com/event', event_obj.get_url())
+  def test_get_url(self):
+    """ Test that get_url returns URL as expected. """
+
+    self.assertEqual(self.url, self.event_obj.get_url())
 
   def test_get_params(self):
     """ Test that get_params returns params as expected. """
 
-    params = {
-      'a': '111001',
-      'n': 'test_event',
-      'g': '111028',
-      'u': 'oeutest_user'
-    }
+    self.assertEqual(self.params, self.event_obj.get_params())
 
-    event_obj = event_builder.Event(params)
-    self.assertEqual(params, event_obj.get_params())
+  def test_get_http_verb(self):
+    """ Test that get_params returns HTTP verb as expected. """
+
+    self.assertEqual(self.http_verb, self.event_obj.get_http_verb())
+
+  def test_get_headers(self):
+    """ Test that get_headers returns headers as expected. """
+
+    self.assertEqual(self.headers, self.event_obj.get_headers())
 
 
-class EventBuilderTest(base.BaseTest):
+class EventBuilderV1Test(base.BaseTest):
 
   def setUp(self):
     base.BaseTest.setUp(self)
@@ -132,6 +138,155 @@ class EventBuilderTest(base.BaseTest):
       'src': 'python-sdk-{version}'.format(version=version.__version__)
     }
     with mock.patch('time.time', return_value=42):
+      event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
+                                                             {'test_attribute': 'test_value'}, 4200,
+                                                             [('111127', 'test_experiment')])
+    self.assertEqual(expected_params, event_obj.params)
+
+
+class EventBuilderV2Test(base.BaseTest):
+
+  def setUp(self):
+    base.BaseTest.setUp(self)
+    self.event_builder = event_builder.EventBuilderV2(self.optimizely.config, self.optimizely.bucketer)
+
+  def test_create_impression_event(self):
+    """ Test that create_impression_event creates Event object with right params. """
+
+    expected_params = {
+      'accountId': '12001',
+      'projectId': '111001',
+      'layerId': '',
+      'visitorId': 'test_user',
+      'decision': {
+        'experimentId': '111127',
+        'variationId': '111129',
+        'isLayerHoldback': False
+      },
+      'timestamp': 42123,
+      'isGlobalHoldback': False,
+      'userFeatures': [],
+      'clientEngine': 'python-sdk',
+      'clientVersion': version.__version__
+    }
+    with mock.patch('time.time', return_value=42.123):
+      event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user', None)
+    print event_obj.get_params()
+    self.assertEqual(expected_params, event_obj.get_params())
+
+  def test_create_impression_event__with_attributes(self):
+    """ Test that create_impression_event creates Event object
+    with right params when attributes are provided. """
+
+    expected_params = {
+      'accountId': '12001',
+      'projectId': '111001',
+      'layerId': '',
+      'visitorId': 'test_user',
+      'decision': {
+        'experimentId': '111127',
+        'variationId': '111129',
+        'isLayerHoldback': False
+      },
+      'timestamp': 42123,
+      'isGlobalHoldback': False,
+      'userFeatures': [],
+      'clientEngine': 'python-sdk',
+      'clientVersion': version.__version__
+    }
+    with mock.patch('time.time', return_value=42.123):
+      event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user',
+                                                             {'test_attribute': 'test_value'})
+    self.assertEqual(expected_params, event_obj.get_params())
+
+  def test_create_conversion_event__with_attributes(self):
+    """ Test that create_conversion_event creates Event object
+    with right params when attributes are provided. """
+
+    expected_params = {
+      'accountId': '12001',
+      'projectId': '111001',
+      'visitorId': 'test_user',
+      'eventName': 'test_event',
+      'eventEntityId': '111095',
+      'eventMetrics': [],
+      'eventFeatures': [],
+      'layerStates': [{
+          'layerId': '',
+          'decision': {
+            'experimentId': '111127',
+            'variationId': '111129',
+            'isLayerHoldback': False
+          },
+          'actionTriggered': True,
+        }
+      ],
+      'timestamp': 42123,
+      'isGlobalHoldback': False,
+      'userFeatures': [],
+      'clientEngine': 'python-sdk',
+      'clientVersion': version.__version__
+    }
+    with mock.patch('time.time', return_value=42.123):
+      event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
+                                                             {'test_attribute': 'test_value'}, None,
+                                                             [('111127', 'test_experiment')])
+    self.assertEqual(expected_params, event_obj.get_params())
+
+  def test_create_conversion_event__with_attributes_no_match(self):
+    """ Test that create_conversion_event creates Event object with right params if attributes do not match. """
+
+    expected_params = {
+      'accountId': '12001',
+      'projectId': '111001',
+      'visitorId': 'test_user',
+      'eventName': 'test_event',
+      'eventEntityId': '111095',
+      'eventMetrics': [],
+      'eventFeatures': [],
+      'layerStates': [],
+      'timestamp': 42123,
+      'isGlobalHoldback': False,
+      'userFeatures': [],
+      'clientEngine': 'python-sdk',
+      'clientVersion': version.__version__
+    }
+    with mock.patch('time.time', return_value=42.123):
+      event_obj = self.event_builder.create_conversion_event('test_event', 'test_user', None, None, [])
+    self.assertEqual(expected_params, event_obj.params)
+
+  def test_create_conversion_event__with_event_value(self):
+    """ Test that create_conversion_event creates Event object
+    with right params when event value is provided. """
+
+    expected_params = {
+      'accountId': '12001',
+      'projectId': '111001',
+      'visitorId': 'test_user',
+      'eventName': 'test_event',
+      'eventEntityId': '111095',
+      'eventMetrics': [{
+        'name': 'revenue',
+        'value': 4200
+      }],
+      'eventFeatures': [],
+      'layerStates': [{
+          'layerId': '',
+          'decision': {
+            'experimentId': '111127',
+            'variationId': '111129',
+            'isLayerHoldback': False
+          },
+          'actionTriggered': True,
+        }
+      ],
+      'timestamp': 42123,
+      'isGlobalHoldback': False,
+      'userFeatures': [],
+      'clientEngine': 'python-sdk',
+      'clientVersion': version.__version__
+    }
+    with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, 4200,
                                                              [('111127', 'test_experiment')])

--- a/tests/test_event_builder.py
+++ b/tests/test_event_builder.py
@@ -8,37 +8,21 @@ from . import base
 
 class EventTest(unittest.TestCase):
 
-  def setUp(self):
-    self.url = 'event.optimizely.com'
-    self.params = {
+  def test_init(self):
+    url = 'event.optimizely.com'
+    params = {
       'a': '111001',
       'n': 'test_event',
       'g': '111028',
       'u': 'oeutest_user'
     }
-    self.http_verb = 'POST'
-    self.headers = {'Content-Type': 'application/json'}
-    self.event_obj = event_builder.Event(self.url, self.params, self.http_verb, self.headers)
-
-  def test_get_url(self):
-    """ Test that get_url returns URL as expected. """
-
-    self.assertEqual(self.url, self.event_obj.get_url())
-
-  def test_get_params(self):
-    """ Test that get_params returns params as expected. """
-
-    self.assertEqual(self.params, self.event_obj.get_params())
-
-  def test_get_http_verb(self):
-    """ Test that get_params returns HTTP verb as expected. """
-
-    self.assertEqual(self.http_verb, self.event_obj.get_http_verb())
-
-  def test_get_headers(self):
-    """ Test that get_headers returns headers as expected. """
-
-    self.assertEqual(self.headers, self.event_obj.get_headers())
+    http_verb = 'POST'
+    headers = {'Content-Type': 'application/json'}
+    event_obj = event_builder.Event(url, params, http_verb=http_verb, headers=headers)
+    self.assertEqual(url, event_obj.url)
+    self.assertEqual(params, event_obj.params)
+    self.assertEqual(http_verb, event_obj.http_verb)
+    self.assertEqual(headers, event_obj.headers)
 
 
 class EventBuilderV1Test(base.BaseTest):
@@ -62,7 +46,10 @@ class EventBuilderV1Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user', None)
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual('GET', event_obj.http_verb)
+    self.assertIsNone(event_obj.headers)
 
   def test_create_impression_event__with_attributes(self):
     """ Test that create_impression_event creates Event object
@@ -82,7 +69,10 @@ class EventBuilderV1Test(base.BaseTest):
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user',
                                                              {'test_attribute': 'test_value'})
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual('GET', event_obj.http_verb)
+    self.assertIsNone(event_obj.headers)
 
   def test_create_conversion_event__with_attributes(self):
     """ Test that create_conversion_event creates Event object
@@ -103,7 +93,10 @@ class EventBuilderV1Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, None,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual('GET', event_obj.http_verb)
+    self.assertIsNone(event_obj.headers)
 
   def test_create_conversion_event__with_attributes_no_match(self):
     """ Test that create_conversion_event creates Event object with right params if attributes do not match. """
@@ -119,7 +112,10 @@ class EventBuilderV1Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user', None, None, [])
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual('GET', event_obj.http_verb)
+    self.assertIsNone(event_obj.headers)
 
   def test_create_conversion_event__with_event_value(self):
     """ Test that create_conversion_event creates Event object
@@ -141,7 +137,10 @@ class EventBuilderV1Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, 4200,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV1.OFFLINE_API_PATH.format(project_id='111001'), event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual('GET', event_obj.http_verb)
+    self.assertIsNone(event_obj.headers)
 
 
 class EventBuilderV2Test(base.BaseTest):
@@ -171,7 +170,10 @@ class EventBuilderV2Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user', None)
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV2.IMPRESSION_ENDPOINT, event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
 
   def test_create_impression_event__with_attributes(self):
     """ Test that create_impression_event creates Event object
@@ -196,7 +198,10 @@ class EventBuilderV2Test(base.BaseTest):
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user',
                                                              {'test_attribute': 'test_value'})
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV2.IMPRESSION_ENDPOINT, event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
 
   def test_create_conversion_event__with_attributes(self):
     """ Test that create_conversion_event creates Event object
@@ -230,7 +235,10 @@ class EventBuilderV2Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, None,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV2.CONVERSION_ENDPOINT, event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
 
   def test_create_conversion_event__with_attributes_no_match(self):
     """ Test that create_conversion_event creates Event object with right params if attributes do not match. """
@@ -252,7 +260,10 @@ class EventBuilderV2Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user', None, None, [])
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV2.CONVERSION_ENDPOINT, event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)
 
   def test_create_conversion_event__with_event_value(self):
     """ Test that create_conversion_event creates Event object
@@ -289,4 +300,7 @@ class EventBuilderV2Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, 4200,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(expected_params, event_obj.get_params())
+    self.assertEqual(event_builder.EventBuilderV2.CONVERSION_ENDPOINT, event_obj.url)
+    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_VERB, event_obj.http_verb)
+    self.assertEqual(event_builder.EventBuilderV2.HTTP_HEADERS, event_obj.headers)

--- a/tests/test_event_builder.py
+++ b/tests/test_event_builder.py
@@ -62,7 +62,7 @@ class EventBuilderV1Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user', None)
-    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_params, event_obj.get_params())
 
   def test_create_impression_event__with_attributes(self):
     """ Test that create_impression_event creates Event object
@@ -82,7 +82,7 @@ class EventBuilderV1Test(base.BaseTest):
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user',
                                                              {'test_attribute': 'test_value'})
-    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_params, event_obj.get_params())
 
   def test_create_conversion_event__with_attributes(self):
     """ Test that create_conversion_event creates Event object
@@ -103,7 +103,7 @@ class EventBuilderV1Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, None,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_params, event_obj.get_params())
 
   def test_create_conversion_event__with_attributes_no_match(self):
     """ Test that create_conversion_event creates Event object with right params if attributes do not match. """
@@ -119,7 +119,7 @@ class EventBuilderV1Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user', None, None, [])
-    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_params, event_obj.get_params())
 
   def test_create_conversion_event__with_event_value(self):
     """ Test that create_conversion_event creates Event object
@@ -141,7 +141,7 @@ class EventBuilderV1Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, 4200,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_params, event_obj.get_params())
 
 
 class EventBuilderV2Test(base.BaseTest):
@@ -171,7 +171,6 @@ class EventBuilderV2Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_impression_event('test_experiment', '111129', 'test_user', None)
-    print event_obj.get_params()
     self.assertEqual(expected_params, event_obj.get_params())
 
   def test_create_impression_event__with_attributes(self):
@@ -253,7 +252,7 @@ class EventBuilderV2Test(base.BaseTest):
     }
     with mock.patch('time.time', return_value=42.123):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user', None, None, [])
-    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_params, event_obj.get_params())
 
   def test_create_conversion_event__with_event_value(self):
     """ Test that create_conversion_event creates Event object
@@ -290,4 +289,4 @@ class EventBuilderV2Test(base.BaseTest):
       event_obj = self.event_builder.create_conversion_event('test_event', 'test_user',
                                                              {'test_attribute': 'test_value'}, 4200,
                                                              [('111127', 'test_experiment')])
-    self.assertEqual(expected_params, event_obj.params)
+    self.assertEqual(expected_params, event_obj.get_params())


### PR DESCRIPTION
This diff introduces event builder v2.

This diff does not intend to:

Redirect to builder v2 based on version (will come in a separate diff)
Look for layer ID on experiment (will come in a separate diff)
Use attributes (will come in a separate diff)
Clean up terminology (change goal --> key every place et al) - Coming in a much later diff

cc @haleybash-optimizely @delikat @vraja2 @mikeng13 