### PR TITLE
refact(ConditionEvaluator): Simplify condition evaluation

### DIFF
--- a/optimizely/entities.py
+++ b/optimizely/entities.py
@@ -27,11 +27,10 @@ class Attribute(BaseEntity):
 
 class Audience(BaseEntity):
 
-  def __init__(self, id, name, conditions, conditionStructure=None, conditionList=None, **kwargs):
+  def __init__(self, id, name, conditions, conditionList=None, **kwargs):
     self.id = id
     self.name = name
     self.conditions = conditions
-    self.conditionStructure = conditionStructure
     self.conditionList = conditionList
 
 

--- a/optimizely/helpers/audience.py
+++ b/optimizely/helpers/audience.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Optimizely
+# Copyright 2016, 2018, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,20 +12,6 @@
 # limitations under the License.
 
 from . import condition as condition_helper
-
-
-def is_match(audience, attributes):
-  """ Given audience information and user attributes determine if user meets the conditions.
-
-  Args:
-    audience: Dict representing the audience.
-    attributes: Dict representing user attributes which will be used in determining if the audience conditions are met.
-
-  Return:
-    Boolean representing if user satisfies audience conditions or not.
-  """
-  condition_evaluator = condition_helper.ConditionEvaluator(audience.conditionList, attributes)
-  return condition_evaluator.evaluate(audience.conditionStructure)
 
 
 def is_user_in_experiment(config, experiment, attributes):
@@ -48,11 +34,13 @@ def is_user_in_experiment(config, experiment, attributes):
   if not attributes:
     return False
 
+  condition_evaluator = condition_helper.ConditionEvaluator(attributes)
+
   # Return True if conditions for any one audience are met
   for audience_id in experiment.audienceIds:
     audience = config.get_audience(audience_id)
 
-    if is_match(audience, attributes):
+    if condition_evaluator.evaluate(audience.conditionList) is True:
       return True
 
   return False

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -133,19 +133,18 @@ class ProjectConfig(object):
 
   @staticmethod
   def _deserialize_audience(audience_map):
-    """ Helper method to de-serialize and populate audience map with the condition list and structure.
+    """ Helper method to de-serialize and populate audience map with the condition list.
 
     Args:
       audience_map: Dict mapping audience ID to audience object.
 
     Returns:
-      Dict additionally consisting of condition list and structure on every audience object.
+      Dict additionally consisting of condition list.
     """
 
     for audience in audience_map.values():
-      condition_structure, condition_list = condition_helper.loads(audience.conditions)
+      condition_list = condition_helper.ConditionDecoder.deserialize_audience_conditions(audience.conditions)
       audience.__dict__.update({
-        'conditionStructure': condition_structure,
         'conditionList': condition_list
       })
 

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -20,7 +20,7 @@ from optimizely.helpers import audience
 class AudienceTest(base.BaseTest):
 
   def test_is_match__audience_condition_matches(self):
-    """ Test that is_match returns True when audience conditions are met. """
+    """ Test that is_user_in_experiment returns True when audience conditions are met. """
 
     user_attributes = {
       'test_attribute': 'test_value_1',
@@ -28,10 +28,12 @@ class AudienceTest(base.BaseTest):
       'location': 'San Francisco'
     }
 
-    self.assertTrue(audience.is_match(self.optimizely.config.get_audience('11154'), user_attributes))
+    self.assertTrue(
+      audience.is_user_in_experiment(
+        self.project_config, self.project_config.get_experiment_from_key('test_experiment'), user_attributes))
 
-  def test_is_match__audience_condition_does_not_match(self):
-    """ Test that is_match returns False when audience conditions are not met. """
+  def test_is_user_in_experiment__audience_condition_does_not_match(self):
+    """ Test that is_user_in_experiment returns False when audience conditions are not met. """
 
     user_attributes = {
       'test_attribute': 'wrong_test_value',
@@ -39,7 +41,9 @@ class AudienceTest(base.BaseTest):
       'location': 'San Francisco'
     }
 
-    self.assertFalse(audience.is_match(self.optimizely.config.get_audience('11154'), user_attributes))
+    self.assertFalse(
+      audience.is_user_in_experiment(
+        self.project_config, self.project_config.get_experiment_from_key('test_experiment'), user_attributes))
 
   def test_is_user_in_experiment__no_audience(self):
     """ Test that is_user_in_experiment returns True when experiment is using no audience. """
@@ -54,7 +58,8 @@ class AudienceTest(base.BaseTest):
     self.assertTrue(audience.is_user_in_experiment(self.project_config, experiment, user_attributes))
 
   def test_is_user_in_experiment__no_attributes(self):
-    """ Test that is_user_in_experiment returns True when experiment is using no audience. """
+    """ Test that is_user_in_experiment returns False when attributes are empty
+    and experiment has an audience. """
 
     self.assertFalse(audience.is_user_in_experiment(
       self.project_config, self.project_config.get_experiment_from_key('test_experiment'), None)
@@ -65,7 +70,7 @@ class AudienceTest(base.BaseTest):
     )
 
   def test_is_user_in_experiment__audience_conditions_are_met(self):
-    """ Test that is_user_in_experiment returns True when audience conditions are met. """
+    """ Test that is_user_in_experiment returns True when Condition Evaluator returns True."""
 
     user_attributes = {
       'test_attribute': 'test_value_1',
@@ -73,14 +78,14 @@ class AudienceTest(base.BaseTest):
       'location': 'San Francisco'
     }
 
-    with mock.patch('optimizely.helpers.audience.is_match', return_value=True) as mock_is_match:
+    with mock.patch('optimizely.helpers.condition.ConditionEvaluator.evaluate', return_value=True) as mock_evaluate:
       self.assertTrue(audience.is_user_in_experiment(self.project_config,
                                                      self.project_config.get_experiment_from_key('test_experiment'),
                                                      user_attributes))
-    mock_is_match.assert_called_once_with(self.optimizely.config.get_audience('11154'), user_attributes)
+    mock_evaluate.assert_called_once_with(self.optimizely.config.get_audience('11154').conditionList)
 
   def test_is_user_in_experiment__audience_conditions_not_met(self):
-    """ Test that is_user_in_experiment returns False when audience conditions are not met. """
+    """ Test that is_user_in_experiment returns False when Condition Evaluator returns False. """
 
     user_attributes = {
       'test_attribute': 'wrong_test_value',
@@ -88,8 +93,8 @@ class AudienceTest(base.BaseTest):
       'location': 'San Francisco'
     }
 
-    with mock.patch('optimizely.helpers.audience.is_match', return_value=False) as mock_is_match:
+    with mock.patch('optimizely.helpers.condition.ConditionEvaluator.evaluate', return_value=False) as mock_evaluate:
       self.assertFalse(audience.is_user_in_experiment(self.project_config,
                                                       self.project_config.get_experiment_from_key('test_experiment'),
                                                       user_attributes))
-    mock_is_match.assert_called_once_with(self.optimizely.config.get_audience('11154'), user_attributes)
+    mock_evaluate.assert_called_once_with(self.optimizely.config.get_audience('11154').conditionList)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,14 +119,14 @@ class ConfigTest(base.BaseTest):
       '11154': entities.Audience(
         '11154', 'Test attribute users 1',
         '["and", ["or", ["or", {"name": "test_attribute", "type": "custom_attribute", "value": "test_value_1"}]]]',
-        conditionStructure=['and', ['or', ['or', 0]]],
-        conditionList=[['test_attribute', 'test_value_1']]
+        conditionList=["and", ["or", ["or", {"name": "test_attribute",
+                                             "type": "custom_attribute", "value": "test_value_1"}]]]
       ),
       '11159': entities.Audience(
         '11159', 'Test attribute users 2',
         '["and", ["or", ["or", {"name": "test_attribute", "type": "custom_attribute", "value": "test_value_2"}]]]',
-        conditionStructure=['and', ['or', ['or', 0]]],
-        conditionList=[['test_attribute', 'test_value_2']]
+        conditionList=["and", ["or", ["or", {"name": "test_attribute",
+                                             "type": "custom_attribute", "value": "test_value_2"}]]]
       )
     }
     expected_variation_key_map = {
@@ -520,8 +520,8 @@ class ConfigTest(base.BaseTest):
       '11154': entities.Audience(
         '11154', 'Test attribute users',
         '["and", ["or", ["or", {"name": "test_attribute", "type": "custom_attribute", "value": "test_value"}]]]',
-        conditionStructure=['and', ['or', ['or', 0]]],
-        conditionList=[['test_attribute', 'test_value']]
+        conditionList=['and', ['or', ['or', {"name": "test_attribute",
+                                             "type": "custom_attribute", "value": "test_value"}]]]
       )
     }
     expected_variation_key_map = {
@@ -625,7 +625,6 @@ class ConfigTest(base.BaseTest):
         '131': entities.Variation.VariableUsage('131', '15')
       }
     }
-
     self.assertEqual(expected_variation_variable_usage_map['28901'],
                      project_config.variation_variable_usage_map['28901'])
     self.assertEqual(expected_group_id_map, project_config.group_id_map)


### PR DESCRIPTION
Python SDK as of now, has a bit complex condition evaluation. Before modifying evaluator for audience match type work, this simplifies the condition evaluator and makes it more like how it's done in Ruby, PHP.

Currently, In python we have conditions list and structure.
The structure stores decoded conditions string with { } replaced by an integer placeholder.
And the conditions list is a list of those replaced { } conditions.
This PR removes this undesired complexity. And directly decodes conditions string as in other SDKs.
This will make audience type work easier, where we will be checking match type/ attribute types. etc.