### PR TITLE
fix: avoid type error for Python 3

### DIFF
--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -335,7 +335,7 @@ class BatchEventProcessorTest(base.BaseTest):
                                                   True,
                                                   self.event_queue,
                                                   self.MAX_BATCH_SIZE,
-                                                  True,
+                                                  "True",
                                                   self.MAX_TIMEOUT_INTERVAL_SEC
                                                   )
 

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -326,7 +326,24 @@ class BatchEventProcessorTest(base.BaseTest):
     self.assertEqual(self._event_processor.flush_interval, timedelta(seconds=30))
     mock_config_logging.info.assert_called_with('Using default value for flush_interval.')
 
-  def test_init__NaN_flush_interval(self):
+  def test_init__bool_flush_interval(self):
+    event_dispatcher = TestEventDispatcher()
+
+    with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
+      self._event_processor = BatchEventProcessor(event_dispatcher,
+                                                  self.optimizely.logger,
+                                                  True,
+                                                  self.event_queue,
+                                                  self.MAX_BATCH_SIZE,
+                                                  True,
+                                                  self.MAX_TIMEOUT_INTERVAL_SEC
+                                                  )
+
+    # default flush interval is 30s.
+    self.assertEqual(self._event_processor.flush_interval, timedelta(seconds=30))
+    mock_config_logging.info.assert_called_with('Using default value for flush_interval.')
+
+  def test_init__string_flush_interval(self):
     event_dispatcher = TestEventDispatcher()
 
     with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:


### PR DESCRIPTION
Summary
-------
- Fixes python 3 type error when flush interval passes as string
- Checks if self.executor is defined before calling method on it to avoid scenario where start_on_init is False and user tries to check if the processor is running or tries to stop it. 

Test plan
---------
Added unit test with flush interval passed as string

Issues
------
-  OASIS-5525
