### PR TITLE
Making notification_center optional for optimizely.Optimizely.

### DIFF
--- a/optimizely/helpers/validator.py
+++ b/optimizely/helpers/validator.py
@@ -17,6 +17,7 @@ import math
 import numbers
 from six import string_types
 
+from optimizely.notification_center import NotificationCenter
 from optimizely.user_profile import UserProfile
 from . import constants
 
@@ -108,6 +109,19 @@ def is_logger_valid(logger):
   """
 
   return _has_method(logger, 'log')
+
+
+def is_notification_center_valid(notification_center):
+  """ Given notification_center determine if it is valid or not.
+
+  Args:
+    notification_center: Instance of notification_center.NotificationCenter
+
+  Returns:
+    Boolean denoting instance is valid or not.
+  """
+
+  return isinstance(notification_center, NotificationCenter)
 
 
 def are_attributes_valid(attributes):

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -155,6 +155,19 @@ class OptimizelyTest(base.BaseTest):
     mock_client_logger.exception.assert_called_once_with('Provided "error_handler" is in an invalid format.')
     self.assertFalse(opt_obj.is_valid)
 
+  def test_init__invalid_notification_center__logs_error(self):
+    """ Test that invalid notification_center logs error on init. """
+
+    class InvalidNotificationCenter(object):
+      pass
+
+    mock_client_logger = mock.MagicMock()
+    with mock.patch('optimizely.logger.reset_logger', return_value=mock_client_logger):
+      opt_obj = optimizely.Optimizely(json.dumps(self.config_dict), notification_center=InvalidNotificationCenter())
+
+    mock_client_logger.exception.assert_called_once_with('Provided "notification_center" is in an invalid format.')
+    self.assertFalse(opt_obj.is_valid)
+
   def test_init__unsupported_datafile_version__logs_error(self):
     """ Test that datafile with unsupported version logs error on init. """
 


### PR DESCRIPTION
Summary
-------

This change introduces `notification_center` on `optimizely.Optimizely` thereby allowing instance of it to be shared by `Optimizely` and all classes under `config_manager`. Previously, `config_manager` had its own `NotificationCenter` instance and `optimizely.Optimizely` had its own instance leading to issues.