### PR TITLE
fix: change datafile accessor feature to return a string representation of datafile

### DIFF
--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -21,15 +21,15 @@ class OptimizelyConfig(object):
         self.revision = revision
         self.experiments_map = experiments_map
         self.features_map = features_map
-        self.datafile = datafile
+        self._datafile = datafile
 
     def get_datafile(self):
         """ Get the datafile associated with OptimizelyConfig.
 
         Returns:
-            A JSON string representation of the environment's datafile.
+            A JSON representation of the environment's datafile.
         """
-        return self.datafile
+        return self._datafile
 
 
 class OptimizelyExperiment(object):

--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -27,7 +27,7 @@ class OptimizelyConfig(object):
         """ Get the datafile associated with OptimizelyConfig.
 
         Returns:
-            A JSON representation of the environment's datafile.
+            A JSON string representation of the environment's datafile.
         """
         return self._datafile
 

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -40,7 +40,7 @@ class ProjectConfig(object):
         """
 
         config = json.loads(datafile)
-        self._datafile = config
+        self._datafile = str(datafile)
         self.logger = logger
         self.error_handler = error_handler
         self.version = config.get('version')
@@ -196,7 +196,7 @@ class ProjectConfig(object):
         """ Get the datafile corresponding to ProjectConfig.
 
         Returns:
-            A JSON representation of the project datafile.
+            A JSON string representation of the project datafile.
         """
 
         return self._datafile

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -40,7 +40,7 @@ class ProjectConfig(object):
         """
 
         config = json.loads(datafile)
-        self._datafile = str(datafile)
+        self._datafile = datafile.encode('utf-8')
         self.logger = logger
         self.error_handler = error_handler
         self.version = config.get('version')

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -40,7 +40,7 @@ class ProjectConfig(object):
         """
 
         config = json.loads(datafile)
-        self._datafile = datafile
+        self._datafile = config
         self.logger = logger
         self.error_handler = error_handler
         self.version = config.get('version')
@@ -196,7 +196,7 @@ class ProjectConfig(object):
         """ Get the datafile corresponding to ProjectConfig.
 
         Returns:
-            A JSON string representation of the project datafile.
+            A JSON representation of the project datafile.
         """
 
         return self._datafile

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -40,7 +40,7 @@ class ProjectConfig(object):
         """
 
         config = json.loads(datafile)
-        self._datafile = datafile.encode('utf-8')
+        self._datafile = u'{}'.format(datafile)
         self.logger = logger
         self.error_handler = error_handler
         self.version = config.get('version')

--- a/tests/test_optimizely_config.py
+++ b/tests/test_optimizely_config.py
@@ -456,7 +456,7 @@ class OptimizelyConfigTest(base.BaseTest):
                 }
             },
             'revision': '1',
-            'datafile': json.dumps(self.config_dict_with_features)
+            '_datafile': json.dumps(self.config_dict_with_features)
         }
 
         self.actual_config = self.opt_config_service.get_config()


### PR DESCRIPTION
Summary
---------
- Updated datafile to ensure that it is being stored and returned as a `string` type instead of previous `bytes` type

Test Plan
---------
- Ran manual tests

Note
-----
- Sohail mentioned that tests were failing in `fullstack_prod_suite` because the `bytes` datafile was not iterable, so I changed it to return a `string`
