### PR TITLE
feat(attribute_value): Don't target NAN, INF, -INF and  > 2^53

### DIFF
--- a/optimizely/helpers/validator.py
+++ b/optimizely/helpers/validator.py
@@ -13,6 +13,8 @@
 
 import json
 import jsonschema
+import math
+import numbers
 from six import string_types
 
 from optimizely.user_profile import UserProfile
@@ -185,7 +187,40 @@ def is_attribute_valid(attribute_key, attribute_value):
   if not isinstance(attribute_key, string_types):
     return False
 
-  if isinstance(attribute_value, string_types) or type(attribute_value) in (int, float, bool):
+  if isinstance(attribute_value, (string_types, bool)):
     return True
 
+  if isinstance(attribute_value, (numbers.Integral, float)):
+    return is_finite_number(attribute_value)
+
   return False
+
+
+def is_finite_number(value):
+  """ Validates if the given value is a number, enforces
+  limit of 1e53 for integers and restricts NAN, INF, -INF for doubles.
+
+  Args:
+    value: Value to be validated
+
+  Returns:
+    Boolean: True if value is a finite number else False
+  """
+
+  if not isinstance(value, (numbers.Integral, float)):
+      # numbers.Integral instead of int to accomodate long integer in python 2
+    return False
+
+  if isinstance(value, bool):
+    # bool is a subclass of int
+    return False
+
+  if isinstance(value, numbers.Integral):
+    if value > 1e53:
+      return False
+
+  if isinstance(value, float):
+    if math.isnan(value) or math.isinf(value):
+      return False
+
+  return True

--- a/optimizely/helpers/validator.py
+++ b/optimizely/helpers/validator.py
@@ -204,7 +204,8 @@ def is_finite_number(value):
     value: Value to be validated.
 
   Returns:
-    Boolean: True if value is a number and not NAN, INF, -INF or greater than 2^53 else False.
+    Boolean: True if value is a number and not NAN, INF, -INF or
+             greater than absolute limit of 2^53 else False.
   """
   if not isinstance(value, (numbers.Integral, float)):
       # numbers.Integral instead of int to accomodate long integer in python 2

--- a/optimizely/helpers/validator.py
+++ b/optimizely/helpers/validator.py
@@ -187,20 +187,24 @@ def is_attribute_valid(attribute_key, attribute_value):
   if not isinstance(attribute_key, string_types):
     return False
 
-  if isinstance(attribute_value, string_types) or type(attribute_value) in (int, float, bool):
+  if isinstance(attribute_value, (string_types, bool)):
     return True
+
+  if isinstance(attribute_value, (numbers.Integral, float)):
+    return is_finite_number(attribute_value)
 
   return False
 
 
 def is_finite_number(value):
-  """ Method to validate if the given value is a number and not one of NAN, INF, -INF.
+  """ Validates if the given value is a number, enforces
+   absolute limit of 2^53 and restricts NAN, INF, -INF.
 
   Args:
     value: Value to be validated.
 
   Returns:
-    Boolean: True if value is a number and not NAN, INF or -INF else False.
+    Boolean: True if value is a number and not NAN, INF, -INF or greater than 2^53 else False.
   """
   if not isinstance(value, (numbers.Integral, float)):
       # numbers.Integral instead of int to accomodate long integer in python 2
@@ -213,6 +217,9 @@ def is_finite_number(value):
   if isinstance(value, float):
     if math.isnan(value) or math.isinf(value):
       return False
+
+  if abs(value) > (2**53):
+    return False
 
   return True
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -13,8 +13,13 @@
 
 import json
 import unittest
+from six import PY3
 
 from optimizely import optimizely
+
+if PY3:
+  def long(a):
+    raise NotImplementedError('Tests should only call `long` if running in PY2')
 
 
 class BaseTest(unittest.TestCase):

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,10 +14,16 @@
 import json
 import unittest
 
+from six import PY3
+
 from optimizely import optimizely
 
 
 class BaseTest(unittest.TestCase):
+
+  if PY3:
+    def long(a):
+        raise NotImplementedError('Tests should only call `long` if running in PY2')
 
   def setUp(self, config_dict='config_dict'):
     self.config_dict = {

--- a/tests/helpers_tests/test_condition.py
+++ b/tests/helpers_tests/test_condition.py
@@ -283,25 +283,26 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
     self.assertIsNone(evaluator.evaluate(0))
 
   def test_exact__given_number_values__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+    """ Test that CustomAttributeConditionEvaluator.evaluate returns True
+        if is_finite_number returns True. Returns None if is_finite_number returns False. """
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
         exact_int_condition_list, {'lasers_count': 9000}
       )
 
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=True) as is_finite:
+                    return_value=True) as mock_is_finite:
       self.assertTrue(evaluator.evaluate(0))
-    is_finite.assert_called_with(9000)
+    mock_is_finite.assert_called_with(9000)
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
       exact_int_condition_list, {'lasers_count': 9000.0}
     )
 
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=False) as is_finite:
+                    return_value=False) as mock_is_finite:
       self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_called_with(9000.0)
+    mock_is_finite.assert_called_with(9000.0)
 
   def test_exact_bool__returns_true__when_user_provided_value_is_equal_to_condition_value(self):
 
@@ -612,7 +613,8 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
     self.assertIsNone(evaluator.evaluate(0))
 
   def test_greater_than__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+    """ Test that CustomAttributeConditionEvaluator.evaluate returns True
+        if is_finite_number returns True. Returns None if is_finite_number returns False. """
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
       gt_int_condition_list, {'meters_travelled': 48.1}
@@ -624,11 +626,11 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       return True
 
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=is_finite_number__rejecting_condition_value) as is_finite_mock:
+                    side_effect=is_finite_number__rejecting_condition_value) as mock_is_finite:
       self.assertIsNone(evaluator.evaluate(0))
 
     # assert that isFiniteNumber only needs to reject condition value to stop evaluation.
-    is_finite_mock.assert_called_once_with(48)
+    mock_is_finite.assert_called_once_with(48)
 
     def is_finite_number__rejecting_user_attribute_value(value):
       if value == 48.1:
@@ -636,11 +638,11 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       return True
 
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=is_finite_number__rejecting_user_attribute_value) as is_finite_mock:
+                    side_effect=is_finite_number__rejecting_user_attribute_value) as mock_is_finite:
       self.assertIsNone(evaluator.evaluate(0))
 
     # assert that isFiniteNumber evaluates user value only if it has accepted condition value.
-    is_finite_mock.assert_has_calls([mock.call(48), mock.call(48.1)])
+    mock_is_finite.assert_has_calls([mock.call(48), mock.call(48.1)])
 
     def is_finite_number__accepting_both_values(value):
       return True
@@ -650,7 +652,8 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       self.assertTrue(evaluator.evaluate(0))
 
   def test_less_than__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+    """ Test that CustomAttributeConditionEvaluator.evaluate returns True
+        if is_finite_number returns True. Returns None if is_finite_number returns False. """
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
       lt_int_condition_list, {'meters_travelled': 47}
@@ -662,11 +665,11 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       return True
 
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=is_finite_number__rejecting_condition_value) as is_finite_mock:
+                    side_effect=is_finite_number__rejecting_condition_value) as mock_is_finite:
       self.assertIsNone(evaluator.evaluate(0))
 
     # assert that isFiniteNumber only needs to reject condition value to stop evaluation.
-    is_finite_mock.assert_called_once_with(48)
+    mock_is_finite.assert_called_once_with(48)
 
     def is_finite_number__rejecting_user_attribute_value(value):
       if value == 47:
@@ -674,11 +677,11 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       return True
 
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=is_finite_number__rejecting_user_attribute_value) as is_finite_mock:
+                    side_effect=is_finite_number__rejecting_user_attribute_value) as mock_is_finite:
       self.assertIsNone(evaluator.evaluate(0))
 
     # assert that isFiniteNumber evaluates user value only if it has accepted condition value.
-    is_finite_mock.assert_has_calls([mock.call(48), mock.call(47)])
+    mock_is_finite.assert_has_calls([mock.call(48), mock.call(47)])
 
     def is_finite_number__accepting_both_values(value):
       return True

--- a/tests/helpers_tests/test_condition.py
+++ b/tests/helpers_tests/test_condition.py
@@ -12,15 +12,11 @@
 # limitations under the License.
 
 import mock
-from six import PY2, PY3
+from six import PY2
 
 from optimizely.helpers import condition as condition_helper
 
 from tests import base
-
-if PY3:
-  def long(a):
-    raise NotImplementedError('Tests should only call `long` if running in PY2')
 
 browserConditionSafari = ['browser_type', 'safari', 'custom_attribute', 'exact']
 booleanCondition = ['is_firefox', True, 'custom_attribute', 'exact']
@@ -205,6 +201,37 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
 
     self.assertStrictTrue(evaluator.evaluate(0))
 
+  def test_exact_int__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    if PY2:
+      evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        exact_int_condition_list, {'lasers_count': long(9000)}
+      )
+
+      with mock.patch('optimizely.helpers.validator.is_finite_number',
+                      return_value=True) as is_finite:
+        self.assertStrictTrue(evaluator.evaluate(0))
+      is_finite.assert_called_with(long(9000))
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        exact_int_condition_list, {'lasers_count': 9000}
+      )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=False) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_called_with(9000)
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      exact_int_condition_list, {'lasers_count': 9000.0}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=False) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_called_with(9000.0)
+
   def test_exact_float__returns_true__when_user_provided_value_is_equal_to_condition_value(self):
 
     if PY2:
@@ -225,6 +252,37 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
     )
 
     self.assertStrictTrue(evaluator.evaluate(0))
+
+  def test_exact_float__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    if PY2:
+      evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        exact_float_condition_list, {'lasers_count': long(9000)}
+      )
+
+      with mock.patch('optimizely.helpers.validator.is_finite_number',
+                      return_value=True) as is_finite:
+        self.assertStrictTrue(evaluator.evaluate(0))
+      is_finite.assert_called_with(long(9000))
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        exact_float_condition_list, {'lasers_count': 9000}
+      )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=False) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_called_with(9000)
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      exact_float_condition_list, {'lasers_count': 9000.0}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=False) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_called_with(9000.0)
 
   def test_exact_int__returns_false__when_user_provided_value_is_not_equal_to_condition_value(self):
 
@@ -371,6 +429,42 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
 
       self.assertStrictTrue(evaluator.evaluate(0))
 
+  def test_greater_than_int__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      gt_int_condition_list, {'meters_travelled': 48.1}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=True) as is_finite:
+      self.assertStrictTrue(evaluator.evaluate(0))
+    is_finite.assert_called_with(48.1)
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      gt_int_condition_list, {'meters_travelled': 49}
+    )
+
+    def side_effect(*args):
+      if args[0] == 49:
+        return False
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=side_effect) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_any_call(49)
+
+    if PY2:
+      evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        gt_int_condition_list, {'meters_travelled': long(49)}
+      )
+
+      with mock.patch('optimizely.helpers.validator.is_finite_number',
+                       side_effect=side_effect) as is_finite:
+        self.assertIsNone(evaluator.evaluate(0))
+      is_finite.assert_called_with(long(49))
+
   def test_greater_than_float__returns_true__when_user_value_greater_than_condition_value(self):
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -391,6 +485,42 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       )
 
       self.assertStrictTrue(evaluator.evaluate(0))
+
+  def test_greater_than_float__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      gt_float_condition_list, {'meters_travelled': 48.3}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=True) as is_finite:
+      self.assertStrictTrue(evaluator.evaluate(0))
+    is_finite.assert_called_with(48.3)
+
+    def side_effect(*args):
+      if args[0] == 49:
+        return False
+      return True
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      gt_float_condition_list, {'meters_travelled': 49}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=side_effect) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_called_with(49)
+
+    if PY2:
+      evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        gt_float_condition_list, {'meters_travelled': long(49)}
+      )
+
+      with mock.patch('optimizely.helpers.validator.is_finite_number',
+                      side_effect=side_effect) as is_finite:
+        self.assertIsNone(evaluator.evaluate(0))
+      is_finite.assert_called_with(long(49))
 
   def test_greater_than_int__returns_false__when_user_value_not_greater_than_condition_value(self):
 
@@ -499,6 +629,42 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
 
       self.assertStrictTrue(evaluator.evaluate(0))
 
+  def test_less_than_int__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      lt_int_condition_list, {'meters_travelled': 47.9}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=True) as is_finite:
+      self.assertStrictTrue(evaluator.evaluate(0))
+    is_finite.assert_called_with(47.9)
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      lt_int_condition_list, {'meters_travelled': 47}
+    )
+
+    def side_effect(*args):
+      if args[0] == 47:
+        return False
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=side_effect) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_any_call(47)
+
+    if PY2:
+      evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        lt_int_condition_list, {'meters_travelled': long(47)}
+      )
+
+      with mock.patch('optimizely.helpers.validator.is_finite_number',
+                       side_effect=side_effect) as is_finite:
+        self.assertIsNone(evaluator.evaluate(0))
+      is_finite.assert_called_with(long(47))
+
   def test_less_than_float__returns_true__when_user_value_less_than_condition_value(self):
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -519,6 +685,42 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       )
 
       self.assertStrictTrue(evaluator.evaluate(0))
+
+  def test_less_than_float__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      lt_float_condition_list, {'meters_travelled': 48.1}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=True) as is_finite:
+      self.assertStrictTrue(evaluator.evaluate(0))
+    is_finite.assert_called_with(48.1)
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      lt_float_condition_list, {'meters_travelled': 48}
+    )
+
+    def side_effect(*args):
+      if args[0] == 48:
+        return False
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=side_effect) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_any_call(48)
+
+    if PY2:
+      evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        lt_float_condition_list, {'meters_travelled': long(48)}
+      )
+
+      with mock.patch('optimizely.helpers.validator.is_finite_number',
+                       side_effect=side_effect) as is_finite:
+        self.assertIsNone(evaluator.evaluate(0))
+      is_finite.assert_called_with(long(48))
 
   def test_less_than_int__returns_false__when_user_value_not_less_than_condition_value(self):
 

--- a/tests/helpers_tests/test_condition.py
+++ b/tests/helpers_tests/test_condition.py
@@ -201,37 +201,6 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
 
     self.assertStrictTrue(evaluator.evaluate(0))
 
-  def test_exact_int__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
-    if PY2:
-      evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        exact_int_condition_list, {'lasers_count': long(9000)}
-      )
-
-      with mock.patch('optimizely.helpers.validator.is_finite_number',
-                      return_value=True) as is_finite:
-        self.assertStrictTrue(evaluator.evaluate(0))
-      is_finite.assert_called_with(long(9000))
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        exact_int_condition_list, {'lasers_count': 9000}
-      )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=False) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_called_with(9000)
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      exact_int_condition_list, {'lasers_count': 9000.0}
-    )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=False) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_called_with(9000.0)
-
   def test_exact_float__returns_true__when_user_provided_value_is_equal_to_condition_value(self):
 
     if PY2:
@@ -252,37 +221,6 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
     )
 
     self.assertStrictTrue(evaluator.evaluate(0))
-
-  def test_exact_float__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
-    if PY2:
-      evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        exact_float_condition_list, {'lasers_count': long(9000)}
-      )
-
-      with mock.patch('optimizely.helpers.validator.is_finite_number',
-                      return_value=True) as is_finite:
-        self.assertStrictTrue(evaluator.evaluate(0))
-      is_finite.assert_called_with(long(9000))
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        exact_float_condition_list, {'lasers_count': 9000}
-      )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=False) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_called_with(9000)
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      exact_float_condition_list, {'lasers_count': 9000.0}
-    )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=False) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_called_with(9000.0)
 
   def test_exact_int__returns_false__when_user_provided_value_is_not_equal_to_condition_value(self):
 
@@ -343,6 +281,27 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
     )
 
     self.assertIsNone(evaluator.evaluate(0))
+
+  def test_exact__given_number_values__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+        exact_int_condition_list, {'lasers_count': 9000}
+      )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=True) as is_finite:
+      self.assertTrue(evaluator.evaluate(0))
+    is_finite.assert_called_with(9000)
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      exact_int_condition_list, {'lasers_count': 9000.0}
+    )
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    return_value=False) as is_finite:
+      self.assertIsNone(evaluator.evaluate(0))
+    is_finite.assert_called_with(9000.0)
 
   def test_exact_bool__returns_true__when_user_provided_value_is_equal_to_condition_value(self):
 
@@ -429,42 +388,6 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
 
       self.assertStrictTrue(evaluator.evaluate(0))
 
-  def test_greater_than_int__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      gt_int_condition_list, {'meters_travelled': 48.1}
-    )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=True) as is_finite:
-      self.assertStrictTrue(evaluator.evaluate(0))
-    is_finite.assert_called_with(48.1)
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      gt_int_condition_list, {'meters_travelled': 49}
-    )
-
-    def side_effect(*args):
-      if args[0] == 49:
-        return False
-      return True
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=side_effect) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_any_call(49)
-
-    if PY2:
-      evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        gt_int_condition_list, {'meters_travelled': long(49)}
-      )
-
-      with mock.patch('optimizely.helpers.validator.is_finite_number',
-                       side_effect=side_effect) as is_finite:
-        self.assertIsNone(evaluator.evaluate(0))
-      is_finite.assert_called_with(long(49))
-
   def test_greater_than_float__returns_true__when_user_value_greater_than_condition_value(self):
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -485,42 +408,6 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       )
 
       self.assertStrictTrue(evaluator.evaluate(0))
-
-  def test_greater_than_float__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      gt_float_condition_list, {'meters_travelled': 48.3}
-    )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=True) as is_finite:
-      self.assertStrictTrue(evaluator.evaluate(0))
-    is_finite.assert_called_with(48.3)
-
-    def side_effect(*args):
-      if args[0] == 49:
-        return False
-      return True
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      gt_float_condition_list, {'meters_travelled': 49}
-    )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=side_effect) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_called_with(49)
-
-    if PY2:
-      evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        gt_float_condition_list, {'meters_travelled': long(49)}
-      )
-
-      with mock.patch('optimizely.helpers.validator.is_finite_number',
-                      side_effect=side_effect) as is_finite:
-        self.assertIsNone(evaluator.evaluate(0))
-      is_finite.assert_called_with(long(49))
 
   def test_greater_than_int__returns_false__when_user_value_not_greater_than_condition_value(self):
 
@@ -629,42 +516,6 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
 
       self.assertStrictTrue(evaluator.evaluate(0))
 
-  def test_less_than_int__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      lt_int_condition_list, {'meters_travelled': 47.9}
-    )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=True) as is_finite:
-      self.assertStrictTrue(evaluator.evaluate(0))
-    is_finite.assert_called_with(47.9)
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      lt_int_condition_list, {'meters_travelled': 47}
-    )
-
-    def side_effect(*args):
-      if args[0] == 47:
-        return False
-      return True
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=side_effect) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_any_call(47)
-
-    if PY2:
-      evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        lt_int_condition_list, {'meters_travelled': long(47)}
-      )
-
-      with mock.patch('optimizely.helpers.validator.is_finite_number',
-                       side_effect=side_effect) as is_finite:
-        self.assertIsNone(evaluator.evaluate(0))
-      is_finite.assert_called_with(long(47))
-
   def test_less_than_float__returns_true__when_user_value_less_than_condition_value(self):
 
     evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -685,42 +536,6 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
       )
 
       self.assertStrictTrue(evaluator.evaluate(0))
-
-  def test_less_than_float__calls_is_finite_number(self):
-    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      lt_float_condition_list, {'meters_travelled': 48.1}
-    )
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=True) as is_finite:
-      self.assertStrictTrue(evaluator.evaluate(0))
-    is_finite.assert_called_with(48.1)
-
-    evaluator = condition_helper.CustomAttributeConditionEvaluator(
-      lt_float_condition_list, {'meters_travelled': 48}
-    )
-
-    def side_effect(*args):
-      if args[0] == 48:
-        return False
-      return True
-
-    with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    side_effect=side_effect) as is_finite:
-      self.assertIsNone(evaluator.evaluate(0))
-    is_finite.assert_any_call(48)
-
-    if PY2:
-      evaluator = condition_helper.CustomAttributeConditionEvaluator(
-        lt_float_condition_list, {'meters_travelled': long(48)}
-      )
-
-      with mock.patch('optimizely.helpers.validator.is_finite_number',
-                       side_effect=side_effect) as is_finite:
-        self.assertIsNone(evaluator.evaluate(0))
-      is_finite.assert_called_with(long(48))
 
   def test_less_than_int__returns_false__when_user_value_not_less_than_condition_value(self):
 
@@ -795,6 +610,82 @@ class CustomAttributeConditionEvaluator(base.BaseTest):
     )
 
     self.assertIsNone(evaluator.evaluate(0))
+
+  def test_greater_than__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      gt_int_condition_list, {'meters_travelled': 48.1}
+    )
+
+    def is_finite_number__rejecting_condition_value(value):
+      if value == 48:
+        return False
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=is_finite_number__rejecting_condition_value) as is_finite_mock:
+      self.assertIsNone(evaluator.evaluate(0))
+
+    # assert that isFiniteNumber only needs to reject condition value to stop evaluation.
+    is_finite_mock.assert_called_once_with(48)
+
+    def is_finite_number__rejecting_user_attribute_value(value):
+      if value == 48.1:
+        return False
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=is_finite_number__rejecting_user_attribute_value) as is_finite_mock:
+      self.assertIsNone(evaluator.evaluate(0))
+
+    # assert that isFiniteNumber evaluates user value only if it has accepted condition value.
+    is_finite_mock.assert_has_calls([mock.call(48), mock.call(48.1)])
+
+    def is_finite_number__accepting_both_values(value):
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=is_finite_number__accepting_both_values):
+      self.assertTrue(evaluator.evaluate(0))
+
+  def test_less_than__calls_is_finite_number(self):
+    """ Returns True if is_finite_number returns True. Returns None if is_finite_number returns False. """
+
+    evaluator = condition_helper.CustomAttributeConditionEvaluator(
+      lt_int_condition_list, {'meters_travelled': 47}
+    )
+
+    def is_finite_number__rejecting_condition_value(value):
+      if value == 48:
+        return False
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=is_finite_number__rejecting_condition_value) as is_finite_mock:
+      self.assertIsNone(evaluator.evaluate(0))
+
+    # assert that isFiniteNumber only needs to reject condition value to stop evaluation.
+    is_finite_mock.assert_called_once_with(48)
+
+    def is_finite_number__rejecting_user_attribute_value(value):
+      if value == 47:
+        return False
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=is_finite_number__rejecting_user_attribute_value) as is_finite_mock:
+      self.assertIsNone(evaluator.evaluate(0))
+
+    # assert that isFiniteNumber evaluates user value only if it has accepted condition value.
+    is_finite_mock.assert_has_calls([mock.call(48), mock.call(47)])
+
+    def is_finite_number__accepting_both_values(value):
+      return True
+
+    with mock.patch('optimizely.helpers.validator.is_finite_number',
+                    side_effect=is_finite_number__accepting_both_values):
+      self.assertTrue(evaluator.evaluate(0))
 
 
 class ConditionDecoderTests(base.BaseTest):

--- a/tests/helpers_tests/test_validator.py
+++ b/tests/helpers_tests/test_validator.py
@@ -173,23 +173,23 @@ class ValidatorTest(base.BaseTest):
 
     # test if attribute value is a number, it calls is_finite_number and returns it's result
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=True) as is_finite:
+                    return_value=True) as mock_is_finite:
       self.assertTrue(validator.is_attribute_valid('test_attribute', 5))
 
-    is_finite.assert_called_once_with(5)
+    mock_is_finite.assert_called_once_with(5)
 
     with mock.patch('optimizely.helpers.validator.is_finite_number',
-                    return_value=False) as is_finite:
+                    return_value=False) as mock_is_finite:
       self.assertFalse(validator.is_attribute_valid('test_attribute', 5.5))
 
-    is_finite.assert_called_once_with(5.5)
+    mock_is_finite.assert_called_once_with(5.5)
 
     if PY2:
       with mock.patch('optimizely.helpers.validator.is_finite_number',
-                      return_value=None) as is_finite:
+                      return_value=None) as mock_is_finite:
         self.assertIsNone(validator.is_attribute_valid('test_attribute', long(5)))
 
-      is_finite.assert_called_once_with(long(5))
+      mock_is_finite.assert_called_once_with(long(5))
 
   def test_is_finite_number(self):
     """ Test that it returns true if value is a number and not NAN, INF, -INF or greater than 2^53.

--- a/tests/helpers_tests/test_validator.py
+++ b/tests/helpers_tests/test_validator.py
@@ -47,7 +47,6 @@ class ValidatorTest(base.BaseTest):
     """ Test that invalid event_dispatcher returns False. """
 
     class CustomEventDispatcher(object):
-
       def some_other_method(self):
         pass
 
@@ -62,7 +61,6 @@ class ValidatorTest(base.BaseTest):
     """ Test that invalid logger returns False. """
 
     class CustomLogger(object):
-
       def some_other_method(self):
         pass
 
@@ -77,7 +75,6 @@ class ValidatorTest(base.BaseTest):
     """ Test that invalid error_handler returns False. """
 
     class CustomErrorHandler(object):
-
       def some_other_method(self):
         pass
 

--- a/tests/helpers_tests/test_validator.py
+++ b/tests/helpers_tests/test_validator.py
@@ -220,6 +220,7 @@ class ValidatorTest(base.BaseTest):
     self.assertTrue(validator.is_finite_number(0))
     self.assertTrue(validator.is_finite_number(5))
     self.assertTrue(validator.is_finite_number(5.5))
+    # float(2**53) + 1.0 evaluates to float(2**53)
     self.assertTrue(validator.is_finite_number(float(2**53) + 1.0))
     self.assertTrue(validator.is_finite_number(-float(2**53) - 1.0))
     self.assertTrue(validator.is_finite_number(int(2**53)))


### PR DESCRIPTION
Summary
-------
Don't target NAN, INF or -INF doubles
Don't target Values > 2^53. 
Modified is_attribute_valid to check if the number is finite. 

Test plan
---------

Issues
------
OASIS-3654
https://github.com/optimizely/python-sdk/pull/146#discussion_r237850806
