### PR TITLE
fix(set_forced_variation): Treats empty variation key as invalid and does not reset forced variation.

### DIFF
--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -15,6 +15,7 @@ import json
 
 from .helpers import condition as condition_helper
 from .helpers import enums
+from .helpers import validator
 from . import entities
 from . import exceptions
 
@@ -499,7 +500,7 @@ class ProjectConfig(object):
       return False
 
     experiment_id = experiment.id
-    if not variation_key:
+    if variation_key is None:
       if user_id in self.forced_variation_map:
         experiment_to_variation_map = self.forced_variation_map.get(user_id)
         if experiment_id in experiment_to_variation_map:
@@ -516,6 +517,10 @@ class ProjectConfig(object):
       else:
         self.logger.debug('Nothing to remove. User "%s" does not exist in the forced variation map.' % user_id)
       return True
+
+    if not validator.is_non_empty_string(variation_key):
+      self.logger.debug('Variation key is invalid.')
+      return False
 
     forced_variation = self.get_variation_from_key(experiment_key, variation_key)
     if not forced_variation:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1055,8 +1055,11 @@ class ConfigTest(base.BaseTest):
 
     self.assertFalse(self.project_config.set_forced_variation('test_experiment', 'test_user',
                                                               'variation_not_in_datafile'))
-    self.assertTrue(self.project_config.set_forced_variation('test_experiment', 'test_user', ''))
     self.assertTrue(self.project_config.set_forced_variation('test_experiment', 'test_user', None))
+
+    with mock.patch.object(self.project_config, 'logger') as mock_config_logging:
+      self.assertIs(self.project_config.set_forced_variation('test_experiment', 'test_user', ''), False)
+    mock_config_logging.debug.assert_called_once_with('Variation key is invalid.')
 
   def test_set_forced_variation__multiple_sets(self):
     """ Test multiple sets of experiments for one and multiple users work """


### PR DESCRIPTION
Summary
-------

- Forced variation key passed as an empty String will be invalid argument.
- Updated inputs validation for set_forced_variation.
- Updated unit tests for empty string variation key.