### PR TITLE
fix(Polling Manager): Fixing how config manager blocks. Miscellaneous other fixes as well.

### DIFF
--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -87,17 +87,17 @@ class BatchEventProcessor(BaseEventProcessor):
     self.event_dispatcher = event_dispatcher or default_event_dispatcher
     self.logger = _logging.adapt_logger(logger or _logging.NoOpLogger())
     self.event_queue = event_queue or queue.Queue(maxsize=self._DEFAULT_QUEUE_CAPACITY)
-    self.batch_size = batch_size if self._validate_intantiation_props(batch_size,
+    self.batch_size = batch_size if self._validate_instantiation_props(batch_size,
                                                                       'batch_size',
                                                                       self._DEFAULT_BATCH_SIZE) \
                         else self._DEFAULT_BATCH_SIZE
     self.flush_interval = timedelta(seconds=flush_interval) \
-                            if self._validate_intantiation_props(flush_interval,
+                            if self._validate_instantiation_props(flush_interval,
                                                                  'flush_interval',
                                                                  self._DEFAULT_FLUSH_INTERVAL) \
                             else timedelta(self._DEFAULT_FLUSH_INTERVAL)
     self.timeout_interval = timedelta(seconds=timeout_interval) \
-                              if self._validate_intantiation_props(timeout_interval,
+                              if self._validate_instantiation_props(timeout_interval,
                                                                    'timeout_interval',
                                                                    self._DEFAULT_TIMEOUT_INTERVAL) \
                               else timedelta(self._DEFAULT_TIMEOUT_INTERVAL)
@@ -119,7 +119,7 @@ class BatchEventProcessor(BaseEventProcessor):
     """ Property to check if consumer thread is alive or not. """
     return self.executor.isAlive() if self.executor else False
 
-  def _validate_intantiation_props(self, prop, prop_name, default_value):
+  def _validate_instantiation_props(self, prop, prop_name, default_value):
     """ Method to determine if instantiation properties like batch_size, flush_interval
     and timeout_interval are valid.
 

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -88,18 +88,18 @@ class BatchEventProcessor(BaseEventProcessor):
     self.logger = _logging.adapt_logger(logger or _logging.NoOpLogger())
     self.event_queue = event_queue or queue.Queue(maxsize=self._DEFAULT_QUEUE_CAPACITY)
     self.batch_size = batch_size if self._validate_instantiation_props(batch_size,
-                                                                      'batch_size',
-                                                                      self._DEFAULT_BATCH_SIZE) \
+                                                                       'batch_size',
+                                                                       self._DEFAULT_BATCH_SIZE) \
                         else self._DEFAULT_BATCH_SIZE
     self.flush_interval = timedelta(seconds=flush_interval) \
                             if self._validate_instantiation_props(flush_interval,
-                                                                 'flush_interval',
-                                                                 self._DEFAULT_FLUSH_INTERVAL) \
+                                                                  'flush_interval',
+                                                                  self._DEFAULT_FLUSH_INTERVAL) \
                             else timedelta(self._DEFAULT_FLUSH_INTERVAL)
     self.timeout_interval = timedelta(seconds=timeout_interval) \
                               if self._validate_instantiation_props(timeout_interval,
-                                                                   'timeout_interval',
-                                                                   self._DEFAULT_TIMEOUT_INTERVAL) \
+                                                                    'timeout_interval',
+                                                                    self._DEFAULT_TIMEOUT_INTERVAL) \
                               else timedelta(self._DEFAULT_TIMEOUT_INTERVAL)
 
     self.notification_center = notification_center or _notification_center.NotificationCenter(self.logger)

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -45,6 +45,7 @@ class BaseEventProcessor(ABC):
 class BatchEventProcessor(BaseEventProcessor):
   """
   BatchEventProcessor is an implementation of the BaseEventProcessor that batches events.
+
   The BatchEventProcessor maintains a single consumer thread that pulls events off of
   the blocking queue and buffers them for either a configured batch size or for a
   maximum duration before the resulting LogEvent is sent to the EventDispatcher.

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -58,7 +58,10 @@ class Optimizely(object):
       notification_center: Optional instance of notification_center.NotificationCenter. Useful when providing own
                            config_manager.BaseConfigManager implementation which can be using the
                            same NotificationCenter instance.
-      event_processor: Processes the given event(s) by creating LogEvent(s) and then dispatching it.
+      event_processor: Optional component which processes the given event(s).
+                       By default optimizely.event.event_processor.ForwardingEventProcessor is used
+                       which simply forwards events to the event dispatcher.
+                       To enable event batching configure and use optimizely.event.event_processor.BatchEventProcessor.
     """
     self.logger_name = '.'.join([__name__, self.__class__.__name__])
     self.is_valid = True
@@ -68,8 +71,8 @@ class Optimizely(object):
     self.config_manager = config_manager
     self.notification_center = notification_center or NotificationCenter(self.logger)
     self.event_processor = event_processor or ForwardingEventProcessor(self.event_dispatcher,
-                                                                       self.logger,
-                                                                       self.notification_center)
+                                                                       logger=self.logger,
+                                                                       notification_center=self.notification_center)
 
     try:
       self._validate_instantiation_options()

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -262,6 +262,7 @@ class PollingConfigManagerTest(base.BaseTest):
         self.assertEqual(5, project_config_manager.blocking_timeout)
 
         # Assert get_config should block until blocking timeout.
+        project_config_manager._config_ready_event.clear()
         start_time = time.time()
         project_config_manager.get_config()
         end_time = time.time()

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -159,6 +159,16 @@ class StaticConfigManagerTest(base.BaseTest):
         # Assert that config is set.
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)
 
+    def test_get_config_blocks(self):
+        """ Test that get_config blocks until blocking timeout is hit. """
+        start_time = time.time()
+        project_config_manager = config_manager.PollingConfigManager(sdk_key='sdk_key',
+                                                                     blocking_timeout=5)
+        # Assert get_config should block until blocking timeout.
+        project_config_manager.get_config()
+        end_time = time.time()
+        self.assertEqual(5, round(end_time - start_time))
+
 
 @mock.patch('requests.get')
 class PollingConfigManagerTest(base.BaseTest):
@@ -217,7 +227,8 @@ class PollingConfigManagerTest(base.BaseTest):
 
     def test_set_update_interval(self, _):
         """ Test set_update_interval with different inputs. """
-        project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
+        with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
+          project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         # Assert that if invalid update_interval is set, then exception is raised.
         with self.assertRaisesRegexp(optimizely_exceptions.InvalidInputException,
@@ -238,7 +249,8 @@ class PollingConfigManagerTest(base.BaseTest):
 
     def test_set_blocking_timeout(self, _):
         """ Test set_blocking_timeout with different inputs. """
-        project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
+        with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
+          project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         # Assert that if invalid blocking_timeout is set, then exception is raised.
         with self.assertRaisesRegexp(optimizely_exceptions.InvalidInputException,
@@ -261,16 +273,10 @@ class PollingConfigManagerTest(base.BaseTest):
         project_config_manager.set_blocking_timeout(5)
         self.assertEqual(5, project_config_manager.blocking_timeout)
 
-        # Assert get_config should block until blocking timeout.
-        project_config_manager._config_ready_event.clear()
-        start_time = time.time()
-        project_config_manager.get_config()
-        end_time = time.time()
-        self.assertEqual(5, round(end_time - start_time))
-
     def test_set_last_modified(self, _):
         """ Test that set_last_modified sets last_modified field based on header. """
-        project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
+        with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
+          project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         last_modified_time = 'Test Last Modified Time'
         test_response_headers = {

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -123,15 +123,16 @@ class BatchEventProcessorTest(base.BaseTest):
     return UserEventFactory.create_conversion_event(config, event_name, self.test_user_id, {}, {})
 
   def _set_event_processor(self, event_dispatcher, logger):
-    self.event_processor = BatchEventProcessor(event_dispatcher,
-                                                 logger,
-                                                 True,
-                                                 self.event_queue,
-                                                 self.MAX_BATCH_SIZE,
-                                                 self.MAX_DURATION_SEC,
-                                                 self.MAX_TIMEOUT_INTERVAL_SEC,
-                                                 self.optimizely.notification_center
-                                                )
+    self.event_processor = BatchEventProcessor(
+      event_dispatcher,
+      logger,
+      True,
+      self.event_queue,
+      self.MAX_BATCH_SIZE,
+      self.MAX_DURATION_SEC,
+      self.MAX_TIMEOUT_INTERVAL_SEC,
+      self.optimizely.notification_center
+    )
 
   def test_drain_on_stop(self):
     event_dispatcher = TestEventDispatcher()
@@ -450,18 +451,20 @@ class ForwardingEventProcessorTest(base.BaseTest):
     self.event_dispatcher = TestForwardingEventDispatcher(is_updated=False)
 
     with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
-      self.event_processor = ForwardingEventProcessor(self.event_dispatcher,
-                                                        mock_config_logging,
-                                                        self.notification_center
-                                                       )
+      self.event_processor = ForwardingEventProcessor(
+        self.event_dispatcher,
+        mock_config_logging,
+        self.notification_center
+      )
 
   def _build_conversion_event(self, event_name):
-    return UserEventFactory.create_conversion_event(self.project_config,
-                                                    event_name,
-                                                    self.test_user_id,
-                                                    {},
-                                                    {}
-                                                    )
+    return UserEventFactory.create_conversion_event(
+      self.project_config,
+      event_name,
+      self.test_user_id,
+      {},
+      {}
+    )
 
   def test_event_processor__dispatch_raises_exception(self):
     """ Test that process logs dispatch failure gracefully. """


### PR DESCRIPTION
Summary
-------
- The polling config manager is supposed to wait until config is ready. Previously, the config will be attempted to be initialized with empty datafile. This was resolved by overriding up `_set_config` in `PollingConfigManager`.
- Config ready event had no business in `StaticConfigManager` so it has been moved from there.
- Some formatting and other miscellaneous fixes.