### PR TITLE
chore(test): Make unit tests go faster

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -402,9 +402,11 @@ class AuthDatafilePollingConfigManager(PollingConfigManager):
 
     def fetch_datafile(self):
         """ Fetch authenticated datafile and set ProjectConfig. """
-        request_headers = {}
-        request_headers[enums.HTTPHeaders.AUTHORIZATION] = \
-            enums.ConfigManager.AUTHORIZATION_HEADER_DATA_TEMPLATE.format(access_token=self.access_token)
+        request_headers = {
+            enums.HTTPHeaders.AUTHORIZATION: enums.ConfigManager.AUTHORIZATION_HEADER_DATA_TEMPLATE.format(
+                access_token=self.access_token
+            )
+        }
 
         if self.last_modified:
             request_headers[enums.HTTPHeaders.IF_MODIFIED_SINCE] = self.last_modified

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -425,7 +425,9 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
         """ Test that fetch_datafile sets authorization header in request header and sets config based on response. """
         access_token = 'some_token'
         sdk_key = 'some_key'
-        with mock.patch('optimizely.config_manager.AuthDatafilePollingConfigManager.fetch_datafile'):
+        with mock.patch('optimizely.config_manager.AuthDatafilePollingConfigManager.fetch_datafile'), mock.patch(
+            'optimizely.config_manager.AuthDatafilePollingConfigManager._run'
+        ):
             project_config_manager = config_manager.AuthDatafilePollingConfigManager(
                 access_token=access_token, sdk_key=sdk_key)
         expected_datafile_url = enums.ConfigManager.AUTHENTICATED_DATAFILE_URL_TEMPLATE.format(sdk_key=sdk_key)
@@ -438,9 +440,7 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
 
         # Call fetch_datafile and assert that request was sent with correct authorization header
         with mock.patch('requests.get',
-                        return_value=test_response) as mock_request, mock.patch(
-            'optimizely.config_manager.AuthDatafilePollingConfigManager._run'
-        ):
+                        return_value=test_response) as mock_request:
             project_config_manager.fetch_datafile()
 
         mock_request.assert_called_once_with(

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -211,11 +211,11 @@ class StaticConfigManagerTest(base.BaseTest):
     def test_get_config_blocks(self):
         """ Test that get_config blocks until blocking timeout is hit. """
         start_time = time.time()
-        project_config_manager = config_manager.PollingConfigManager(sdk_key='sdk_key', blocking_timeout=5)
+        project_config_manager = config_manager.PollingConfigManager(sdk_key='sdk_key', blocking_timeout=1)
         # Assert get_config should block until blocking timeout.
         project_config_manager.get_config()
         end_time = time.time()
-        self.assertEqual(5, round(end_time - start_time))
+        self.assertEqual(1, round(end_time - start_time))
 
 
 @mock.patch('requests.get')

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -449,5 +449,4 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
             timeout=enums.ConfigManager.REQUEST_TIMEOUT,
         )
 
-        self.assertEqual(test_headers['Last-Modified'], project_config_manager.last_modified)
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)


### PR DESCRIPTION
Noticed a number of tests were taking a long time. Used the command `pytest --duration=10` to get top 10 slowest tests.

Before:
```
5.01s call     tests/test_event_processor.py::BatchEventProcessorTest::test_drain_on_stop
5.00s call     tests/test_config_manager.py::StaticConfigManagerTest::test_get_config_blocks
3.01s call     tests/test_event_processor.py::BatchEventProcessorTest::test_stop_and_start
3.01s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush
3.01s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_on_mismatch_project_id
3.01s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_on_mismatch_revision
3.00s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_on_max_timeout
1.76s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_once_max_timeout
1.01s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_max_batch_size
0.70s call     tests/test_optimizely.py::OptimizelyTest::test_get_enabled_features__broadcasts_decision_for_each_feature
```
Total tests run time: **31.28 seconds**

After:
```
1.01s call     tests/test_config_manager.py::StaticConfigManagerTest::test_get_config_blocks
0.70s call     tests/test_optimizely.py::OptimizelyTest::test_get_enabled_features__broadcasts_decision_for_each_feature
0.36s call     tests/test_optimizely.py::OptimizelyTest::test_activate__whitelisting_overrides_audience_check
0.31s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_on_mismatch_project_id
0.31s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_once_max_timeout
0.31s call     tests/test_event_processor.py::BatchEventProcessorTest::test_drain_on_stop
0.31s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_max_batch_size
0.31s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush_on_max_timeout
0.31s call     tests/test_event_processor.py::BatchEventProcessorTest::test_flush
0.30s call     tests/test_event_processor.py::BatchEventProcessorTest::test_stop_and_start
```
Total tests run time: **7.05 seconds**