### PR TITLE
refact: fix warnings in pytest output

### DIFF
--- a/tests/helpers_tests/test_event_tag_utils.py
+++ b/tests/helpers_tests/test_event_tag_utils.py
@@ -13,12 +13,16 @@
 
 import sys
 import unittest
-from optimizely import logger
+
 
 from optimizely.helpers import event_tag_utils
+from optimizely.logger import NoOpLogger
 
 
 class EventTagUtilsTest(unittest.TestCase):
+    def setUp(self, *args, **kwargs):
+        self.logger = NoOpLogger()
+
     def test_get_revenue_value__invalid_args(self):
         """ Test that revenue value is not returned for invalid arguments. """
         self.assertIsNone(event_tag_utils.get_revenue_value(None))
@@ -82,70 +86,70 @@ class EventTagUtilsTest(unittest.TestCase):
 
         # An integer should be cast to a float
         self.assertEqual(
-            12345.0, event_tag_utils.get_numeric_value({'value': 12345}, logger=logger.SimpleLogger()),
+            12345.0, event_tag_utils.get_numeric_value({'value': 12345}),
         )
 
         # A string should be cast to a float
         self.assertEqual(
-            12345.0, event_tag_utils.get_numeric_value({'value': '12345'}, logger=logger.SimpleLogger()),
+            12345.0, event_tag_utils.get_numeric_value({'value': '12345'}, self.logger),
         )
 
         # Valid float values
         some_float = 1.2345
         self.assertEqual(
-            some_float, event_tag_utils.get_numeric_value({'value': some_float}, logger=logger.SimpleLogger()),
+            some_float, event_tag_utils.get_numeric_value({'value': some_float}, self.logger),
         )
 
         max_float = sys.float_info.max
         self.assertEqual(
-            max_float, event_tag_utils.get_numeric_value({'value': max_float}, logger=logger.SimpleLogger()),
+            max_float, event_tag_utils.get_numeric_value({'value': max_float}, self.logger),
         )
 
         min_float = sys.float_info.min
         self.assertEqual(
-            min_float, event_tag_utils.get_numeric_value({'value': min_float}, logger=logger.SimpleLogger()),
+            min_float, event_tag_utils.get_numeric_value({'value': min_float}, self.logger),
         )
 
         # Invalid values
-        self.assertIsNone(event_tag_utils.get_numeric_value({'value': False}, logger=logger.SimpleLogger()))
-        self.assertIsNone(event_tag_utils.get_numeric_value({'value': None}, logger=logger.SimpleLogger()))
+        self.assertIsNone(event_tag_utils.get_numeric_value({'value': False}, self.logger))
+        self.assertIsNone(event_tag_utils.get_numeric_value({'value': None}, self.logger))
 
-        numeric_value_nan = event_tag_utils.get_numeric_value({'value': float('nan')}, logger=logger.SimpleLogger())
+        numeric_value_nan = event_tag_utils.get_numeric_value({'value': float('nan')}, self.logger)
         self.assertIsNone(numeric_value_nan, 'nan numeric value is {}'.format(numeric_value_nan))
 
-        numeric_value_array = event_tag_utils.get_numeric_value({'value': []}, logger=logger.SimpleLogger())
+        numeric_value_array = event_tag_utils.get_numeric_value({'value': []}, self.logger)
         self.assertIsNone(numeric_value_array, 'Array numeric value is {}'.format(numeric_value_array))
 
-        numeric_value_dict = event_tag_utils.get_numeric_value({'value': []}, logger=logger.SimpleLogger())
+        numeric_value_dict = event_tag_utils.get_numeric_value({'value': []}, self.logger)
         self.assertIsNone(numeric_value_dict, 'Dict numeric value is {}'.format(numeric_value_dict))
 
-        numeric_value_none = event_tag_utils.get_numeric_value({'value': None}, logger=logger.SimpleLogger())
+        numeric_value_none = event_tag_utils.get_numeric_value({'value': None}, self.logger)
         self.assertIsNone(numeric_value_none, 'None numeric value is {}'.format(numeric_value_none))
 
         numeric_value_invalid_literal = event_tag_utils.get_numeric_value(
-            {'value': '1,234'}, logger=logger.SimpleLogger()
+            {'value': '1,234'}, self.logger
         )
         self.assertIsNone(
             numeric_value_invalid_literal, 'Invalid string literal value is {}'.format(numeric_value_invalid_literal),
         )
 
         numeric_value_overflow = event_tag_utils.get_numeric_value(
-            {'value': sys.float_info.max * 10}, logger=logger.SimpleLogger()
+            {'value': sys.float_info.max * 10}, self.logger
         )
         self.assertIsNone(
             numeric_value_overflow, 'Max numeric value is {}'.format(numeric_value_overflow),
         )
 
-        numeric_value_inf = event_tag_utils.get_numeric_value({'value': float('inf')}, logger=logger.SimpleLogger())
+        numeric_value_inf = event_tag_utils.get_numeric_value({'value': float('inf')}, self.logger)
         self.assertIsNone(numeric_value_inf, 'Infinity numeric value is {}'.format(numeric_value_inf))
 
         numeric_value_neg_inf = event_tag_utils.get_numeric_value(
-            {'value': float('-inf')}, logger=logger.SimpleLogger()
+            {'value': float('-inf')}, self.logger
         )
         self.assertIsNone(
             numeric_value_neg_inf, 'Negative infinity numeric value is {}'.format(numeric_value_neg_inf),
         )
 
         self.assertEqual(
-            0.0, event_tag_utils.get_numeric_value({'value': 0.0}, logger=logger.SimpleLogger()),
+            0.0, event_tag_utils.get_numeric_value({'value': 0.0}, self.logger),
         )

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -46,7 +46,7 @@ class CanonicalEvent(object):
         return self.__dict__ == other.__dict__
 
 
-class TestEventDispatcher(object):
+class CustomEventDispatcher(object):
 
     IMPRESSION_EVENT_NAME = 'campaign_activated'
 
@@ -146,7 +146,7 @@ class BatchEventProcessorTest(base.BaseTest):
         )
 
     def test_drain_on_stop(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self._set_event_processor(event_dispatcher, mock_config_logging)
@@ -161,7 +161,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(0, self.event_processor.event_queue.qsize())
 
     def test_flush_on_max_timeout(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self._set_event_processor(event_dispatcher, mock_config_logging)
@@ -176,7 +176,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(0, self.event_processor.event_queue.qsize())
 
     def test_flush_once_max_timeout(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         self.optimizely.logger = NoOpLogger()
 
@@ -199,7 +199,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.optimizely.logger = NoOpLogger()
 
     def test_flush_max_batch_size(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self._set_event_processor(event_dispatcher, mock_config_logging)
@@ -215,7 +215,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(0, self.event_processor.event_queue.qsize())
 
     def test_flush(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self._set_event_processor(event_dispatcher, mock_config_logging)
@@ -235,7 +235,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(0, self.event_processor.event_queue.qsize())
 
     def test_flush_on_mismatch_revision(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self._set_event_processor(event_dispatcher, mock_config_logging)
@@ -260,7 +260,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(0, self.event_processor.event_queue.qsize())
 
     def test_flush_on_mismatch_project_id(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self._set_event_processor(event_dispatcher, mock_config_logging)
@@ -285,7 +285,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(0, self.event_processor.event_queue.qsize())
 
     def test_stop_and_start(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self._set_event_processor(event_dispatcher, mock_config_logging)
@@ -311,7 +311,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(0, self.event_processor.event_queue.qsize())
 
     def test_init__invalid_batch_size(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -329,7 +329,7 @@ class BatchEventProcessorTest(base.BaseTest):
         mock_config_logging.info.assert_called_with('Using default value 10 for batch_size.')
 
     def test_init__NaN_batch_size(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -347,7 +347,7 @@ class BatchEventProcessorTest(base.BaseTest):
         mock_config_logging.info.assert_called_with('Using default value 10 for batch_size.')
 
     def test_init__invalid_flush_interval(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -365,7 +365,7 @@ class BatchEventProcessorTest(base.BaseTest):
         mock_config_logging.info.assert_called_with('Using default value 30 for flush_interval.')
 
     def test_init__float_flush_interval(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -382,7 +382,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertEqual(datetime.timedelta(seconds=0.5), self.event_processor.flush_interval)
 
     def test_init__float_flush_deadline(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -399,7 +399,7 @@ class BatchEventProcessorTest(base.BaseTest):
         self.assertTrue(isinstance(self.event_processor.flushing_interval_deadline, float))
 
     def test_init__bool_flush_interval(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -417,7 +417,7 @@ class BatchEventProcessorTest(base.BaseTest):
         mock_config_logging.info.assert_called_with('Using default value 30 for flush_interval.')
 
     def test_init__string_flush_interval(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -435,7 +435,7 @@ class BatchEventProcessorTest(base.BaseTest):
         mock_config_logging.info.assert_called_with('Using default value 30 for flush_interval.')
 
     def test_init__invalid_timeout_interval(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -453,7 +453,7 @@ class BatchEventProcessorTest(base.BaseTest):
         mock_config_logging.info.assert_called_with('Using default value 5 for timeout_interval.')
 
     def test_init__NaN_timeout_interval(self):
-        event_dispatcher = TestEventDispatcher()
+        event_dispatcher = CustomEventDispatcher()
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
@@ -495,7 +495,7 @@ class BatchEventProcessorTest(base.BaseTest):
         )
 
 
-class TestForwardingEventDispatcher(object):
+class CustomForwardingEventDispatcher(object):
     def __init__(self, is_updated=False):
         self.is_updated = is_updated
 
@@ -512,7 +512,7 @@ class ForwardingEventProcessorTest(base.BaseTest):
         self.event_name = 'test_event'
         self.optimizely.logger = NoOpLogger()
         self.notification_center = self.optimizely.notification_center
-        self.event_dispatcher = TestForwardingEventDispatcher(is_updated=False)
+        self.event_dispatcher = CustomForwardingEventDispatcher(is_updated=False)
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = ForwardingEventProcessor(


### PR DESCRIPTION
Summary
-------
- Renames TestEventDispatcher class so that pytest doesn't mistake it for a test class. 
- Replace SimpleLogger from event tag utils test since it's been deprecated.

**Warnings**
```
tests/test_event_processor.py:49
  /home/oakbani/Documents/Optimizely/python-sdk/tests/test_event_processor.py:49: PytestCollectionWarning: cannot collect test class 'TestEventDispatcher' because it has a __init__ constructor (from: tests/test_event_processor.py)
    class TestEventDispatcher(object):

tests/test_event_processor.py:498
  /home/oakbani/Documents/Optimizely/python-sdk/tests/test_event_processor.py:498: PytestCollectionWarning: cannot collect test class 'TestForwardingEventDispatcher' because it has a __init__ constructor (from: tests/test_event_processor.py)
    class TestForwardingEventDispatcher(object):


tests/helpers_tests/test_event_tag_utils.py::EventTagUtilsTest::test_get_numeric_metric__value_tag
tests/helpers_tests/test_event_tag_utils.py::EventTagUtilsTest::test_get_numeric_metric__value_tag
tests/helpers_tests/test_event_tag_utils.py::EventTagUtilsTest::test_get_numeric_metric__value_tag
tests/helpers_tests/test_event_tag_utils.py::EventTagUtilsTest::test_get_numeric_metric__value_tag
tests/helpers_tests/test_event_tag_utils.py::EventTagUtilsTest::test_get_numeric_metric__value_tag
tests/helpers_tests/test_event_tag_utils.py::EventTagUtilsTest::test_get_numeric_metric__value_tag
  /home/oakbani/Documents/Optimizely/python-sdk/optimizely/logger.py:83: DeprecationWarning: <class 'optimizely.logger.SimpleLogger'> is deprecated. Please use standard python loggers.
    warnings.warn(warning, DeprecationWarning)
```


Test plan
---------
All tests should continue to pass

Issues
------

