### PR TITLE
refac(ci): switch stage order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ script: "nosetests --with-coverage --cover-package=optimizely"
 after_success:
   - coveralls
 
+# Integration tests need to run first to reset the PR build status to pending
+stages:
+  - 'Integration tests'
+  - 'Test'
+
 jobs:
   include:
     - stage: 'Integration tests'


### PR DESCRIPTION
Summary
-------

-  switch the order of stages so that integration tests occur ahead of unit tests. this allows resetting the build status to pending without having to wait for unit tests to finish first.