### PR TITLE
adds Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5.5"
   - "3.6"
+# - "3.7" is handled in 'Test' job using xenial as Python 3.7 is not available for trusty.
   - "pypy"
   - "pypy3"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
@@ -34,3 +35,6 @@ jobs:
       script:
         - "ci/trigger_fullstack-sdk-compat.sh"
       after_success: travis_terminate 0
+    - stage: 'Test'
+      dist: xenial
+      python: "3.7"


### PR DESCRIPTION
Summary
-------

-  Adds Python 3.7 support
Trusty (default build dist) does not support Python 3.7, so this had to be handled in a separate stage using Xenial.