### PR TITLE
Clarifying ownership of SDK in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/optimizely/python-sdk/badge.svg)](https://coveralls.io/github/optimizely/python-sdk)
 [![Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-This repository houses the Python SDK for Optimizely Full Stack.
+This repository houses the official Python SDK for Optimizely Full Stack.
 
 ## Getting Started
 


### PR DESCRIPTION
Due to there being several third-party SDKs in different languages of varying quality / age, adding "official" to the phrasing of the title should help people understand that this is owned and maintained by Optimizely.