### PR TITLE
use named arguments in calls to public methods with more than one param

### DIFF
--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -411,7 +411,7 @@ class Optimizely(object):
             self.logger.error(enums.Errors.INVALID_PROJECT_CONFIG.format('activate'))
             return None
 
-        variation_key = self.get_variation(experiment_key, user_id, attributes)
+        variation_key = self.get_variation(experiment_key=experiment_key, user_id=user_id, attributes=attributes)
 
         if not variation_key:
             self.logger.info('Not activating user "%s".' % user_id)
@@ -636,7 +636,7 @@ class Optimizely(object):
             return enabled_features
 
         for feature in project_config.feature_key_map.values():
-            if self.is_feature_enabled(feature.key, user_id, attributes):
+            if self.is_feature_enabled(feature_key=feature.key, user_id=user_id, attributes=attributes):
                 enabled_features.append(feature.key)
 
         return enabled_features
@@ -876,7 +876,6 @@ class Optimizely(object):
 
         forced_variation = self.decision_service.get_forced_variation(project_config, experiment_key, user_id)
         return forced_variation.key if forced_variation else None
-
     def get_optimizely_config(self):
         """ Gets OptimizelyConfig instance for the current project config.
 

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -876,6 +876,7 @@ class Optimizely(object):
 
         forced_variation = self.decision_service.get_forced_variation(project_config, experiment_key, user_id)
         return forced_variation.key if forced_variation else None
+
     def get_optimizely_config(self):
         """ Gets OptimizelyConfig instance for the current project config.
 


### PR DESCRIPTION
Summary
-------

- Calls made by `class Optimizely` to methods attached to `self` that are public and have more than one parameter are now made with named parameters.

Why
-------

In a private personal project, I implemented an Optimizely wrapper that inherits from the python-sdk client. I've implemented `activate` and `get_variation`, only I implemented `get_variation` with extra parameters relevant to my wrapper. Like so:

```python
def get_variation(self, experiment_key, other_info=None, excess_data=None, attributes=None):
```

My error in the above code is not having `attributes` be the third argument. When I called the wrapped `activate`, it calls `self.get_variation`, without named parameters. Because my code was wrong, but also because they are called with named parameters, values from `attributes` were being passed as `excess_data`, which caused unexpected behavior.

Test plan
---------
there are no syntactical changes that would be noticed by the interpreter in this changeset.

Issues
------
n/a