### PR TITLE
ci: Replace pep8 by flake8 and separate linting stage on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,13 @@ python:
   - "pypy"
   - "pypy3"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
-before_script: skip
 addons:
   srcclr: true
 script: "nosetests --with-coverage --cover-package=optimizely"
 after_success:
   - coveralls
 
-# Integration tests need to run first to reset the PR build status to pending
+# Linting and Integration tests need to run first to reset the PR build status to pending.
 stages:
   - 'Linting'
   - 'Integration tests'
@@ -27,16 +26,13 @@ jobs:
       language: python
       python: "2.7"
       install: "pip install flake8"
-      before_script: skip
       script: "flake8"
-      after_script: skip
       after_success: travis_terminate 0
     - stage: 'Integration Tests'
       merge_mode: replace
       env: SDK=python
       cache: false
       language: python
-      before_install: skip
       install:
         - "pip install awscli"
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "pypy"
   - "pypy3"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
-before_script: "pep8"
+before_script: skip
 addons:
   srcclr: true
 script: "nosetests --with-coverage --cover-package=optimizely"
@@ -17,12 +17,21 @@ after_success:
 
 # Integration tests need to run first to reset the PR build status to pending
 stages:
+  - 'Linting'
   - 'Integration tests'
   - 'Test'
 
 jobs:
   include:
-    - stage: 'Integration tests'
+    - stage: 'Linting'
+      language: python
+      python: "2.7"
+      install: "pip install flake8"
+      before_script: skip
+      script: "flake8"
+      after_script: skip
+      after_success: travis_terminate 0
+    - stage: 'Integration Tests'
       merge_mode: replace
       env: SDK=python
       cache: false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,7 +37,7 @@ Pull request acceptance criteria
 Style
 -----
 
-We enforce PEP-8 rules with a few minor `deviations`_.
+We enforce Flake8 rules with a few minor `deviations`_.
 
 License
 -------

--- a/optimizely/helpers/condition.py
+++ b/optimizely/helpers/condition.py
@@ -1,4 +1,4 @@
-# Copyright 2016, 2018, Optimizely
+# Copyright 2016, 2018-2019, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import json
-import numbers
 
 from six import string_types
 

--- a/optimizely/helpers/condition_tree_evaluator.py
+++ b/optimizely/helpers/condition_tree_evaluator.py
@@ -1,4 +1,4 @@
-# Copyright 2018, Optimizely
+# Copyright 2018-2019, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -85,6 +85,7 @@ def not_evaluator(conditions, leaf_evaluator):
 
   result = evaluate(conditions[0], leaf_evaluator)
   return None if result is None else not result
+
 
 EVALUATORS_BY_OPERATOR_TYPE = {
   ConditionOperatorTypes.AND: and_evaluator,

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 coverage==4.0.3
+flake8==3.6.0
 funcsigs==0.4
 mock==1.3.0
 nose==1.3.7
-pep8==1.7.0
 python-coveralls==2.7.0
 tabulate==0.7.5

--- a/tests/benchmarking/benchmarking_tests.py
+++ b/tests/benchmarking/benchmarking_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Optimizely
+# Copyright 2016, 2019, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -230,6 +230,7 @@ def run_benchmarking_tests():
         all_test_results_median[experiment_count][test_name] = time_in_milliseconds_median
 
   display_results(all_test_results_average, all_test_results_median)
+
 
 if __name__ == '__main__':
   run_benchmarking_tests()

--- a/tests/benchmarking/data.py
+++ b/tests/benchmarking/data.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Optimizely
+# Copyright 2016, 2019, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -3280,6 +3280,7 @@ def create_optimizely_object(datafile):
     pass
 
   return optimizely.Optimizely(datafile, event_dispatcher=NoOpEventDispatcher)
+
 
 optimizely_obj_10_exp = create_optimizely_object(json.dumps(datafiles.get(10)))
 optimizely_obj_25_exp = create_optimizely_object(json.dumps(datafiles.get(25)))

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Optimizely
+# Copyright 2016-2019, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 import json
 import mock
 
-from optimizely import entities
 from optimizely import optimizely
 from optimizely.helpers import audience
 from tests import base
@@ -97,7 +96,7 @@ class AudienceTest(base.BaseTest):
 
     user_attributes = {'test_attribute': 'test_value_1'}
     experiment = self.project_config.get_experiment_from_key('test_experiment')
-    with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=True) as cond_tree_eval:
+    with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=True):
 
       self.assertStrictTrue(audience.is_user_in_experiment(self.project_config, experiment, user_attributes))
 
@@ -106,11 +105,11 @@ class AudienceTest(base.BaseTest):
 
     user_attributes = {'test_attribute': 'test_value_1'}
     experiment = self.project_config.get_experiment_from_key('test_experiment')
-    with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=None) as cond_tree_eval:
+    with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=None):
 
       self.assertStrictFalse(audience.is_user_in_experiment(self.project_config, experiment, user_attributes))
 
-    with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=False) as cond_tree_eval:
+    with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=False):
 
       self.assertStrictFalse(audience.is_user_in_experiment(self.project_config, experiment, user_attributes))
 
@@ -118,7 +117,6 @@ class AudienceTest(base.BaseTest):
     """ Test that is_user_in_experiment correctly evaluates audience Ids and
         calls custom attribute evaluator for leaf nodes. """
 
-    user_attributes = {'test_attribute': 'test_value_1'}
     experiment = self.project_config.get_experiment_from_key('test_experiment')
     experiment.audienceIds = ['11154', '11159']
     experiment.audienceConditions = None

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Optimizely
+# Copyright 2016-2019, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -371,7 +371,6 @@ class OptimizelyTest(base.BaseTest):
 
   def test_add_invalid_listener(self):
     """ Test adding a invalid listener """
-    not_a_listener = "This is not a listener"
     self.assertEqual(0, len(self.optimizely.notification_center.notifications[enums.NotificationTypes.TRACK]))
 
   def test_add_multi_listener(self):
@@ -455,7 +454,7 @@ class OptimizelyTest(base.BaseTest):
     with mock.patch('optimizely.decision_service.DecisionService.get_variation',
                     return_value=self.project_config.get_variation_from_id(
                       'test_experiment', '111128'
-                    )) as mock_get_variation, \
+                    )), \
       mock.patch('optimizely.event_dispatcher.EventDispatcher.dispatch_event') as mock_dispatch, \
       mock.patch('optimizely.notification_center.NotificationCenter.send_notifications') as mock_event_tracked:
       self.optimizely.track('test_event', 'test_user', attributes={'test_attribute': 'test_value'})
@@ -470,7 +469,7 @@ class OptimizelyTest(base.BaseTest):
     with mock.patch('optimizely.decision_service.DecisionService.get_variation',
                     return_value=self.project_config.get_variation_from_id(
                       'test_experiment', '111128'
-                    )) as mock_get_variation, \
+                    )), \
       mock.patch('optimizely.event_dispatcher.EventDispatcher.dispatch_event') as mock_dispatch, \
       mock.patch('optimizely.notification_center.NotificationCenter.send_notifications') as mock_event_tracked:
       self.optimizely.track('test_event', 'test_user', attributes={'test_attribute': 'test_value'},
@@ -505,7 +504,7 @@ class OptimizelyTest(base.BaseTest):
                       mock_variation,
                       decision_service.DECISION_SOURCE_EXPERIMENT
                     )) as mock_decision, \
-      mock.patch('optimizely.event_dispatcher.EventDispatcher.dispatch_event') as mock_dispatch_event, \
+      mock.patch('optimizely.event_dispatcher.EventDispatcher.dispatch_event'), \
       mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'), \
       mock.patch('time.time', return_value=42):
       self.assertTrue(opt_obj.is_feature_enabled('test_feature_in_experiment', 'test_user'))
@@ -2629,7 +2628,7 @@ class OptimizelyWithLoggingTest(base.BaseTest):
   def test_get_variation__user_profile__forced_bucketing(self):
     """ Test that the expected forced variation is called if a user profile exists """
     with mock.patch('optimizely.decision_service.DecisionService.get_stored_variation',
-                    return_value=entities.Variation('111128', 'control')) as mock_get_stored_variation:
+                    return_value=entities.Variation('111128', 'control')):
       self.assertTrue(self.optimizely.set_forced_variation('test_experiment', 'test_user', 'variation'))
       self.assertEqual('variation', self.optimizely.get_forced_variation('test_experiment', 'test_user'))
       variation_key = self.optimizely.get_variation('test_experiment',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
-[pep8]
+[flake8]
 # E111 - indentation is not a multiple of four
 # E114 - indentation is not a multiple of four (comment)
 # E121 - continuation line indentation is not a multiple of four
 # E127 - continuation line over-indented for visual indent
-ignore = E111,E114,E121,E127
+# E722 - do not use bare 'except'
+ignore = E111,E114,E121,E127, E722
 exclude = optimizely/lib/pymmh3.py,*virtualenv*
 max-line-length = 120


### PR DESCRIPTION
Summary
-------
This implements flake8 which is a wrapper over pyflakes, pycodestyle(PEP8), and circular complexity checks. 

Also, the linting stage has been separated so that it immediately fails the build rather than creating separate environments for multiple python versions and failing all the jobs for the same reason. 

Test plan
---------

Issues
------

