### PR TITLE
feat: Add blocking timeout in polling manager

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -96,7 +96,7 @@ class StaticConfigManager(BaseConfigManager):
                                                   notification_center=notification_center)
         self._config = None
         self.validate_schema = not skip_json_validation
-        self._configReadyEvent = threading.Event()
+        self._config_ready_event = threading.Event()
         self._set_config(datafile)
 
     def _set_config(self, datafile):
@@ -135,7 +135,7 @@ class StaticConfigManager(BaseConfigManager):
             return
 
         self._config = config
-        self._configReadyEvent.set()
+        self._config_ready_event.set()
         self.notification_center.send_notifications(enums.NotificationTypes.OPTIMIZELY_CONFIG_UPDATE)
         self.logger.debug(
             'Received new datafile and updated config. '
@@ -240,7 +240,7 @@ class PollingConfigManager(StaticConfigManager):
             ProjectConfig. None if not set.
         """
 
-        self._configReadyEvent.wait(self.blocking_timeout)
+        self._config_ready_event.wait(self.blocking_timeout)
         return self._config
 
     def set_update_interval(self, update_interval):
@@ -251,7 +251,7 @@ class PollingConfigManager(StaticConfigManager):
         """
         if update_interval is None:
             update_interval = enums.ConfigManager.DEFAULT_UPDATE_INTERVAL
-            self.logger.debug('Set config update interval to default value {}.'.format(update_interval))
+            self.logger.debug('Setting config update interval to default value {}.'.format(update_interval))
 
         if not isinstance(update_interval, (int, float)):
             raise optimizely_exceptions.InvalidInputException(
@@ -276,15 +276,15 @@ class PollingConfigManager(StaticConfigManager):
         """
         if blocking_timeout is None:
             blocking_timeout = enums.ConfigManager.DEFAULT_BLOCKING_TIMEOUT
-            self.logger.debug('Set config blocking timeout to default value {}.'.format(blocking_timeout))
+            self.logger.debug('Setting config blocking timeout to default value {}.'.format(blocking_timeout))
 
         if not isinstance(blocking_timeout, (numbers.Integral, float)):
             raise optimizely_exceptions.InvalidInputException(
                 'Invalid blocking timeout "{}" provided.'.format(blocking_timeout)
             )
 
-        # If blocking timeout is less than or equal to 0 then set it to default blocking timeout.
-        if blocking_timeout <= 0:
+        # If blocking timeout is less than 0 then set it to default blocking timeout.
+        if blocking_timeout < 0:
             self.logger.debug('blocking timeout value {} too small. Defaulting to {}'.format(
                 blocking_timeout,
                 enums.ConfigManager.DEFAULT_BLOCKING_TIMEOUT)

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -38,7 +38,7 @@ class AudienceEvaluationLogs(object):
 
 class ConfigManager(object):
   DATAFILE_URL_TEMPLATE = 'https://cdn.optimizely.com/datafiles/{sdk_key}.json'
-  # Default time in seconds to block the 'config' method call until 'config' instance has been initialized.
+  # Default time in seconds to block the 'get_config' method call until 'config' instance has been initialized.
   DEFAULT_BLOCKING_TIMEOUT = 15
   # Default config update interval of 5 minutes
   DEFAULT_UPDATE_INTERVAL = 5 * 60

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -38,6 +38,8 @@ class AudienceEvaluationLogs(object):
 
 class ConfigManager(object):
   DATAFILE_URL_TEMPLATE = 'https://cdn.optimizely.com/datafiles/{sdk_key}.json'
+  # Default time in seconds to block the 'config' method call until 'config' instance has been initialized.
+  DEFAULT_BLOCKING_TIMEOUT = 15
   # Default config update interval of 5 minutes
   DEFAULT_UPDATE_INTERVAL = 5 * 60
   # Time in seconds before which request for datafile times out

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -39,7 +39,7 @@ class AudienceEvaluationLogs(object):
 class ConfigManager(object):
   DATAFILE_URL_TEMPLATE = 'https://cdn.optimizely.com/datafiles/{sdk_key}.json'
   # Default time in seconds to block the 'get_config' method call until 'config' instance has been initialized.
-  DEFAULT_BLOCKING_TIMEOUT = 15
+  DEFAULT_BLOCKING_TIMEOUT = 10
   # Default config update interval of 5 minutes
   DEFAULT_UPDATE_INTERVAL = 5 * 60
   # Time in seconds before which request for datafile times out

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -249,6 +249,10 @@ class PollingConfigManagerTest(base.BaseTest):
         project_config_manager.set_blocking_timeout(-4)
         self.assertEqual(enums.ConfigManager.DEFAULT_BLOCKING_TIMEOUT, project_config_manager.blocking_timeout)
 
+        # Assert that blocking_timeout can be set to 0.
+        project_config_manager.set_blocking_timeout(0)
+        self.assertIs(0, project_config_manager.blocking_timeout)
+
         # Assert that if no blocking_timeout is provided, it is set to default value.
         project_config_manager.set_blocking_timeout(None)
         self.assertEqual(enums.ConfigManager.DEFAULT_BLOCKING_TIMEOUT, project_config_manager.blocking_timeout)


### PR DESCRIPTION
Summary
-------
This introduces blocking timeout in Python Config Manager. Config Manager will block the main thread until the config is available or the timeout occurs. 

https://github.com/optimizely/python-testapp/pull/63 should be merged to pass FSC tests for this PR. 
