### PR TITLE
fix(batch_event_processor): small fix to start the processor if not started. By default the batch…

### DIFF
--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -256,6 +256,12 @@ class BatchEventProcessor(BaseEventProcessor):
             'Received event of type {} for user {}.'.format(type(user_event).__name__, user_event.user_id)
         )
 
+        if not self.is_running:
+            try:
+                self.start()
+            except Exception as e:
+                self.logger.error('Error starting processing thread: ' + str(log_event) + ' ' + str(e))
+
         try:
             self.event_queue.put_nowait(user_event)
         except queue.Full:

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -260,7 +260,7 @@ class BatchEventProcessor(BaseEventProcessor):
             try:
                 self.start()
             except Exception as e:
-                self.logger.error('Error starting processing thread: ' + str(log_event) + ' ' + str(e))
+                self.logger.error('Error starting processing thread: ' + str(e))
 
         try:
             self.event_queue.put_nowait(user_event)


### PR DESCRIPTION
… processor thread is not started at init

Summary
-------

-  start the processor if not started. By default the batch processor thread is not started at init

The “why”, or other context.

Test plan
---------
- all unit tests should pass