### PR TITLE
build: Fix package installation for Python 3.4 and pypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Optimizely Python SDK 
+# Optimizely Python SDK
 
 [![PyPI version](https://badge.fury.io/py/optimizely-sdk.svg)](https://pypi.org/project/optimizely-sdk)
 [![Build Status](https://travis-ci.org/optimizely/python-sdk.svg?branch=master)](https://travis-ci.org/optimizely/python-sdk)

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,3 +1,4 @@
 jsonschema==3.2.0
+pyrsistent==0.14.0
 mmh3==2.5.1
 requests[security]>=2.9.1


### PR DESCRIPTION
Summary
-------
jsonschema 3.2.0 has a dependency to pyrsistent>=0.14.0. When PIP tries to install the latest pyrsistent version, it requires Python > 3.5. Therefore, in this PR we explicitly define the version for pyrsistent package. 

Test plan
---------
All checks continue to pass.

