### PR TITLE
chore(build): Making sure docs is excluded from build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include LICENSE
 include CHANGELOG.md
 include README.md
 include requirements/*
+recursive-exclude docs *
 recursive-exclude tests *

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
 
-from optimizely.version import __version__
+from optimizely.version import __version__      # noqa: E402
 
 # -- Project information -----------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['docs', 'tests']),
     extras_require={'test': TEST_REQUIREMENTS},
     install_requires=REQUIREMENTS,
     tests_require=TEST_REQUIREMENTS,


### PR DESCRIPTION
This PR ensures that we do not include docs in the packaged SDK.