### PR TITLE
Added docstrings from config_manager.py and optimizely_config.py to docs

### DIFF
--- a/docs/source/bucketing_algorithm.rst
+++ b/docs/source/bucketing_algorithm.rst
@@ -8,7 +8,7 @@ Bucketing Algorithm Methods
 
 Decision Service
 ================
-.. automodule:: optimizely.decision_service
+.. autoclass:: optimizely.decision_service.DecisionService
    :members:
    :special-members:
    :private-members:

--- a/docs/source/config_manager.rst
+++ b/docs/source/config_manager.rst
@@ -1,0 +1,26 @@
+Config Manager
+==============
+
+``Base Config Manager``
+-----------------------
+
+.. autoclass:: optimizely.config_manager.BaseConfigManager
+   :members:
+   :special-members:
+   :private-members:
+
+``Static Config Manager``
+-------------------------
+
+.. autoclass:: optimizely.config_manager.StaticConfigManager
+   :members:
+   :special-members:
+   :private-members:
+
+``Polling Config Manager``
+--------------------------
+
+.. autoclass:: optimizely.config_manager.PollingConfigManager
+   :members:
+   :special-members:
+   :private-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,13 @@ Python SDK
 
 
 .. toctree::
+   :caption: Configuration Data
+
+   config_manager
+   optimizely_config
+
+
+.. toctree::
    :caption: Help
 
    contributing

--- a/docs/source/optimizely_config.rst
+++ b/docs/source/optimizely_config.rst
@@ -1,0 +1,7 @@
+OptimizelyConfig
+================
+
+.. automodule:: optimizely.optimizely_config
+   :members:
+   :special-members:
+   :private-members:


### PR DESCRIPTION
Hi @aliabbasrizvi! Please take a look at the changes to the docs below.

Summary
---------

-  Updated buckering_algorithm to exclude namedtuple docstrings
-  Added docstrings from config_manager.py and optimizely_config.py to docs

Test plan
---------
None at the moment

Issues
------

OASIS-6103
