### PR TITLE
refac(ci): (adding python 3.7 support fix) only xenial for 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.4"
   - "3.5.5"
   - "3.6"
-  - "3.7"
+# - "3.7"  is handled in 'Test' job using xenial as Python 3.7 is not available for trusty.
   - "pypy"
   - "pypy3"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
@@ -33,3 +33,7 @@ jobs:
       script:
         - "ci/trigger_fullstack-sdk-compat.sh"
       after_success: skip
+    - stage: 'Test'
+      # python 3.7 not available for trusty
+      dist: xenial
+      python: "3.7"


### PR DESCRIPTION
Summary
-------

- Adding python3.7 support. Ubuntu Trusty does not support this version so we have to use Xenial instead.

Note
----

- If you merge this one, discard https://github.com/optimizely/python-sdk/pull/159