### PR TITLE
Refactoring and passing ProjectConfig from Optimizely itself.

### DIFF
--- a/optimizely/bucketer.py
+++ b/optimizely/bucketer.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017, Optimizely
+# Copyright 2016-2017, 2019 Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -29,15 +29,10 @@ GROUP_POLICIES = ['random']
 class Bucketer(object):
   """ Optimizely bucketing algorithm that evenly distributes visitors. """
 
-  def __init__(self, project_config):
-    """ Bucketer init method to set bucketing seed and project config data.
-
-    Args:
-      project_config: Project config data to be used in making bucketing decisions.
-    """
+  def __init__(self):
+    """ Bucketer init method to set bucketing seed and logger instance. """
 
     self.bucket_seed = HASH_SEED
-    self.config = project_config
 
   def _generate_unsigned_hash_code_32_bit(self, bucketing_id):
     """ Helper method to retrieve hash code.
@@ -65,10 +60,11 @@ class Bucketer(object):
     ratio = float(self._generate_unsigned_hash_code_32_bit(bucketing_id)) / MAX_HASH_VALUE
     return math.floor(ratio * MAX_TRAFFIC_VALUE)
 
-  def find_bucket(self, bucketing_id, parent_id, traffic_allocations):
+  def find_bucket(self, project_config, bucketing_id, parent_id, traffic_allocations):
     """ Determine entity based on bucket value and traffic allocations.
 
     Args:
+      project_config: Instance of ProjectConfig.
       bucketing_id: ID to be used for bucketing the user.
       parent_id: ID representing group or experiment.
       traffic_allocations: Traffic allocations representing traffic allotted to experiments or variations.
@@ -79,7 +75,7 @@ class Bucketer(object):
 
     bucketing_key = BUCKETING_ID_TEMPLATE.format(bucketing_id=bucketing_id, parent_id=parent_id)
     bucketing_number = self._generate_bucket_value(bucketing_key)
-    self.config.logger.debug('Assigned bucket %s to user with bucketing ID "%s".' % (
+    project_config.logger.debug('Assigned bucket %s to user with bucketing ID "%s".' % (
       bucketing_number,
       bucketing_id
     ))
@@ -91,10 +87,11 @@ class Bucketer(object):
 
     return None
 
-  def bucket(self, experiment, user_id, bucketing_id):
+  def bucket(self, project_config, experiment, user_id, bucketing_id):
     """ For a given experiment and bucketing ID determines variation to be shown to user.
 
     Args:
+      project_config: Instance of ProjectConfig.
       experiment: Object representing the experiment for which user is to be bucketed.
       user_id: ID for user.
       bucketing_id: ID to be used for bucketing the user.
@@ -108,40 +105,40 @@ class Bucketer(object):
 
     # Determine if experiment is in a mutually exclusive group
     if experiment.groupPolicy in GROUP_POLICIES:
-      group = self.config.get_group(experiment.groupId)
+      group = project_config.get_group(experiment.groupId)
 
       if not group:
         return None
 
-      user_experiment_id = self.find_bucket(bucketing_id, experiment.groupId, group.trafficAllocation)
+      user_experiment_id = self.find_bucket(project_config, bucketing_id, experiment.groupId, group.trafficAllocation)
       if not user_experiment_id:
-        self.config.logger.info('User "%s" is in no experiment.' % user_id)
+        project_config.logger.info('User "%s" is in no experiment.' % user_id)
         return None
 
       if user_experiment_id != experiment.id:
-        self.config.logger.info('User "%s" is not in experiment "%s" of group %s.' % (
+        project_config.logger.info('User "%s" is not in experiment "%s" of group %s.' % (
           user_id,
           experiment.key,
           experiment.groupId
         ))
         return None
 
-      self.config.logger.info('User "%s" is in experiment %s of group %s.' % (
+      project_config.logger.info('User "%s" is in experiment %s of group %s.' % (
         user_id,
         experiment.key,
         experiment.groupId
       ))
 
     # Bucket user if not in white-list and in group (if any)
-    variation_id = self.find_bucket(bucketing_id, experiment.id, experiment.trafficAllocation)
+    variation_id = self.find_bucket(project_config, bucketing_id, experiment.id, experiment.trafficAllocation)
     if variation_id:
-      variation = self.config.get_variation_from_id(experiment.key, variation_id)
-      self.config.logger.info('User "%s" is in variation "%s" of experiment %s.' % (
+      variation = project_config.get_variation_from_id(experiment.key, variation_id)
+      project_config.logger.info('User "%s" is in variation "%s" of experiment %s.' % (
         user_id,
         variation.key,
         experiment.key
       ))
       return variation
 
-    self.config.logger.info('User "%s" is in no variation.' % user_id)
+    project_config.logger.info('User "%s" is in no variation.' % user_id)
     return None

--- a/optimizely/event_builder.py
+++ b/optimizely/event_builder.py
@@ -13,8 +13,6 @@
 
 import time
 import uuid
-from abc import abstractmethod
-from abc import abstractproperty
 
 from . import version
 from .helpers import enums
@@ -32,113 +30,7 @@ class Event(object):
     self.headers = headers
 
 
-class BaseEventBuilder(object):
-  """ Base class which encapsulates methods to build events for tracking impressions and conversions. """
-
-  def __init__(self, config):
-    self.config = config
-
-  @abstractproperty
-  class EventParams(object):
-    pass
-
-  def _get_project_id(self):
-    """ Get project ID.
-
-    Returns:
-      Project ID of the datafile.
-    """
-
-    return self.config.get_project_id()
-
-  def _get_revision(self):
-    """ Get revision.
-
-    Returns:
-      Revision of the datafile.
-    """
-
-    return self.config.get_revision()
-
-  def _get_account_id(self):
-    """ Get account ID.
-
-    Returns:
-      Account ID in the datafile.
-    """
-
-    return self.config.get_account_id()
-
-  @abstractmethod
-  def _get_attributes(self, attributes):
-    """ Get attribute(s) information.
-
-    Args:
-      attributes: Dict representing user attributes and values which need to be recorded.
-    """
-    pass
-
-  def _get_anonymize_ip(self):
-    """ Get IP anonymization bool
-
-    Returns:
-      Boolean representing whether IP anonymization is enabled or not.
-    """
-
-    return self.config.get_anonymize_ip_value()
-
-  def _get_bot_filtering(self):
-    """ Get bot filtering bool
-
-    Returns:
-      Boolean representing whether bot filtering is enabled or not.
-    """
-
-    return self.config.get_bot_filtering_value()
-
-  @abstractmethod
-  def _get_time(self):
-    """ Get time in milliseconds to be added.
-
-    Returns:
-      int Current time in milliseconds.
-    """
-
-    return int(round(time.time() * 1000))
-
-  def _get_common_params(self, user_id, attributes):
-    """ Get params which are used same in both conversion and impression events.
-
-    Args:
-      user_id: ID for user.
-      attributes: Dict representing user attributes and values which need to be recorded.
-
-    Returns:
-     Dict consisting of parameters common to both impression and conversion events.
-    """
-    commonParams = {}
-
-    commonParams[self.EventParams.PROJECT_ID] = self._get_project_id()
-    commonParams[self.EventParams.ACCOUNT_ID] = self._get_account_id()
-
-    visitor = {}
-    visitor[self.EventParams.END_USER_ID] = user_id
-    visitor[self.EventParams.SNAPSHOTS] = []
-
-    commonParams[self.EventParams.USERS] = []
-    commonParams[self.EventParams.USERS].append(visitor)
-    commonParams[self.EventParams.USERS][0][self.EventParams.ATTRIBUTES] = self._get_attributes(attributes)
-
-    commonParams[self.EventParams.SOURCE_SDK_TYPE] = 'python-sdk'
-    commonParams[self.EventParams.ENRICH_DECISIONS] = True
-    commonParams[self.EventParams.SOURCE_SDK_VERSION] = version.__version__
-    commonParams[self.EventParams.ANONYMIZE_IP] = self._get_anonymize_ip()
-    commonParams[self.EventParams.REVISION] = self._get_revision()
-
-    return commonParams
-
-
-class EventBuilder(BaseEventBuilder):
+class EventBuilder(object):
   """ Class which encapsulates methods to build events for tracking
   impressions and conversions using the new V3 event API (batch). """
 
@@ -170,10 +62,11 @@ class EventBuilder(BaseEventBuilder):
     ANONYMIZE_IP = 'anonymize_ip'
     REVISION = 'revision'
 
-  def _get_attributes(self, attributes):
+  def _get_attributes_data(self, project_config, attributes):
     """ Get attribute(s) information.
 
     Args:
+      project_config: Instance of ProjectConfig.
       attributes: Dict representing user attributes and values which need to be recorded.
 
     Returns:
@@ -187,7 +80,7 @@ class EventBuilder(BaseEventBuilder):
         attribute_value = attributes.get(attribute_key)
         # Omit attribute values that are not supported by the log endpoint.
         if validator.is_attribute_valid(attribute_key, attribute_value):
-          attribute_id = self.config.get_attribute_id(attribute_key)
+          attribute_id = project_config.get_attribute_id(attribute_key)
           if attribute_id:
             params.append({
               'entity_id': attribute_id,
@@ -197,7 +90,7 @@ class EventBuilder(BaseEventBuilder):
             })
 
     # Append Bot Filtering Attribute
-    bot_filtering_value = self._get_bot_filtering()
+    bot_filtering_value = project_config.get_bot_filtering_value()
     if isinstance(bot_filtering_value, bool):
       params.append({
           'entity_id': enums.ControlAttributes.BOT_FILTERING,
@@ -207,6 +100,50 @@ class EventBuilder(BaseEventBuilder):
       })
 
     return params
+
+  def _get_time(self):
+    """ Get time in milliseconds to be added.
+
+    Returns:
+      int Current time in milliseconds.
+    """
+
+    return int(round(time.time() * 1000))
+
+  def _get_common_params(self, project_config, user_id, attributes):
+    """ Get params which are used same in both conversion and impression events.
+
+    Args:
+      project_config: Instance of ProjectConfig.
+      user_id: ID for user.
+      attributes: Dict representing user attributes and values which need to be recorded.
+
+    Returns:
+     Dict consisting of parameters common to both impression and conversion events.
+    """
+    common_params = {
+      self.EventParams.PROJECT_ID: project_config.get_project_id(),
+      self.EventParams.ACCOUNT_ID: project_config.get_account_id()
+    }
+
+    visitor = {
+      self.EventParams.END_USER_ID: user_id,
+      self.EventParams.SNAPSHOTS: []
+    }
+
+    common_params[self.EventParams.USERS] = []
+    common_params[self.EventParams.USERS].append(visitor)
+    common_params[self.EventParams.USERS][0][self.EventParams.ATTRIBUTES] = self._get_attributes_data(
+      project_config, attributes
+    )
+
+    common_params[self.EventParams.SOURCE_SDK_TYPE] = 'python-sdk'
+    common_params[self.EventParams.ENRICH_DECISIONS] = True
+    common_params[self.EventParams.SOURCE_SDK_VERSION] = version.__version__
+    common_params[self.EventParams.ANONYMIZE_IP] = project_config.get_anonymize_ip_value()
+    common_params[self.EventParams.REVISION] = project_config.get_revision()
+
+    return common_params
 
   def _get_required_params_for_impression(self, experiment, variation_id):
     """ Get parameters that are required for the impression event to register.
@@ -235,10 +172,11 @@ class EventBuilder(BaseEventBuilder):
 
     return snapshot
 
-  def _get_required_params_for_conversion(self, event_key, event_tags):
+  def _get_required_params_for_conversion(self, project_config, event_key, event_tags):
     """ Get parameters that are required for the conversion event to register.
 
     Args:
+      project_config: Instance of ProjectConfig.
       event_key: Key representing the event which needs to be recorded.
       event_tags: Dict representing metadata associated with the event.
 
@@ -248,7 +186,7 @@ class EventBuilder(BaseEventBuilder):
     snapshot = {}
 
     event_dict = {
-      self.EventParams.EVENT_ID: self.config.get_event(event_key).id,
+      self.EventParams.EVENT_ID: project_config.get_event(event_key).id,
       self.EventParams.TIME: self._get_time(),
       self.EventParams.KEY: event_key,
       self.EventParams.UUID: str(uuid.uuid4())
@@ -259,7 +197,7 @@ class EventBuilder(BaseEventBuilder):
       if revenue_value is not None:
         event_dict[event_tag_utils.REVENUE_METRIC_TYPE] = revenue_value
 
-      numeric_value = event_tag_utils.get_numeric_value(event_tags, self.config.logger)
+      numeric_value = event_tag_utils.get_numeric_value(event_tags, project_config.logger)
       if numeric_value is not None:
         event_dict[event_tag_utils.NUMERIC_METRIC_TYPE] = numeric_value
 
@@ -269,10 +207,11 @@ class EventBuilder(BaseEventBuilder):
     snapshot[self.EventParams.EVENTS] = [event_dict]
     return snapshot
 
-  def create_impression_event(self, experiment, variation_id, user_id, attributes):
+  def create_impression_event(self, project_config, experiment, variation_id, user_id, attributes):
     """ Create impression Event to be sent to the logging endpoint.
 
     Args:
+      project_config: Instance of ProjectConfig.
       experiment: Experiment for which impression needs to be recorded.
       variation_id: ID for variation which would be presented to user.
       user_id: ID for user.
@@ -282,7 +221,7 @@ class EventBuilder(BaseEventBuilder):
       Event object encapsulating the impression event.
     """
 
-    params = self._get_common_params(user_id, attributes)
+    params = self._get_common_params(project_config, user_id, attributes)
     impression_params = self._get_required_params_for_impression(experiment, variation_id)
 
     params[self.EventParams.USERS][0][self.EventParams.SNAPSHOTS].append(impression_params)
@@ -292,10 +231,11 @@ class EventBuilder(BaseEventBuilder):
                  http_verb=self.HTTP_VERB,
                  headers=self.HTTP_HEADERS)
 
-  def create_conversion_event(self, event_key, user_id, attributes, event_tags):
+  def create_conversion_event(self, project_config, event_key, user_id, attributes, event_tags):
     """ Create conversion Event to be sent to the logging endpoint.
 
     Args:
+      project_config: Instance of ProjectConfig.
       event_key: Key representing the event which needs to be recorded.
       user_id: ID for user.
       attributes: Dict representing user attributes and values.
@@ -305,8 +245,8 @@ class EventBuilder(BaseEventBuilder):
       Event object encapsulating the conversion event.
     """
 
-    params = self._get_common_params(user_id, attributes)
-    conversion_params = self._get_required_params_for_conversion(event_key, event_tags)
+    params = self._get_common_params(project_config, user_id, attributes)
+    conversion_params = self._get_required_params_for_conversion(project_config, event_key, event_tags)
 
     params[self.EventParams.USERS][0][self.EventParams.SNAPSHOTS].append(conversion_params)
     return Event(self.EVENTS_URL,

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -32,7 +32,7 @@ class ProjectConfig(object):
 
     Args:
       datafile: JSON string representing the project.
-      logger: Provides a log message to send log messages to.
+      logger: Provides a logger instance.
       error_handler: Provides a handle_error method to handle exceptions.
     """
 

--- a/tests/test_event_builder.py
+++ b/tests/test_event_builder.py
@@ -41,7 +41,7 @@ class EventTest(unittest.TestCase):
 
 class EventBuilderTest(base.BaseTest):
 
-  def setUp(self):
+  def setUp(self, *args, **kwargs):
     base.BaseTest.setUp(self, 'config_dict_with_multiple_experiments')
     self.event_builder = self.optimizely.event_builder
 
@@ -93,7 +93,7 @@ class EventBuilderTest(base.BaseTest):
          mock.patch('optimizely.bucketer.Bucketer._generate_bucket_value', return_value=5042), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
       event_obj = self.event_builder.create_impression_event(
-        self.project_config.get_experiment_from_key('test_experiment'), '111129', 'test_user', None
+        self.project_config, self.project_config.get_experiment_from_key('test_experiment'), '111129', 'test_user', None
       )
     self._validate_event_object(event_obj,
                                 event_builder.EventBuilder.EVENTS_URL,
@@ -140,7 +140,7 @@ class EventBuilderTest(base.BaseTest):
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
       event_obj = self.event_builder.create_impression_event(
-        self.project_config.get_experiment_from_key('test_experiment'),
+        self.project_config, self.project_config.get_experiment_from_key('test_experiment'),
         '111129', 'test_user', {'test_attribute': 'test_value'}
       )
     self._validate_event_object(event_obj,
@@ -183,7 +183,7 @@ class EventBuilderTest(base.BaseTest):
       with mock.patch('time.time', return_value=42.123), \
            mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
         event_obj = self.event_builder.create_impression_event(
-          self.project_config.get_experiment_from_key('test_experiment'),
+          self.project_config, self.project_config.get_experiment_from_key('test_experiment'),
           '111129', 'test_user', {'do_you_know_me': 'test_value'}
         )
       self._validate_event_object(event_obj,
@@ -252,7 +252,7 @@ class EventBuilderTest(base.BaseTest):
          mock.patch('optimizely.helpers.validator.is_attribute_valid', side_effect=side_effect):
 
       event_obj = self.event_builder.create_impression_event(
-        self.project_config.get_experiment_from_key('test_experiment'),
+        self.project_config, self.project_config.get_experiment_from_key('test_experiment'),
         '111129', 'test_user', attributes
       )
 
@@ -306,8 +306,9 @@ class EventBuilderTest(base.BaseTest):
 
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'),\
-         mock.patch('optimizely.event_builder.EventBuilder._get_bot_filtering', return_value=True):
+         mock.patch('optimizely.project_config.ProjectConfig.get_bot_filtering_value', return_value=True):
       event_obj = self.event_builder.create_impression_event(
+        self.project_config,
         self.project_config.get_experiment_from_key('test_experiment'),
         '111129', 'test_user', {'$opt_user_agent': 'Edge'}
       )
@@ -357,8 +358,9 @@ class EventBuilderTest(base.BaseTest):
 
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'),\
-         mock.patch('optimizely.event_builder.EventBuilder._get_bot_filtering', return_value=True):
+         mock.patch('optimizely.project_config.ProjectConfig.get_bot_filtering_value', return_value=True):
       event_obj = self.event_builder.create_impression_event(
+        self.project_config,
         self.project_config.get_experiment_from_key('test_experiment'),
         '111129', 'test_user', None
       )
@@ -413,8 +415,9 @@ class EventBuilderTest(base.BaseTest):
 
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'),\
-         mock.patch('optimizely.event_builder.EventBuilder._get_bot_filtering', return_value=False):
+         mock.patch('optimizely.project_config.ProjectConfig.get_bot_filtering_value', return_value=False):
       event_obj = self.event_builder.create_impression_event(
+        self.project_config,
         self.project_config.get_experiment_from_key('test_experiment'),
         '111129', 'test_user', {'$opt_user_agent': 'Chrome'}
       )
@@ -454,7 +457,7 @@ class EventBuilderTest(base.BaseTest):
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
       event_obj = self.event_builder.create_conversion_event(
-        'test_event', 'test_user', None, None
+        self.project_config, 'test_event', 'test_user', None, None
       )
     self._validate_event_object(event_obj,
                                 event_builder.EventBuilder.EVENTS_URL,
@@ -496,7 +499,7 @@ class EventBuilderTest(base.BaseTest):
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
       event_obj = self.event_builder.create_conversion_event(
-        'test_event', 'test_user', {'test_attribute': 'test_value'}, None
+        self.project_config, 'test_event', 'test_user', {'test_attribute': 'test_value'}, None
       )
     self._validate_event_object(event_obj,
                                 event_builder.EventBuilder.EVENTS_URL,
@@ -543,10 +546,10 @@ class EventBuilderTest(base.BaseTest):
 
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'), \
-         mock.patch('optimizely.event_builder.EventBuilder._get_bot_filtering', return_value=True):
+         mock.patch('optimizely.project_config.ProjectConfig.get_bot_filtering_value', return_value=True):
       event_obj = self.event_builder.create_conversion_event(
-       'test_event', 'test_user', {'$opt_user_agent': 'Edge'}, None
-          )
+       self.project_config, 'test_event', 'test_user', {'$opt_user_agent': 'Edge'}, None
+      )
 
     self._validate_event_object(event_obj,
                                 event_builder.EventBuilder.EVENTS_URL,
@@ -593,9 +596,9 @@ class EventBuilderTest(base.BaseTest):
 
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'), \
-         mock.patch('optimizely.event_builder.EventBuilder._get_bot_filtering', return_value=False):
+         mock.patch('optimizely.project_config.ProjectConfig.get_bot_filtering_value', return_value=False):
       event_obj = self.event_builder.create_conversion_event(
-        'test_event', 'test_user', {'$opt_user_agent': 'Chrome'}, None
+        self.project_config, 'test_event', 'test_user', {'$opt_user_agent': 'Chrome'}, None
       )
 
     self._validate_event_object(event_obj,
@@ -645,6 +648,7 @@ class EventBuilderTest(base.BaseTest):
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
       event_obj = self.event_builder.create_conversion_event(
+        self.project_config,
         'test_event',
         'test_user',
         {'test_attribute': 'test_value'},
@@ -695,6 +699,7 @@ class EventBuilderTest(base.BaseTest):
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
       event_obj = self.event_builder.create_conversion_event(
+        self.project_config,
         'test_event',
         'test_user',
         {'test_attribute': 'test_value'},
@@ -747,6 +752,7 @@ class EventBuilderTest(base.BaseTest):
     with mock.patch('time.time', return_value=42.123), \
          mock.patch('uuid.uuid4', return_value='a68cf1ad-0393-4e18-af87-efe8f01a7c9c'):
       event_obj = self.event_builder.create_conversion_event(
+        self.project_config,
         'test_event',
         'test_user',
         {'test_attribute': 'test_value'},

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -251,7 +251,7 @@ class OptimizelyTest(base.BaseTest):
       'revision': '42'
     }
     mock_decision.assert_called_once_with(
-      self.project_config.get_experiment_from_key('test_experiment'), 'test_user', None
+      self.project_config, self.project_config.get_experiment_from_key('test_experiment'), 'test_user', None
     )
     self.assertEqual(1, mock_dispatch_event.call_count)
     self._validate_event_object(mock_dispatch_event.call_args[0][0], 'https://logx.optimizely.com/v1/events',
@@ -560,7 +560,7 @@ class OptimizelyTest(base.BaseTest):
       mock.patch('time.time', return_value=42):
       self.assertTrue(opt_obj.is_feature_enabled('test_feature_in_experiment', 'test_user'))
 
-    mock_decision.assert_called_once_with(feature, 'test_user', None)
+    mock_decision.assert_called_once_with(opt_obj.config, feature, 'test_user', None)
     self.assertTrue(access_callback[0])
 
   def test_is_feature_enabled_rollout_callback_listener(self):
@@ -591,7 +591,7 @@ class OptimizelyTest(base.BaseTest):
       mock.patch('time.time', return_value=42):
       self.assertTrue(opt_obj.is_feature_enabled('test_feature_in_experiment', 'test_user'))
 
-    mock_decision.assert_called_once_with(feature, 'test_user', None)
+    mock_decision.assert_called_once_with(project_config, feature, 'test_user', None)
 
     # Check that impression event is not sent
     self.assertEqual(0, mock_dispatch_event.call_count)
@@ -641,7 +641,8 @@ class OptimizelyTest(base.BaseTest):
       'anonymize_ip': False,
       'revision': '42'
     }
-    mock_get_variation.assert_called_once_with(self.project_config.get_experiment_from_key('test_experiment'),
+    mock_get_variation.assert_called_once_with(self.project_config,
+                                               self.project_config.get_experiment_from_key('test_experiment'),
                                                'test_user', {'test_attribute': 'test_value'})
     self.assertEqual(1, mock_dispatch_event.call_count)
     self._validate_event_object(mock_dispatch_event.call_args[0][0], 'https://logx.optimizely.com/v1/events',
@@ -716,7 +717,7 @@ class OptimizelyTest(base.BaseTest):
     }
 
     mock_bucket.assert_called_once_with(
-      self.project_config.get_experiment_from_key('test_experiment'), 'test_user', 'test_user'
+      self.project_config, self.project_config.get_experiment_from_key('test_experiment'), 'test_user', 'test_user'
     )
     self.assertEqual(1, mock_dispatch_event.call_count)
     self._validate_event_object(mock_dispatch_event.call_args[0][0], 'https://logx.optimizely.com/v1/events',
@@ -911,7 +912,8 @@ class OptimizelyTest(base.BaseTest):
       'anonymize_ip': False,
       'revision': '42'
     }
-    mock_get_variation.assert_called_once_with(self.project_config.get_experiment_from_key('test_experiment'),
+    mock_get_variation.assert_called_once_with(self.project_config,
+                                               self.project_config.get_experiment_from_key('test_experiment'),
                                                'test_user', {'test_attribute': 'test_value',
                                                              '$opt_bucketing_id': 'user_bucket_value'})
     self.assertEqual(1, mock_dispatch_event.call_count)
@@ -973,7 +975,8 @@ class OptimizelyTest(base.BaseTest):
       mock.patch('optimizely.event_dispatcher.EventDispatcher.dispatch_event') as mock_dispatch_event:
       self.assertIsNone(self.optimizely.activate('test_experiment', 'test_user',
                                                  attributes={'test_attribute': 'test_value'}))
-    mock_bucket.assert_called_once_with(self.project_config.get_experiment_from_key('test_experiment'),
+    mock_bucket.assert_called_once_with(self.project_config,
+                                        self.project_config.get_experiment_from_key('test_experiment'),
                                         'test_user',
                                         'test_user')
     self.assertEqual(0, mock_dispatch_event.call_count)
@@ -1646,7 +1649,7 @@ class OptimizelyTest(base.BaseTest):
       mock.patch('time.time', return_value=42):
       self.assertTrue(opt_obj.is_feature_enabled('test_feature_in_experiment', 'test_user'))
 
-    mock_decision.assert_called_once_with(feature, 'test_user', None)
+    mock_decision.assert_called_once_with(opt_obj.config, feature, 'test_user', None)
 
     mock_broadcast_decision.assert_called_with(
       enums.NotificationTypes.DECISION,
@@ -1727,7 +1730,7 @@ class OptimizelyTest(base.BaseTest):
       mock.patch('time.time', return_value=42):
       self.assertFalse(opt_obj.is_feature_enabled('test_feature_in_experiment', 'test_user'))
 
-    mock_decision.assert_called_once_with(feature, 'test_user', None)
+    mock_decision.assert_called_once_with(opt_obj.config, feature, 'test_user', None)
 
     mock_broadcast_decision.assert_called_with(
       enums.NotificationTypes.DECISION,
@@ -1809,7 +1812,7 @@ class OptimizelyTest(base.BaseTest):
       mock.patch('time.time', return_value=42):
       self.assertTrue(opt_obj.is_feature_enabled('test_feature_in_experiment', 'test_user'))
 
-    mock_decision.assert_called_once_with(feature, 'test_user', None)
+    mock_decision.assert_called_once_with(opt_obj.config, feature, 'test_user', None)
 
     mock_broadcast_decision.assert_called_with(
       enums.NotificationTypes.DECISION,
@@ -1854,7 +1857,7 @@ class OptimizelyTest(base.BaseTest):
       mock.patch('time.time', return_value=42):
       self.assertFalse(opt_obj.is_feature_enabled('test_feature_in_experiment', 'test_user'))
 
-    mock_decision.assert_called_once_with(feature, 'test_user', None)
+    mock_decision.assert_called_once_with(opt_obj.config, feature, 'test_user', None)
 
     mock_broadcast_decision.assert_called_with(
       enums.NotificationTypes.DECISION,
@@ -1895,7 +1898,7 @@ class OptimizelyTest(base.BaseTest):
     # Check that impression event is not sent
     self.assertEqual(0, mock_dispatch_event.call_count)
 
-    mock_decision.assert_called_once_with(feature, 'test_user', None)
+    mock_decision.assert_called_once_with(opt_obj.config, feature, 'test_user', None)
 
     mock_broadcast_decision.assert_called_with(
       enums.NotificationTypes.DECISION,
@@ -1960,23 +1963,23 @@ class OptimizelyTest(base.BaseTest):
     mock_variation_2 = opt_obj.config.get_variation_from_id('test_experiment', '111128')
 
     def side_effect(*args, **kwargs):
-      feature = args[0]
+      feature = args[1]
       if feature.key == 'test_feature_in_experiment':
-        return decision_service.Decision(mock_experiment, mock_variation,
-                                         enums.DecisionSources.FEATURE_TEST
-                                         )
+        return decision_service.Decision(
+          mock_experiment, mock_variation, enums.DecisionSources.FEATURE_TEST
+        )
       elif feature.key == 'test_feature_in_rollout':
-        return decision_service.Decision(mock_experiment, mock_variation,
-                                         enums.DecisionSources.ROLLOUT
-                                         )
+        return decision_service.Decision(
+          mock_experiment, mock_variation, enums.DecisionSources.ROLLOUT
+        )
       elif feature.key == 'test_feature_in_experiment_and_rollout':
-        return decision_service.Decision(mock_experiment, mock_variation_2,
-                                         enums.DecisionSources.FEATURE_TEST
-                                         )
+        return decision_service.Decision(
+          mock_experiment, mock_variation_2, enums.DecisionSources.FEATURE_TEST
+        )
       else:
-        return decision_service.Decision(mock_experiment, mock_variation_2,
-                                         enums.DecisionSources.ROLLOUT
-                                         )
+        return decision_service.Decision(
+          mock_experiment, mock_variation_2, enums.DecisionSources.ROLLOUT
+        )
 
     with mock.patch('optimizely.decision_service.DecisionService.get_variation_for_feature',
                         side_effect=side_effect),\


### PR DESCRIPTION
Summary
-------

- Refactoring to pass around `ProjectConfig` vs every class having its own copy of `ProjectConfig`. This way `Bucketer`, `DecisionService` and `EventBuilder` are static and makes way for us to introduce datafile manager.

Test plan
---------

Unit tests and compatibility suite tests continue to pass.