### PR TITLE
fix(exception-handling): Fix handling of network and other non-status-code errors when polling for datafile

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Build and install the SDK with pip, using the following command:
 To get test dependencies installed, use a modified version of the
 install command:
 
-    pip install -e .[test]
+    pip install -e '.[test]'
 
 You can run all unit tests with:
 

--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -344,9 +344,14 @@ class PollingConfigManager(StaticConfigManager):
         if self.last_modified:
             request_headers[enums.HTTPHeaders.IF_MODIFIED_SINCE] = self.last_modified
 
-        response = requests.get(
-            self.datafile_url, headers=request_headers, timeout=enums.ConfigManager.REQUEST_TIMEOUT,
-        )
+        try:
+            response = requests.get(
+                self.datafile_url, headers=request_headers, timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            )
+        except requests_exceptions.RequestException as err:
+            self.logger.error('Fetching datafile from {} failed. Error: {}'.format(self.datafile_url, str(err)))
+            return
+
         self._handle_response(response)
 
     @property
@@ -411,7 +416,12 @@ class AuthDatafilePollingConfigManager(PollingConfigManager):
         if self.last_modified:
             request_headers[enums.HTTPHeaders.IF_MODIFIED_SINCE] = self.last_modified
 
-        response = requests.get(
-            self.datafile_url, headers=request_headers, timeout=enums.ConfigManager.REQUEST_TIMEOUT,
-        )
+        try:
+            response = requests.get(
+                self.datafile_url, headers=request_headers, timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            )
+        except requests_exceptions.RequestException as err:
+            self.logger.error('Fetching datafile from {} failed. Error: {}'.format(self.datafile_url, str(err)))
+            return
+
         self._handle_response(response)


### PR DESCRIPTION
Summary
-------

- https://github.com/optimizely/python-sdk/pull/285 was an incomplete fix; as per [the docs](https://requests.readthedocs.io/en/master/user/quickstart/#timeouts), timeouts and other network errors throw on the call to `.get()`, not on the call to `.raise_for_status()` (`raise_for_status` just checks for a non-2xx HTTP return code; it doesn't handle other kinds of errors)

- This adds additional error handling around calls to `requests.get`.

- Also made a small tweak to the README; `zsh` requires quoting around `.[test]`.

Test plan
---------

- Added unit tests for both the polling config manager and the static config manager

