### PR TITLE
refac(ci): (adding python 3.7 support fix) use xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
+dist: xenial
 python:
   - "2.7"
   - "3.4"
   - "3.5.5"
   - "3.6"
   - "3.7"
-  - "pypy"
-  - "pypy3"
+  - "pypy2.7-6.0"
+  - "pypy3.5-6.0"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 before_script: "pep8"
 addons:


### PR DESCRIPTION
Summary
-------

- Adding python3.7 support. Ubuntu Trusty does not support this version so we have to use Xenial instead.

Note
----
- If you merge this one, discard https://github.com/optimizely/python-sdk/pull/160