### PR TITLE
Fixing formatting of description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     version=__version__,
     description='Python SDK for Optimizely X Full Stack.',
     long_description=about_text + '\n\n# Readme: \n' + README + '\n\n# Change Log: \n' + CHANGELOG,
+    long_description_content_type='text/markdown',
     author='Optimizely',
     author_email='developers@optimizely.com',
     url='https://github.com/optimizely/python-sdk',


### PR DESCRIPTION
The `long_description` was introduced recently. On publishing I noticed that formatting is all broken here: https://pypi.org/project/optimizely-sdk.

Searching on the web revealed that by default it expects text to be `rst`. Defining content type is the solution to continue using markdown format.