### PR TITLE
Fixed a bug with how the numeric metric getters handle non string and number values.

### DIFF
--- a/optimizely/helpers/event_tag_utils.py
+++ b/optimizely/helpers/event_tag_utils.py
@@ -95,6 +95,7 @@ def get_numeric_value(event_tags, logger=None):
            numeric_metric_value = cast_numeric_metric_value
       else:
         logger_message_debug = 'Numeric metric value is not in integer, float, or string form.'
+        numeric_metric_value = None
 
     except ValueError:
       logger_message_debug = 'Value error while casting numeric metric value to a float.'

--- a/tests/helpers_tests/test_event_tag_utils.py
+++ b/tests/helpers_tests/test_event_tag_utils.py
@@ -106,7 +106,10 @@ class EventTagUtilsTest(unittest.TestCase):
     self.assertIsNone(numeric_value_nan, 'nan numeric value is {}'.format(numeric_value_nan))
 
     numeric_value_array = event_tag_utils.get_numeric_value({'value': []}, logger=logger.SimpleLogger())
-    self.assertIsNone(numeric_value_nan, 'Array numeric value is {}'.format(numeric_value_array))
+    self.assertIsNone(numeric_value_array, 'Array numeric value is {}'.format(numeric_value_array))
+
+    numeric_value_dict = event_tag_utils.get_numeric_value({'value': []}, logger=logger.SimpleLogger())
+    self.assertIsNone(numeric_value_dict, 'Dict numeric value is {}'.format(numeric_value_dict))
 
     numeric_value_none = event_tag_utils.get_numeric_value({'value': None}, logger=logger.SimpleLogger())
     self.assertIsNone(numeric_value_none, 'None numeric value is {}'.format(numeric_value_none))


### PR DESCRIPTION
Caught this when I was running some numeric metric e2e tests.