### PR TITLE
fix(exception-handling): Catch errors when requesting datafile

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -325,7 +325,7 @@ class PollingConfigManager(StaticConfigManager):
         """
         try:
             response.raise_for_status()
-        except requests_exceptions.HTTPError as err:
+        except requests_exceptions.RequestException as err:
             self.logger.error('Fetching datafile from {} failed. Error: {}'.format(self.datafile_url, str(err)))
             return
 


### PR DESCRIPTION
Summary
-------

We were not catching all exceptions when requesting the datafile. The `HTTPError` class is only a single class of errors and we were not capturing all the other errors like timeout issues, proxy issues, etc.

The class of exceptions can be seen here: https://requests.readthedocs.io/en/master/_modules/requests/exceptions

Updating to catch `RequestException`. It is also something we were already doing correctly in event dispatching: https://github.com/optimizely/python-sdk/blob/master/optimizely/event_dispatcher.py#L42

Test plan
---------
- Tested timeout before and after the fix.
- Unit test added.
