### PR TITLE
fix(logs): Fixing log messages for Targeted Rollouts

### DIFF
--- a/optimizely/bucketer.py
+++ b/optimizely/bucketer.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017, 2019 Optimizely
+# Copyright 2016-2017, 2019-2020 Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -21,6 +21,7 @@ from .helpers import experiment as experiment_helper
 from .helpers import validator
 from .user_profile import UserProfile
 
+
 Decision = namedtuple('Decision', 'experiment variation source')
 
 
@@ -263,8 +264,10 @@ class DecisionService(object):
 
         # Bucket user and store the new decision
         audience_conditions = experiment.get_audience_conditions_or_ids()
-        if not audience_helper.does_user_meet_audience_conditions(project_config, audience_conditions, 'experiment',
-                                                                  experiment.key, attributes, self.logger):
+        if not audience_helper.does_user_meet_audience_conditions(project_config, audience_conditions,
+                                                                  enums.ExperimentAudienceEvaluationLogs,
+                                                                  experiment.key,
+                                                                  attributes, self.logger):
             self.logger.info(
                 'User "{}" does not meet conditions to be in experiment "{}".'.format(user_id, experiment.key))
             return None
@@ -313,7 +316,7 @@ class DecisionService(object):
                 audience_conditions = rollout_rule.get_audience_conditions_or_ids()
                 if not audience_helper.does_user_meet_audience_conditions(project_config,
                                                                           audience_conditions,
-                                                                          'rollout-rule',
+                                                                          enums.RolloutRuleAudienceEvaluationLogs,
                                                                           logging_key,
                                                                           attributes,
                                                                           self.logger):
@@ -345,7 +348,7 @@ class DecisionService(object):
             if audience_helper.does_user_meet_audience_conditions(
                 project_config,
                 audience_conditions,
-                'rollout-rule',
+                enums.RolloutRuleAudienceEvaluationLogs,
                 'Everyone Else',
                 attributes,
                 self.logger

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -274,6 +274,9 @@ class DecisionService(object):
         variation = self.bucketer.bucket(project_config, experiment, user_id, bucketing_id)
 
         if variation:
+            self.logger.info(
+                'User "%s" is in variation "%s" of experiment %s.' % (user_id, variation.key, experiment.key)
+            )
             # Store this new decision and return the variation for the user
             if not ignore_user_profile and self.user_profile_service:
                 try:
@@ -283,6 +286,7 @@ class DecisionService(object):
                     self.logger.exception('Unable to save user profile for user "{}".'.format(user_id))
             return variation
 
+        self.logger.info('User "%s" is in no variation.' % user_id)
         return None
 
     def get_variation_for_rollout(self, project_config, rollout, user_id, attributes=None):

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -262,7 +262,7 @@ class DecisionService(object):
                 self.logger.warning('User profile has invalid format.')
 
         # Bucket user and store the new decision
-        audience_conditions = experiment.getAudienceConditionsOrIds()
+        audience_conditions = experiment.get_audience_conditions_or_ids()
         if not audience_helper.does_user_meet_audience_conditions(
           project_config, audience_conditions, 'experiment', experiment.key, attributes, self.logger):
             self.logger.info(
@@ -306,7 +306,7 @@ class DecisionService(object):
                 rollout_rule = project_config.get_experiment_from_key(rollout.experiments[idx].get('key'))
 
                 # Check if user meets audience conditions for targeting rule
-                audience_conditions = rollout_rule.getAudienceConditionsOrIds()
+                audience_conditions = rollout_rule.get_audience_conditions_or_ids()
                 if not audience_helper.does_user_meet_audience_conditions(
                   project_config, audience_conditions, 'rollout-rule', logging_key, attributes, self.logger):
                     self.logger.debug(
@@ -333,7 +333,7 @@ class DecisionService(object):
 
             # Evaluate last rule i.e. "Everyone Else" rule
             everyone_else_rule = project_config.get_experiment_from_key(rollout.experiments[-1].get('key'))
-            audience_conditions = everyone_else_rule.getAudienceConditionsOrIds()
+            audience_conditions = everyone_else_rule.get_audience_conditions_or_ids()
             if audience_helper.does_user_meet_audience_conditions(
                 project_config,
                 audience_conditions,

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -263,8 +263,8 @@ class DecisionService(object):
 
         # Bucket user and store the new decision
         audience_conditions = experiment.get_audience_conditions_or_ids()
-        if not audience_helper.does_user_meet_audience_conditions(
-          project_config, audience_conditions, 'experiment', experiment.key, attributes, self.logger):
+        if not audience_helper.does_user_meet_audience_conditions(project_config, audience_conditions, 'experiment',
+                                                                  experiment.key, attributes, self.logger):
             self.logger.info(
                 'User "{}" does not meet conditions to be in experiment "{}".'.format(user_id, experiment.key))
             return None
@@ -307,8 +307,12 @@ class DecisionService(object):
 
                 # Check if user meets audience conditions for targeting rule
                 audience_conditions = rollout_rule.get_audience_conditions_or_ids()
-                if not audience_helper.does_user_meet_audience_conditions(
-                  project_config, audience_conditions, 'rollout-rule', logging_key, attributes, self.logger):
+                if not audience_helper.does_user_meet_audience_conditions(project_config,
+                                                                          audience_conditions,
+                                                                          'rollout-rule',
+                                                                          logging_key,
+                                                                          attributes,
+                                                                          self.logger):
                     self.logger.debug(
                         'User "{}" does not meet conditions for targeting rule {}.'.format(user_id, logging_key))
                     continue
@@ -340,7 +344,8 @@ class DecisionService(object):
                 'rollout-rule',
                 'Everyone Else',
                 attributes,
-                self.logger):
+                self.logger
+            ):
                 # Determine bucketing ID to be used
                 bucketing_id = self._get_bucketing_id(user_id, attributes)
                 variation = self.bucketer.bucket(project_config, everyone_else_rule, user_id, bucketing_id)

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -327,7 +327,7 @@ class DecisionService(object):
                     # Evaluate no further rules
                     self.logger.debug(
                         'User "{}" is not in the traffic group for targeting rule {}. '
-                        'Checking "Everyone Else" rule now.'.format(logging_key, user_id)
+                        'Checking "Everyone Else" rule now.'.format(user_id, logging_key)
                     )
                     break
 

--- a/optimizely/helpers/audience.py
+++ b/optimizely/helpers/audience.py
@@ -19,8 +19,12 @@ from .enums import ExperimentAudienceEvaluationLogs as experiment_audience_logs
 from .enums import RolloutRuleAudienceEvaluationLogs as rules_audience_logs
 
 
-def does_user_meet_audience_conditions(
-    config, audience_conditions, experiment_or_rollout_rule, logging_key, attributes, logger):
+def does_user_meet_audience_conditions(config,
+                                       audience_conditions,
+                                       experiment_or_rollout_rule,
+                                       logging_key,
+                                       attributes,
+                                       logger):
     """ Determine for given experiment if user satisfies the audiences for the experiment.
 
     Args:

--- a/optimizely/helpers/audience.py
+++ b/optimizely/helpers/audience.py
@@ -15,13 +15,11 @@ import json
 
 from . import condition as condition_helper
 from . import condition_tree_evaluator
-from .enums import ExperimentAudienceEvaluationLogs as experiment_audience_logs
-from .enums import RolloutRuleAudienceEvaluationLogs as rules_audience_logs
 
 
 def does_user_meet_audience_conditions(config,
                                        audience_conditions,
-                                       experiment_or_rollout_rule,
+                                       audience_logs,
                                        logging_key,
                                        attributes,
                                        logger):
@@ -30,7 +28,7 @@ def does_user_meet_audience_conditions(config,
     Args:
         config: project_config.ProjectConfig object representing the project.
         audience_conditions: Audience conditions corresponding to the experiment or rollout rule.
-        experiment_or_rollout_rule: String representing whether entity being evaluated is experiment or rollout rule.
+        audience_logs: Log class capturing the messages to be logged .
         logging_key: String representing experiment key or rollout rule. To be used in log messages only.
         attributes: Dict representing user attributes which will be used in determining
                     if the audience conditions are met. If not provided, default to an empty dict.
@@ -39,10 +37,6 @@ def does_user_meet_audience_conditions(config,
     Returns:
         Boolean representing if user satisfies audience conditions for any of the audiences or not.
     """
-    audience_logs = experiment_audience_logs
-    if experiment_or_rollout_rule == 'rollout-rule':
-        audience_logs = rules_audience_logs
-
     logger.debug(audience_logs.EVALUATING_AUDIENCES_COMBINED.format(logging_key, json.dumps(audience_conditions)))
 
     # Return True in case there are no audiences

--- a/optimizely/helpers/audience.py
+++ b/optimizely/helpers/audience.py
@@ -27,7 +27,7 @@ def does_user_meet_audience_conditions(
         config: project_config.ProjectConfig object representing the project.
         audience_conditions: Audience conditions corresponding to the experiment or rollout rule.
         experiment_or_rollout_rule: String representing whether entity being evaluated is experiment or rollout rule.
-        logging_key: String representing experiment key or rollout rule's index. To be used in log messages only.
+        logging_key: String representing experiment key or rollout rule. To be used in log messages only.
         attributes: Dict representing user attributes which will be used in determining
                     if the audience conditions are met. If not provided, default to an empty dict.
         logger: Provides a logger to send log messages to.

--- a/optimizely/helpers/condition.py
+++ b/optimizely/helpers/condition.py
@@ -1,4 +1,4 @@
-# Copyright 2016, 2018-2019, Optimizely
+# Copyright 2016, 2018-2020, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/helpers/condition.py
+++ b/optimizely/helpers/condition.py
@@ -17,7 +17,7 @@ import numbers
 from six import string_types
 
 from . import validator
-from .enums import AudienceEvaluationLogs as audience_logs
+from .enums import CommonAudienceEvaluationLogs as audience_logs
 
 
 class ConditionOperatorTypes(object):

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019, Optimizely
+# Copyright 2016-2020, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,11 +14,9 @@
 import logging
 
 
-class AudienceEvaluationLogs(object):
+class CommonAudienceEvaluationLogs(object):
     AUDIENCE_EVALUATION_RESULT = 'Audience "{}" evaluated to {}.'
-    AUDIENCE_EVALUATION_RESULT_COMBINED = 'Audiences for experiment "{}" collectively evaluated to {}.'
     EVALUATING_AUDIENCE = 'Starting to evaluate audience "{}" with conditions: {}.'
-    EVALUATING_AUDIENCES_COMBINED = 'Evaluating audiences for experiment "{}": {}.'
     INFINITE_ATTRIBUTE_VALUE = (
         'Audience condition "{}" evaluated to UNKNOWN because the number value '
         'for user attribute "{}" is not in the range [-2^53, +2^53].'
@@ -46,6 +44,16 @@ class AudienceEvaluationLogs(object):
         'Audience condition "{}" uses an unknown match type. You may need to upgrade to a '
         'newer release of the Optimizely SDK.'
     )
+
+
+class ExperimentAudienceEvaluationLogs(CommonAudienceEvaluationLogs):
+    AUDIENCE_EVALUATION_RESULT_COMBINED = 'Audiences for experiment "{}" collectively evaluated to {}.'
+    EVALUATING_AUDIENCES_COMBINED = 'Evaluating audiences for experiment "{}": {}.'
+
+
+class RolloutRuleAudienceEvaluationLogs(CommonAudienceEvaluationLogs):
+    AUDIENCE_EVALUATION_RESULT_COMBINED = 'Audiences for rule {} collectively evaluated to {}.'
+    EVALUATING_AUDIENCES_COMBINED = 'Evaluating audiences for rule {}: {}.'
 
 
 class ConfigManager(object):

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -550,4 +550,3 @@ class RolloutRuleAudienceLoggingTest(base.BaseTest):
                 ),
             ]
         )
-

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -34,7 +34,14 @@ class AudienceTest(base.BaseTest):
         experiment.audienceIds = []
         experiment.audienceConditions = []
         self.assertStrictTrue(
-            audience.does_user_meet_audience_conditions(self.project_config, experiment, user_attributes, self.mock_client_logger,)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                user_attributes,
+                self.mock_client_logger
+            )
         )
 
         # Audience Ids exist but Audience Conditions is Empty
@@ -42,7 +49,15 @@ class AudienceTest(base.BaseTest):
         experiment.audienceIds = ['11154']
         experiment.audienceConditions = []
         self.assertStrictTrue(
-            audience.does_user_meet_audience_conditions(self.project_config, experiment, user_attributes, self.mock_client_logger,)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                user_attributes,
+                self.mock_client_logger
+            )
+
         )
 
         # Audience Ids is Empty and  Audience Conditions is None
@@ -50,7 +65,15 @@ class AudienceTest(base.BaseTest):
         experiment.audienceIds = []
         experiment.audienceConditions = None
         self.assertStrictTrue(
-            audience.does_user_meet_audience_conditions(self.project_config, experiment, user_attributes, self.mock_client_logger,)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                user_attributes,
+                self.mock_client_logger
+            )
+
         )
 
     def test_does_user_meet_audience_conditions__with_audience(self):
@@ -72,7 +95,12 @@ class AudienceTest(base.BaseTest):
                 ['or', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
             ]
             audience.does_user_meet_audience_conditions(
-                self.project_config, experiment, user_attributes, self.mock_client_logger,
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                user_attributes,
+                self.mock_client_logger
             )
 
         self.assertEqual(experiment.audienceConditions, cond_tree_eval.call_args[0][0])
@@ -82,7 +110,12 @@ class AudienceTest(base.BaseTest):
 
             experiment.audienceConditions = None
             audience.does_user_meet_audience_conditions(
-                self.project_config, experiment, user_attributes, self.mock_client_logger,
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                user_attributes,
+                self.mock_client_logger
             )
 
         self.assertEqual(experiment.audienceIds, cond_tree_eval.call_args[0][0])
@@ -95,17 +128,31 @@ class AudienceTest(base.BaseTest):
 
         # attributes set to empty dict
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.does_user_meet_audience_conditions(self.project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                {},
+                self.mock_client_logger
+            )
 
         self.assertEqual({}, custom_attr_eval.call_args[0][1])
 
         # attributes set to None
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.does_user_meet_audience_conditions(self.project_config, experiment, None, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                None,
+                self.mock_client_logger
+            )
 
         self.assertEqual({}, custom_attr_eval.call_args[0][1])
 
-    def test_does_user_meet_audience_conditions__returns_True__when_condition_tree_evaluator_returns_True(self,):
+    def test_does_user_meet_audience_conditions__returns_true__when_condition_tree_evaluator_returns_true(self):
         """ Test that does_user_meet_audience_conditions returns True when call to condition_tree_evaluator returns True. """
 
         user_attributes = {'test_attribute': 'test_value_1'}
@@ -114,11 +161,16 @@ class AudienceTest(base.BaseTest):
 
             self.assertStrictTrue(
                 audience.does_user_meet_audience_conditions(
-                    self.project_config, experiment, user_attributes, self.mock_client_logger,
+                    self.project_config,
+                    experiment.get_audience_conditions_or_ids(),
+                    'experiment',
+                    'test_experiment',
+                    user_attributes,
+                    self.mock_client_logger
                 )
             )
 
-    def test_does_user_meet_audience_conditions__returns_False__when_condition_tree_evaluator_returns_None_or_False(self,):
+    def test_does_user_meet_audience_conditions__returns_false__when_condition_tree_evaluator_returns_none_or_false(self):
         """ Test that does_user_meet_audience_conditions returns False
         when call to condition_tree_evaluator returns None or False. """
 
@@ -128,7 +180,12 @@ class AudienceTest(base.BaseTest):
 
             self.assertStrictFalse(
                 audience.does_user_meet_audience_conditions(
-                    self.project_config, experiment, user_attributes, self.mock_client_logger,
+                    self.project_config,
+                    experiment.get_audience_conditions_or_ids(),
+                    'experiment',
+                    'test_experiment',
+                    user_attributes,
+                    self.mock_client_logger
                 )
             )
 
@@ -136,7 +193,12 @@ class AudienceTest(base.BaseTest):
 
             self.assertStrictFalse(
                 audience.does_user_meet_audience_conditions(
-                    self.project_config, experiment, user_attributes, self.mock_client_logger,
+                    self.project_config,
+                    experiment.get_audience_conditions_or_ids(),
+                    'experiment',
+                    'test_experiment',
+                    user_attributes,
+                    self.mock_client_logger
                 )
             )
 
@@ -149,7 +211,14 @@ class AudienceTest(base.BaseTest):
         experiment.audienceConditions = None
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.does_user_meet_audience_conditions(self.project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                {},
+                self.mock_client_logger
+            )
 
         audience_11154 = self.project_config.get_audience('11154')
         audience_11159 = self.project_config.get_audience('11159')
@@ -178,7 +247,14 @@ class AudienceTest(base.BaseTest):
         ]
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.does_user_meet_audience_conditions(project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'audience_combinations_experiment',
+                {},
+                self.mock_client_logger
+            )
 
         audience_3468206642 = project_config.get_audience('3468206642')
         audience_3988293898 = project_config.get_audience('3988293898')
@@ -208,7 +284,14 @@ class AudienceTest(base.BaseTest):
         experiment.audienceConditions = '3468206645'
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.does_user_meet_audience_conditions(project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'audience_combinations_experiment',
+                {},
+                self.mock_client_logger
+            )
 
         audience_3468206645 = project_config.get_audience('3468206645')
 
@@ -232,7 +315,14 @@ class AudienceLoggingTest(base.BaseTest):
         experiment.audienceIds = []
         experiment.audienceConditions = []
 
-        audience.does_user_meet_audience_conditions(self.project_config, experiment, {}, self.mock_client_logger)
+        audience.does_user_meet_audience_conditions(
+            self.project_config,
+            experiment.get_audience_conditions_or_ids(),
+            'experiment',
+            'test_experiment',
+            {},
+            self.mock_client_logger
+        )
 
         self.mock_client_logger.assert_has_calls(
             [
@@ -253,7 +343,12 @@ class AudienceLoggingTest(base.BaseTest):
             'optimizely.helpers.condition.CustomAttributeConditionEvaluator.evaluate', side_effect=[None, None],
         ):
             audience.does_user_meet_audience_conditions(
-                self.project_config, experiment, user_attributes, self.mock_client_logger,
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'test_experiment',
+                user_attributes,
+                self.mock_client_logger
             )
 
         self.assertEqual(5, self.mock_client_logger.debug.call_count)
@@ -290,7 +385,14 @@ class AudienceLoggingTest(base.BaseTest):
         with mock.patch(
             'optimizely.helpers.condition.CustomAttributeConditionEvaluator.evaluate', side_effect=[False, None, True],
         ):
-            audience.does_user_meet_audience_conditions(project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(
+                self.project_config,
+                experiment.get_audience_conditions_or_ids(),
+                'experiment',
+                'audience_combinations_experiment',
+                {},
+                self.mock_client_logger
+            )
 
         self.assertEqual(7, self.mock_client_logger.debug.call_count)
         self.assertEqual(1, self.mock_client_logger.info.call_count)

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -24,8 +24,8 @@ class AudienceTest(base.BaseTest):
         base.BaseTest.setUp(self)
         self.mock_client_logger = mock.MagicMock()
 
-    def test_is_user_in_experiment__no_audience(self):
-        """ Test that is_user_in_experiment returns True when experiment is using no audience. """
+    def test_does_user_meet_audience_conditions__no_audience(self):
+        """ Test that does_user_meet_audience_conditions returns True when experiment is using no audience. """
 
         user_attributes = {}
 
@@ -34,7 +34,7 @@ class AudienceTest(base.BaseTest):
         experiment.audienceIds = []
         experiment.audienceConditions = []
         self.assertStrictTrue(
-            audience.is_user_in_experiment(self.project_config, experiment, user_attributes, self.mock_client_logger,)
+            audience.does_user_meet_audience_conditions(self.project_config, experiment, user_attributes, self.mock_client_logger,)
         )
 
         # Audience Ids exist but Audience Conditions is Empty
@@ -42,7 +42,7 @@ class AudienceTest(base.BaseTest):
         experiment.audienceIds = ['11154']
         experiment.audienceConditions = []
         self.assertStrictTrue(
-            audience.is_user_in_experiment(self.project_config, experiment, user_attributes, self.mock_client_logger,)
+            audience.does_user_meet_audience_conditions(self.project_config, experiment, user_attributes, self.mock_client_logger,)
         )
 
         # Audience Ids is Empty and  Audience Conditions is None
@@ -50,13 +50,13 @@ class AudienceTest(base.BaseTest):
         experiment.audienceIds = []
         experiment.audienceConditions = None
         self.assertStrictTrue(
-            audience.is_user_in_experiment(self.project_config, experiment, user_attributes, self.mock_client_logger,)
+            audience.does_user_meet_audience_conditions(self.project_config, experiment, user_attributes, self.mock_client_logger,)
         )
 
-    def test_is_user_in_experiment__with_audience(self):
-        """ Test that is_user_in_experiment evaluates non-empty audience.
-        Test that is_user_in_experiment uses not None audienceConditions and ignores audienceIds.
-        Test that is_user_in_experiment uses audienceIds when audienceConditions is None.
+    def test_does_user_meet_audience_conditions__with_audience(self):
+        """ Test that does_user_meet_audience_conditions evaluates non-empty audience.
+        Test that does_user_meet_audience_conditions uses not None audienceConditions and ignores audienceIds.
+        Test that does_user_meet_audience_conditions uses audienceIds when audienceConditions is None.
     """
 
         user_attributes = {'test_attribute': 'test_value_1'}
@@ -71,7 +71,7 @@ class AudienceTest(base.BaseTest):
                 ['or', '3468206642', '3988293898'],
                 ['or', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
             ]
-            audience.is_user_in_experiment(
+            audience.does_user_meet_audience_conditions(
                 self.project_config, experiment, user_attributes, self.mock_client_logger,
             )
 
@@ -81,45 +81,45 @@ class AudienceTest(base.BaseTest):
         with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate') as cond_tree_eval:
 
             experiment.audienceConditions = None
-            audience.is_user_in_experiment(
+            audience.does_user_meet_audience_conditions(
                 self.project_config, experiment, user_attributes, self.mock_client_logger,
             )
 
         self.assertEqual(experiment.audienceIds, cond_tree_eval.call_args[0][0])
 
-    def test_is_user_in_experiment__no_attributes(self):
-        """ Test that is_user_in_experiment evaluates audience when attributes are empty.
-        Test that is_user_in_experiment defaults attributes to empty dict when attributes is None.
+    def test_does_user_meet_audience_conditions__no_attributes(self):
+        """ Test that does_user_meet_audience_conditions evaluates audience when attributes are empty.
+        Test that does_user_meet_audience_conditions defaults attributes to empty dict when attributes is None.
     """
         experiment = self.project_config.get_experiment_from_key('test_experiment')
 
         # attributes set to empty dict
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.is_user_in_experiment(self.project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(self.project_config, experiment, {}, self.mock_client_logger)
 
         self.assertEqual({}, custom_attr_eval.call_args[0][1])
 
         # attributes set to None
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.is_user_in_experiment(self.project_config, experiment, None, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(self.project_config, experiment, None, self.mock_client_logger)
 
         self.assertEqual({}, custom_attr_eval.call_args[0][1])
 
-    def test_is_user_in_experiment__returns_True__when_condition_tree_evaluator_returns_True(self,):
-        """ Test that is_user_in_experiment returns True when call to condition_tree_evaluator returns True. """
+    def test_does_user_meet_audience_conditions__returns_True__when_condition_tree_evaluator_returns_True(self,):
+        """ Test that does_user_meet_audience_conditions returns True when call to condition_tree_evaluator returns True. """
 
         user_attributes = {'test_attribute': 'test_value_1'}
         experiment = self.project_config.get_experiment_from_key('test_experiment')
         with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=True):
 
             self.assertStrictTrue(
-                audience.is_user_in_experiment(
+                audience.does_user_meet_audience_conditions(
                     self.project_config, experiment, user_attributes, self.mock_client_logger,
                 )
             )
 
-    def test_is_user_in_experiment__returns_False__when_condition_tree_evaluator_returns_None_or_False(self,):
-        """ Test that is_user_in_experiment returns False
+    def test_does_user_meet_audience_conditions__returns_False__when_condition_tree_evaluator_returns_None_or_False(self,):
+        """ Test that does_user_meet_audience_conditions returns False
         when call to condition_tree_evaluator returns None or False. """
 
         user_attributes = {'test_attribute': 'test_value_1'}
@@ -127,7 +127,7 @@ class AudienceTest(base.BaseTest):
         with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=None):
 
             self.assertStrictFalse(
-                audience.is_user_in_experiment(
+                audience.does_user_meet_audience_conditions(
                     self.project_config, experiment, user_attributes, self.mock_client_logger,
                 )
             )
@@ -135,7 +135,7 @@ class AudienceTest(base.BaseTest):
         with mock.patch('optimizely.helpers.condition_tree_evaluator.evaluate', return_value=False):
 
             self.assertStrictFalse(
-                audience.is_user_in_experiment(
+                audience.does_user_meet_audience_conditions(
                     self.project_config, experiment, user_attributes, self.mock_client_logger,
                 )
             )
@@ -149,7 +149,7 @@ class AudienceTest(base.BaseTest):
         experiment.audienceConditions = None
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.is_user_in_experiment(self.project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(self.project_config, experiment, {}, self.mock_client_logger)
 
         audience_11154 = self.project_config.get_audience('11154')
         audience_11159 = self.project_config.get_audience('11159')
@@ -163,8 +163,8 @@ class AudienceTest(base.BaseTest):
             any_order=True,
         )
 
-    def test_is_user_in_experiment__evaluates_audience_conditions(self):
-        """ Test that is_user_in_experiment correctly evaluates audienceConditions and
+    def test_does_user_meet_audience_conditions__evaluates_audience_conditions(self):
+        """ Test that does_user_meet_audience_conditions correctly evaluates audienceConditions and
         calls custom attribute evaluator for leaf nodes. """
 
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_typed_audiences))
@@ -178,7 +178,7 @@ class AudienceTest(base.BaseTest):
         ]
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.is_user_in_experiment(project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(project_config, experiment, {}, self.mock_client_logger)
 
         audience_3468206642 = project_config.get_audience('3468206642')
         audience_3988293898 = project_config.get_audience('3988293898')
@@ -199,8 +199,8 @@ class AudienceTest(base.BaseTest):
             any_order=True,
         )
 
-    def test_is_user_in_experiment__evaluates_audience_conditions_leaf_node(self):
-        """ Test that is_user_in_experiment correctly evaluates leaf node in audienceConditions. """
+    def test_does_user_meet_audience_conditions__evaluates_audience_conditions_leaf_node(self):
+        """ Test that does_user_meet_audience_conditions correctly evaluates leaf node in audienceConditions. """
 
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_typed_audiences))
         project_config = opt_obj.config_manager.get_config()
@@ -208,7 +208,7 @@ class AudienceTest(base.BaseTest):
         experiment.audienceConditions = '3468206645'
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
-            audience.is_user_in_experiment(project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(project_config, experiment, {}, self.mock_client_logger)
 
         audience_3468206645 = project_config.get_audience('3468206645')
 
@@ -227,12 +227,12 @@ class AudienceLoggingTest(base.BaseTest):
         base.BaseTest.setUp(self)
         self.mock_client_logger = mock.MagicMock()
 
-    def test_is_user_in_experiment__with_no_audience(self):
+    def test_does_user_meet_audience_conditions__with_no_audience(self):
         experiment = self.project_config.get_experiment_from_key('test_experiment')
         experiment.audienceIds = []
         experiment.audienceConditions = []
 
-        audience.is_user_in_experiment(self.project_config, experiment, {}, self.mock_client_logger)
+        audience.does_user_meet_audience_conditions(self.project_config, experiment, {}, self.mock_client_logger)
 
         self.mock_client_logger.assert_has_calls(
             [
@@ -252,7 +252,7 @@ class AudienceLoggingTest(base.BaseTest):
         with mock.patch(
             'optimizely.helpers.condition.CustomAttributeConditionEvaluator.evaluate', side_effect=[None, None],
         ):
-            audience.is_user_in_experiment(
+            audience.does_user_meet_audience_conditions(
                 self.project_config, experiment, user_attributes, self.mock_client_logger,
             )
 
@@ -274,7 +274,7 @@ class AudienceLoggingTest(base.BaseTest):
             ]
         )
 
-    def test_is_user_in_experiment__evaluates_audience_conditions(self):
+    def test_does_user_meet_audience_conditions__evaluates_audience_conditions(self):
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_typed_audiences))
         project_config = opt_obj.config_manager.get_config()
         experiment = project_config.get_experiment_from_key('audience_combinations_experiment')
@@ -290,7 +290,7 @@ class AudienceLoggingTest(base.BaseTest):
         with mock.patch(
             'optimizely.helpers.condition.CustomAttributeConditionEvaluator.evaluate', side_effect=[False, None, True],
         ):
-            audience.is_user_in_experiment(project_config, experiment, {}, self.mock_client_logger)
+            audience.does_user_meet_audience_conditions(project_config, experiment, {}, self.mock_client_logger)
 
         self.assertEqual(7, self.mock_client_logger.debug.call_count)
         self.assertEqual(1, self.mock_client_logger.info.call_count)

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -16,6 +16,7 @@ import mock
 
 from optimizely import optimizely
 from optimizely.helpers import audience
+from optimizely.helpers import enums
 from tests import base
 
 
@@ -37,7 +38,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 user_attributes,
                 self.mock_client_logger
@@ -52,7 +53,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 user_attributes,
                 self.mock_client_logger
@@ -68,7 +69,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 user_attributes,
                 self.mock_client_logger
@@ -97,7 +98,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 user_attributes,
                 self.mock_client_logger
@@ -112,7 +113,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 user_attributes,
                 self.mock_client_logger
@@ -131,7 +132,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 {},
                 self.mock_client_logger
@@ -144,7 +145,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 None,
                 self.mock_client_logger
@@ -164,7 +165,7 @@ class AudienceTest(base.BaseTest):
                 audience.does_user_meet_audience_conditions(
                     self.project_config,
                     experiment.get_audience_conditions_or_ids(),
-                    'experiment',
+                    enums.ExperimentAudienceEvaluationLogs,
                     'test_experiment',
                     user_attributes,
                     self.mock_client_logger
@@ -183,7 +184,7 @@ class AudienceTest(base.BaseTest):
                 audience.does_user_meet_audience_conditions(
                     self.project_config,
                     experiment.get_audience_conditions_or_ids(),
-                    'experiment',
+                    enums.ExperimentAudienceEvaluationLogs,
                     'test_experiment',
                     user_attributes,
                     self.mock_client_logger
@@ -196,7 +197,7 @@ class AudienceTest(base.BaseTest):
                 audience.does_user_meet_audience_conditions(
                     self.project_config,
                     experiment.get_audience_conditions_or_ids(),
-                    'experiment',
+                    enums.ExperimentAudienceEvaluationLogs,
                     'test_experiment',
                     user_attributes,
                     self.mock_client_logger
@@ -215,7 +216,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 {},
                 self.mock_client_logger
@@ -251,7 +252,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'audience_combinations_experiment',
                 {},
                 self.mock_client_logger
@@ -288,7 +289,7 @@ class AudienceTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'audience_combinations_experiment',
                 {},
                 self.mock_client_logger
@@ -319,7 +320,7 @@ class AudienceLoggingTest(base.BaseTest):
         audience.does_user_meet_audience_conditions(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            'experiment',
+            enums.ExperimentAudienceEvaluationLogs,
             'test_experiment',
             {},
             self.mock_client_logger
@@ -346,7 +347,7 @@ class AudienceLoggingTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 self.project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'test_experiment',
                 user_attributes,
                 self.mock_client_logger
@@ -389,7 +390,7 @@ class AudienceLoggingTest(base.BaseTest):
             audience.does_user_meet_audience_conditions(
                 project_config,
                 experiment.get_audience_conditions_or_ids(),
-                'experiment',
+                enums.ExperimentAudienceEvaluationLogs,
                 'audience_combinations_experiment',
                 {},
                 self.mock_client_logger

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -153,7 +153,8 @@ class AudienceTest(base.BaseTest):
         self.assertEqual({}, custom_attr_eval.call_args[0][1])
 
     def test_does_user_meet_audience_conditions__returns_true__when_condition_tree_evaluator_returns_true(self):
-        """ Test that does_user_meet_audience_conditions returns True when call to condition_tree_evaluator returns True. """
+        """ Test that does_user_meet_audience_conditions returns True
+            when call to condition_tree_evaluator returns True. """
 
         user_attributes = {'test_attribute': 'test_value_1'}
         experiment = self.project_config.get_experiment_from_key('test_experiment')
@@ -170,7 +171,7 @@ class AudienceTest(base.BaseTest):
                 )
             )
 
-    def test_does_user_meet_audience_conditions__returns_false__when_condition_tree_evaluator_returns_none_or_false(self):
+    def test_does_user_meet_audience_conditions_returns_false_when_condition_tree_evaluator_returns_none_or_false(self):
         """ Test that does_user_meet_audience_conditions returns False
         when call to condition_tree_evaluator returns None or False. """
 
@@ -248,7 +249,7 @@ class AudienceTest(base.BaseTest):
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
             audience.does_user_meet_audience_conditions(
-                self.project_config,
+                project_config,
                 experiment.get_audience_conditions_or_ids(),
                 'experiment',
                 'audience_combinations_experiment',
@@ -285,7 +286,7 @@ class AudienceTest(base.BaseTest):
 
         with mock.patch('optimizely.helpers.condition.CustomAttributeConditionEvaluator') as custom_attr_eval:
             audience.does_user_meet_audience_conditions(
-                self.project_config,
+                project_config,
                 experiment.get_audience_conditions_or_ids(),
                 'experiment',
                 'audience_combinations_experiment',
@@ -386,7 +387,7 @@ class AudienceLoggingTest(base.BaseTest):
             'optimizely.helpers.condition.CustomAttributeConditionEvaluator.evaluate', side_effect=[False, None, True],
         ):
             audience.does_user_meet_audience_conditions(
-                self.project_config,
+                project_config,
                 experiment.get_audience_conditions_or_ids(),
                 'experiment',
                 'audience_combinations_experiment',

--- a/tests/test_bucketing.py
+++ b/tests/test_bucketing.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019, Optimizely
+# Copyright 2016-2020, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/test_bucketing.py
+++ b/tests/test_bucketing.py
@@ -234,9 +234,6 @@ class BucketerWithLoggingTest(base.BaseTest):
             )
 
         mock_config_logging.debug.assert_called_once_with('Assigned bucket 42 to user with bucketing ID "test_user".')
-        mock_config_logging.info.assert_called_once_with(
-            'User "test_user" is in variation "control" of experiment test_experiment.'
-        )
 
         # Empty entity ID
         with mock.patch('optimizely.bucketer.Bucketer._generate_bucket_value', return_value=4242), mock.patch.object(
@@ -252,7 +249,6 @@ class BucketerWithLoggingTest(base.BaseTest):
             )
 
         mock_config_logging.debug.assert_called_once_with('Assigned bucket 4242 to user with bucketing ID "test_user".')
-        mock_config_logging.info.assert_called_once_with('User "test_user" is in no variation.')
 
         # Variation 2
         with mock.patch('optimizely.bucketer.Bucketer._generate_bucket_value', return_value=5042), mock.patch.object(
@@ -269,9 +265,6 @@ class BucketerWithLoggingTest(base.BaseTest):
             )
 
         mock_config_logging.debug.assert_called_once_with('Assigned bucket 5042 to user with bucketing ID "test_user".')
-        mock_config_logging.info.assert_called_once_with(
-            'User "test_user" is in variation "variation" of experiment test_experiment.'
-        )
 
         # No matching variation
         with mock.patch('optimizely.bucketer.Bucketer._generate_bucket_value', return_value=424242), mock.patch.object(
@@ -289,7 +282,6 @@ class BucketerWithLoggingTest(base.BaseTest):
         mock_config_logging.debug.assert_called_once_with(
             'Assigned bucket 424242 to user with bucketing ID "test_user".'
         )
-        mock_config_logging.info.assert_called_once_with('User "test_user" is in no variation.')
 
     def test_bucket__experiment_in_group(self):
         """ Test that for provided bucket values correct variation ID is returned. """
@@ -316,7 +308,6 @@ class BucketerWithLoggingTest(base.BaseTest):
         mock_config_logging.info.assert_has_calls(
             [
                 mock.call('User "test_user" is in experiment group_exp_1 of group 19228.'),
-                mock.call('User "test_user" is in variation "group_exp_1_variation" of experiment group_exp_1.'),
             ]
         )
 
@@ -356,7 +347,6 @@ class BucketerWithLoggingTest(base.BaseTest):
         mock_config_logging.info.assert_has_calls(
             [
                 mock.call('User "test_user" is in experiment group_exp_1 of group 19228.'),
-                mock.call('User "test_user" is in no variation.'),
             ]
         )
 
@@ -399,6 +389,5 @@ class BucketerWithLoggingTest(base.BaseTest):
         mock_config_logging.info.assert_has_calls(
             [
                 mock.call('User "test_user" is in experiment group_exp_1 of group 19228.'),
-                mock.call('User "test_user" is in no variation.'),
             ]
         )

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -598,7 +598,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
             None,
             mock_decision_service_logging
@@ -656,7 +656,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
             None,
             mock_decision_service_logging
@@ -705,7 +705,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
             None,
             mock_decision_service_logging
@@ -752,7 +752,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
             None,
             mock_decision_service_logging
@@ -809,7 +809,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
             None,
             mock_decision_service_logging
@@ -865,7 +865,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
             None,
             mock_decision_service_logging
@@ -920,7 +920,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
             None,
             mock_decision_service_logging
@@ -1059,7 +1059,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 mock.call(
                     self.project_config,
                     self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
-                    'rollout-rule',
+                    enums.RolloutRuleAudienceEvaluationLogs,
                     '1',
                     None,
                     mock_decision_service_logging,
@@ -1067,7 +1067,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 mock.call(
                     self.project_config,
                     self.project_config.get_experiment_from_key("211147").get_audience_conditions_or_ids(),
-                    'rollout-rule',
+                    enums.RolloutRuleAudienceEvaluationLogs,
                     'Everyone Else',
                     None,
                     mock_decision_service_logging,
@@ -1111,7 +1111,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 mock.call(
                     self.project_config,
                     self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
-                    "rollout-rule",
+                    enums.RolloutRuleAudienceEvaluationLogs,
                     "1",
                     None,
                     mock_decision_service_logging,
@@ -1119,7 +1119,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 mock.call(
                     self.project_config,
                     self.project_config.get_experiment_from_key("211137").get_audience_conditions_or_ids(),
-                    "rollout-rule",
+                    enums.RolloutRuleAudienceEvaluationLogs,
                     "2",
                     None,
                     mock_decision_service_logging,
@@ -1127,7 +1127,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 mock.call(
                     self.project_config,
                     self.project_config.get_experiment_from_key("211147").get_audience_conditions_or_ids(),
-                    "rollout-rule",
+                    enums.RolloutRuleAudienceEvaluationLogs,
                     "Everyone Else",
                     None,
                     mock_decision_service_logging,
@@ -1252,7 +1252,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         mock_audience_check.assert_any_call(
             self.project_config,
             self.project_config.get_experiment_from_key("group_exp_2").get_audience_conditions_or_ids(),
-            "experiment",
+            enums.ExperimentAudienceEvaluationLogs,
             "group_exp_2",
             None,
             mock_decision_service_logging,
@@ -1260,7 +1260,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         mock_audience_check.assert_any_call(
             self.project_config,
             self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
-            "rollout-rule",
+            enums.RolloutRuleAudienceEvaluationLogs,
             "1",
             None,
             mock_decision_service_logging,

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -596,7 +596,12 @@ class DecisionServiceTest(base.BaseTest):
         mock_lookup.assert_called_once_with("test_user")
         self.assertEqual(1, mock_get_stored_variation.call_count)
         mock_audience_check.assert_called_once_with(
-            self.project_config, experiment, None, mock_decision_service_logging
+            self.project_config,
+            experiment.get_audience_conditions_or_ids(),
+            "experiment",
+            "test_experiment",
+            None,
+            mock_decision_service_logging
         )
         mock_bucket.assert_called_once_with(
             self.project_config, experiment, "test_user", "test_user"
@@ -649,7 +654,12 @@ class DecisionServiceTest(base.BaseTest):
         self.assertEqual(0, mock_lookup.call_count)
         self.assertEqual(0, mock_get_stored_variation.call_count)
         mock_audience_check.assert_called_once_with(
-            self.project_config, experiment, None, mock_decision_service_logging
+            self.project_config,
+            experiment.get_audience_conditions_or_ids(),
+            "experiment",
+            "test_experiment",
+            None,
+            mock_decision_service_logging
         )
         mock_bucket.assert_called_once_with(
             self.project_config, experiment, "test_user", "test_user"
@@ -693,7 +703,12 @@ class DecisionServiceTest(base.BaseTest):
             self.project_config, experiment, user_profile.UserProfile("test_user")
         )
         mock_audience_check.assert_called_once_with(
-            self.project_config, experiment, None, mock_decision_service_logging
+            self.project_config,
+            experiment.get_audience_conditions_or_ids(),
+            "experiment",
+            "test_experiment",
+            None,
+            mock_decision_service_logging
         )
         self.assertEqual(0, mock_bucket.call_count)
         self.assertEqual(0, mock_save.call_count)
@@ -735,7 +750,12 @@ class DecisionServiceTest(base.BaseTest):
         # Stored decision is not consulted as user profile is invalid
         self.assertEqual(0, mock_get_stored_variation.call_count)
         mock_audience_check.assert_called_once_with(
-            self.project_config, experiment, None, mock_decision_service_logging
+            self.project_config,
+            experiment.get_audience_conditions_or_ids(),
+            "experiment",
+            "test_experiment",
+            None,
+            mock_decision_service_logging
         )
         mock_decision_service_logging.warning.assert_called_once_with(
             "User profile has invalid format."
@@ -787,7 +807,12 @@ class DecisionServiceTest(base.BaseTest):
         # Stored decision is not consulted as lookup failed
         self.assertEqual(0, mock_get_stored_variation.call_count)
         mock_audience_check.assert_called_once_with(
-            self.project_config, experiment, None, mock_decision_service_logging
+            self.project_config,
+            experiment.get_audience_conditions_or_ids(),
+            "experiment",
+            "test_experiment",
+            None,
+            mock_decision_service_logging
         )
         mock_decision_service_logging.exception.assert_called_once_with(
             'Unable to retrieve user profile for user "test_user" as lookup failed.'
@@ -893,7 +918,12 @@ class DecisionServiceTest(base.BaseTest):
             self.project_config, experiment, "test_user"
         )
         mock_audience_check.assert_called_once_with(
-            self.project_config, experiment, None, mock_decision_service_logging
+            self.project_config,
+            experiment.get_audience_conditions_or_ids(),
+            "experiment",
+            "test_experiment",
+            None,
+            mock_decision_service_logging
         )
         mock_bucket.assert_called_once_with(
             self.project_config, experiment, "test_user", "test_user"

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -420,7 +420,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_decision_service_logging, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation"
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment"
+            "optimizely.helpers.audience.does_user_meet_audience_conditions"
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket"
         ) as mock_bucket, mock.patch(
@@ -456,7 +456,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.decision_service.DecisionService.get_stored_variation",
             return_value=None,
         ), mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ), mock.patch(
             "optimizely.bucketer.Bucketer.bucket"
         ) as mock_bucket:
@@ -485,7 +485,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_get_whitelisted_variation, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation"
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment"
+            "optimizely.helpers.audience.does_user_meet_audience_conditions"
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket"
         ) as mock_bucket, mock.patch(
@@ -521,7 +521,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.decision_service.DecisionService.get_stored_variation",
             return_value=entities.Variation("111128", "control"),
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment"
+            "optimizely.helpers.audience.does_user_meet_audience_conditions"
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket"
         ) as mock_bucket, mock.patch(
@@ -572,7 +572,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.decision_service.DecisionService.get_stored_variation",
             return_value=None,
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=entities.Variation("111129", "variation"),
@@ -626,7 +626,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_get_whitelisted_variation, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation"
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=entities.Variation("111129", "variation"),
@@ -669,7 +669,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.decision_service.DecisionService.get_stored_variation",
             return_value=None,
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=False
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=False
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket"
         ) as mock_bucket, mock.patch(
@@ -710,7 +710,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_get_whitelisted_variation, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation"
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=entities.Variation("111129", "variation"),
@@ -762,7 +762,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_get_whitelisted_variation, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation"
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=entities.Variation("111129", "variation"),
@@ -814,7 +814,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_get_whitelisted_variation, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation"
         ) as mock_get_stored_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=entities.Variation("111129", "variation"),
@@ -838,7 +838,12 @@ class DecisionServiceTest(base.BaseTest):
         mock_lookup.assert_called_once_with("test_user")
         self.assertEqual(0, mock_get_stored_variation.call_count)
         mock_audience_check.assert_called_once_with(
-            self.project_config, experiment, None, mock_decision_service_logging
+            self.project_config,
+            experiment.getAudienceConditionsOrIds(),
+            "experiment",
+            "test_experiment",
+            None,
+            mock_decision_service_logging
         )
         mock_decision_service_logging.exception.assert_called_once_with(
             'Unable to save user profile for user "test_user".'
@@ -863,7 +868,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.decision_service.DecisionService.get_whitelisted_variation",
             return_value=None,
         ) as mock_get_whitelisted_variation, mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=entities.Variation("111129", "variation"),
@@ -928,7 +933,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         rollout = self.project_config.get_rollout_from_id("211111")
 
         with mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ), self.mock_decision_logger as mock_decision_service_logging, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=self.project_config.get_variation_from_id("211127", "211129"),
@@ -945,13 +950,8 @@ class FeatureFlagDecisionTests(base.BaseTest):
             )
 
         # Check all log messages
-        mock_decision_service_logging.debug.assert_has_calls(
-            [
-                mock.call('User "test_user" meets conditions for targeting rule 1.'),
-                mock.call(
-                    'User "test_user" is in variation 211129 of experiment 211127.'
-                ),
-            ]
+        mock_decision_service_logging.debug.assert_has_calls([
+            mock.call('User "test_user" meets audience conditions for targeting rule 1.')]
         )
 
         # Check that bucket is called with correct parameters
@@ -968,7 +968,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         rollout = self.project_config.get_rollout_from_id("211111")
 
         with mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ), self.mock_decision_logger as mock_decision_service_logging, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
             return_value=self.project_config.get_variation_from_id("211127", "211129"),
@@ -989,12 +989,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
 
         # Check all log messages
         mock_decision_service_logging.debug.assert_has_calls(
-            [
-                mock.call('User "test_user" meets conditions for targeting rule 1.'),
-                mock.call(
-                    'User "test_user" is in variation 211129 of experiment 211127.'
-                ),
-            ]
+            [mock.call('User "test_user" meets audience conditions for targeting rule 1.')]
         )
         # Check that bucket is called with correct parameters
         mock_bucket.assert_called_once_with(
@@ -1015,7 +1010,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         )
 
         with mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=True
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=True
         ) as mock_audience_check, self.mock_decision_logger as mock_decision_service_logging, mock.patch(
             "optimizely.bucketer.Bucketer.bucket", side_effect=[None, variation_to_mock]
         ):
@@ -1033,13 +1028,17 @@ class FeatureFlagDecisionTests(base.BaseTest):
             [
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211127"),
+                    self.project_config.get_experiment_from_key("211127").getAudienceConditionsOrIds(),
+                    'rollout-rule',
+                    '1',
                     None,
                     mock_decision_service_logging,
                 ),
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211147"),
+                    self.project_config.get_experiment_from_key("211147").getAudienceConditionsOrIds(),
+                    'rollout-rule',
+                    'Everyone Else',
                     None,
                     mock_decision_service_logging,
                 ),
@@ -1050,9 +1049,9 @@ class FeatureFlagDecisionTests(base.BaseTest):
         # Check all log messages
         mock_decision_service_logging.debug.assert_has_calls(
             [
-                mock.call('User "test_user" meets conditions for targeting rule 1.'),
+                mock.call('User "test_user" meets audience conditions for targeting rule 1.'),
                 mock.call(
-                    'User "test_user" is not in the traffic group for the targeting else. '
+                    'User "test_user" is not in the traffic group for targeting rule 1. '
                     'Checking "Everyone Else" rule now.'
                 ),
                 mock.call(
@@ -1067,7 +1066,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         rollout = self.project_config.get_rollout_from_id("211111")
 
         with mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment", return_value=False
+            "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=False
         ) as mock_audience_check, self.mock_decision_logger as mock_decision_service_logging:
             self.assertEqual(
                 decision_service.Decision(None, None, enums.DecisionSources.ROLLOUT),
@@ -1081,19 +1080,25 @@ class FeatureFlagDecisionTests(base.BaseTest):
             [
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211127"),
+                    self.project_config.get_experiment_from_key("211127").getAudienceConditionsOrIds(),
+                    "rollout-rule",
+                    "1",
                     None,
                     mock_decision_service_logging,
                 ),
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211137"),
+                    self.project_config.get_experiment_from_key("211137").getAudienceConditionsOrIds(),
+                    "rollout-rule",
+                    "2",
                     None,
                     mock_decision_service_logging,
                 ),
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211147"),
+                    self.project_config.get_experiment_from_key("211147").getAudienceConditionsOrIds(),
+                    "rollout-rule",
+                    "Everyone Else",
                     None,
                     mock_decision_service_logging,
                 ),
@@ -1131,7 +1136,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             "optimizely.decision_service.DecisionService.get_variation",
             return_value=expected_variation,
         )
-        with decision_patch as mock_decision, self.mock_decision_logger as mock_decision_service_logging:
+        with decision_patch as mock_decision, self.mock_decision_logger:
             self.assertEqual(
                 decision_service.Decision(
                     expected_experiment,
@@ -1148,11 +1153,6 @@ class FeatureFlagDecisionTests(base.BaseTest):
             self.project_config.get_experiment_from_key("test_experiment"),
             "test_user",
             None,
-        )
-
-        # Check log message
-        mock_decision_service_logging.debug.assert_called_once_with(
-            'User "test_user" is in variation variation of experiment test_experiment.'
         )
 
     def test_get_variation_for_feature__returns_variation_for_feature_in_rollout(self):
@@ -1202,7 +1202,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             "211127", "211129"
         )
         with mock.patch(
-            "optimizely.helpers.audience.is_user_in_experiment",
+            "optimizely.helpers.audience.does_user_meet_audience_conditions",
             side_effect=[False, True],
         ) as mock_audience_check, self.mock_decision_logger as mock_decision_service_logging, mock.patch(
             "optimizely.bucketer.Bucketer.bucket", return_value=expected_variation
@@ -1221,13 +1221,17 @@ class FeatureFlagDecisionTests(base.BaseTest):
         self.assertEqual(2, mock_audience_check.call_count)
         mock_audience_check.assert_any_call(
             self.project_config,
-            self.project_config.get_experiment_from_key("group_exp_2"),
+            self.project_config.get_experiment_from_key("group_exp_2").getAudienceConditionsOrIds(),
+            "experiment",
+            "group_exp_2",
             None,
             mock_decision_service_logging,
         )
         mock_audience_check.assert_any_call(
             self.project_config,
-            self.project_config.get_experiment_from_key("211127"),
+            self.project_config.get_experiment_from_key("211127").getAudienceConditionsOrIds(),
+            "rollout-rule",
+            "1",
             None,
             mock_decision_service_logging,
         )

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Optimizely
+# Copyright 2017-2020, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -839,7 +839,7 @@ class DecisionServiceTest(base.BaseTest):
         self.assertEqual(0, mock_get_stored_variation.call_count)
         mock_audience_check.assert_called_once_with(
             self.project_config,
-            experiment.getAudienceConditionsOrIds(),
+            experiment.get_audience_conditions_or_ids(),
             "experiment",
             "test_experiment",
             None,
@@ -1028,7 +1028,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             [
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211127").getAudienceConditionsOrIds(),
+                    self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
                     'rollout-rule',
                     '1',
                     None,
@@ -1036,7 +1036,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 ),
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211147").getAudienceConditionsOrIds(),
+                    self.project_config.get_experiment_from_key("211147").get_audience_conditions_or_ids(),
                     'rollout-rule',
                     'Everyone Else',
                     None,
@@ -1080,7 +1080,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             [
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211127").getAudienceConditionsOrIds(),
+                    self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
                     "rollout-rule",
                     "1",
                     None,
@@ -1088,7 +1088,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 ),
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211137").getAudienceConditionsOrIds(),
+                    self.project_config.get_experiment_from_key("211137").get_audience_conditions_or_ids(),
                     "rollout-rule",
                     "2",
                     None,
@@ -1096,7 +1096,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 ),
                 mock.call(
                     self.project_config,
-                    self.project_config.get_experiment_from_key("211147").getAudienceConditionsOrIds(),
+                    self.project_config.get_experiment_from_key("211147").get_audience_conditions_or_ids(),
                     "rollout-rule",
                     "Everyone Else",
                     None,
@@ -1221,7 +1221,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         self.assertEqual(2, mock_audience_check.call_count)
         mock_audience_check.assert_any_call(
             self.project_config,
-            self.project_config.get_experiment_from_key("group_exp_2").getAudienceConditionsOrIds(),
+            self.project_config.get_experiment_from_key("group_exp_2").get_audience_conditions_or_ids(),
             "experiment",
             "group_exp_2",
             None,
@@ -1229,7 +1229,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         )
         mock_audience_check.assert_any_call(
             self.project_config,
-            self.project_config.get_experiment_from_key("211127").getAudienceConditionsOrIds(),
+            self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
             "rollout-rule",
             "1",
             None,

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -1094,10 +1094,13 @@ class OptimizelyTest(base.BaseTest):
     def test_activate__bucketer_returns_none(self):
         """ Test that activate returns None and does not process event when user is in no variation. """
 
-        with mock.patch('optimizely.helpers.audience.does_user_meet_audience_conditions',
-                        return_value=True),\
-             mock.patch('optimizely.bucketer.Bucketer.bucket', return_value=None) as mock_bucket, \
-             mock.patch('optimizely.event.event_processor.ForwardingEventProcessor.process') as mock_process:
+        with mock.patch(
+            'optimizely.helpers.audience.does_user_meet_audience_conditions',
+            return_value=True), mock.patch(
+            'optimizely.bucketer.Bucketer.bucket',
+            return_value=None) as mock_bucket, mock.patch(
+            'optimizely.event.event_processor.ForwardingEventProcessor.process'
+        ) as mock_process:
             self.assertIsNone(
                 self.optimizely.activate('test_experiment', 'test_user', attributes={'test_attribute': 'test_value'},)
             )

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -1028,7 +1028,8 @@ class OptimizelyTest(base.BaseTest):
     def test_activate__with_attributes__no_audience_match(self):
         """ Test that activate returns None when audience conditions do not match. """
 
-        with mock.patch('optimizely.helpers.audience.is_user_in_experiment', return_value=False) as mock_audience_check:
+        with mock.patch('optimizely.helpers.audience.does_user_meet_audience_conditions',
+                        return_value=False) as mock_audience_check:
             self.assertIsNone(
                 self.optimizely.activate('test_experiment', 'test_user', attributes={'test_attribute': 'test_value'},)
             )
@@ -1054,7 +1055,7 @@ class OptimizelyTest(base.BaseTest):
         """ Test that activate returns None and does not process event when experiment is not Running. """
 
         with mock.patch(
-            'optimizely.helpers.audience.is_user_in_experiment', return_value=True
+            'optimizely.helpers.audience.does_user_meet_audience_conditions', return_value=True
         ) as mock_audience_check, mock.patch(
             'optimizely.helpers.experiment.is_experiment_running', return_value=False
         ) as mock_is_experiment_running, mock.patch(
@@ -1077,7 +1078,7 @@ class OptimizelyTest(base.BaseTest):
         """ Test that during activate whitelist overrides audience check if user is in the whitelist. """
 
         with mock.patch(
-            'optimizely.helpers.audience.is_user_in_experiment', return_value=False
+            'optimizely.helpers.audience.does_user_meet_audience_conditions', return_value=False
         ) as mock_audience_check, mock.patch(
             'optimizely.helpers.experiment.is_experiment_running', return_value=True
         ) as mock_is_experiment_running:
@@ -1090,11 +1091,10 @@ class OptimizelyTest(base.BaseTest):
     def test_activate__bucketer_returns_none(self):
         """ Test that activate returns None and does not process event when user is in no variation. """
 
-        with mock.patch('optimizely.helpers.audience.is_user_in_experiment', return_value=True), mock.patch(
-            'optimizely.bucketer.Bucketer.bucket', return_value=None
-        ) as mock_bucket, mock.patch(
-            'optimizely.event.event_processor.ForwardingEventProcessor.process'
-        ) as mock_process:
+        with mock.patch('optimizely.helpers.audience.does_user_meet_audience_conditions',
+                        return_value=True),\
+             mock.patch('optimizely.bucketer.Bucketer.bucket', return_value=None) as mock_bucket, \
+             mock.patch('optimizely.event.event_processor.ForwardingEventProcessor.process') as mock_process:
             self.assertIsNone(
                 self.optimizely.activate('test_experiment', 'test_user', attributes={'test_attribute': 'test_value'},)
             )

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -1033,9 +1033,12 @@ class OptimizelyTest(base.BaseTest):
             self.assertIsNone(
                 self.optimizely.activate('test_experiment', 'test_user', attributes={'test_attribute': 'test_value'},)
             )
+        expected_experiment = self.project_config.get_experiment_from_key('test_experiment')
         mock_audience_check.assert_called_once_with(
             self.project_config,
-            self.project_config.get_experiment_from_key('test_experiment'),
+            expected_experiment.get_audience_conditions_or_ids(),
+            'experiment',
+            'test_experiment',
             {'test_attribute': 'test_value'},
             self.optimizely.logger,
         )

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -1037,7 +1037,7 @@ class OptimizelyTest(base.BaseTest):
         mock_audience_check.assert_called_once_with(
             self.project_config,
             expected_experiment.get_audience_conditions_or_ids(),
-            'experiment',
+            enums.ExperimentAudienceEvaluationLogs,
             'test_experiment',
             {'test_attribute': 'test_value'},
             self.optimizely.logger,


### PR DESCRIPTION
With this change we are introducing targeted rollout specific log messages. 

Since, rules right now do not have a "name", I am proposing to use rule's index in the log message.