### PR TITLE
feat: added enabled field to decision metadata

### DIFF
--- a/optimizely/event/event_factory.py
+++ b/optimizely/event/event_factory.py
@@ -99,7 +99,7 @@ class EventFactory(object):
                 experiment_layerId = event.experiment.layerId
                 experiment_id = event.experiment.id
 
-            metadata = payload.Metadata(event.flag_key, event.rule_key, event.rule_type, variation_key)
+            metadata = payload.Metadata(event.flag_key, event.rule_key, event.rule_type, variation_key, event.enabled)
             decision = payload.Decision(experiment_layerId, experiment_id, variation_id, metadata)
             snapshot_event = payload.SnapshotEvent(
                 experiment_layerId, event.uuid, cls.ACTIVATE_EVENT_KEY, event.timestamp,

--- a/optimizely/event/payload.py
+++ b/optimizely/event/payload.py
@@ -71,11 +71,12 @@ class Decision(object):
 class Metadata(object):
     """ Class respresenting Metadata. """
 
-    def __init__(self, flag_key, rule_key, rule_type, variation_key):
+    def __init__(self, flag_key, rule_key, rule_type, variation_key, enabled):
         self.flag_key = flag_key
         self.rule_key = rule_key
         self.rule_type = rule_type
         self.variation_key = variation_key
+        self.enabled = enabled
 
 
 class Snapshot(object):

--- a/optimizely/event/user_event.py
+++ b/optimizely/event/user_event.py
@@ -41,8 +41,8 @@ class ImpressionEvent(UserEvent):
     """ Class representing Impression Event. """
 
     def __init__(
-        self, event_context, user_id, experiment, visitor_attributes, variation, flag_key, rule_key, rule_type,
-        bot_filtering=None,
+        self, event_context, user_id, experiment, visitor_attributes, variation, flag_key,
+        rule_key, rule_type, enabled, bot_filtering=None
     ):
         super(ImpressionEvent, self).__init__(event_context, user_id, visitor_attributes, bot_filtering)
         self.experiment = experiment
@@ -50,6 +50,7 @@ class ImpressionEvent(UserEvent):
         self.flag_key = flag_key
         self.rule_key = rule_key
         self.rule_type = rule_type
+        self.enabled = enabled
 
 
 class ConversionEvent(UserEvent):

--- a/optimizely/event/user_event_factory.py
+++ b/optimizely/event/user_event_factory.py
@@ -21,7 +21,8 @@ class UserEventFactory(object):
 
     @classmethod
     def create_impression_event(
-        cls, project_config, activated_experiment, variation_id, flag_key, rule_key, rule_type, user_id, user_attributes
+        cls, project_config, activated_experiment, variation_id, flag_key, rule_key, rule_type,
+        enabled, user_id, user_attributes
     ):
         """ Create impression Event to be sent to the logging endpoint.
 
@@ -32,6 +33,7 @@ class UserEventFactory(object):
       flag_key: key for a feature flag.
       rule_key: key for an experiment.
       rule_type: type for the source.
+      enabled: boolean representing if feature is enabled
       user_id: ID for user.
       attributes: Dict representing user attributes and values which need to be recorded.
 
@@ -62,6 +64,7 @@ class UserEventFactory(object):
             flag_key,
             rule_key,
             rule_type,
+            enabled,
             project_config.get_bot_filtering_value(),
         )
 

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -160,8 +160,8 @@ class Optimizely(object):
 
         return True
 
-    def _send_impression_event(self, project_config, experiment, variation, flag_key, rule_key, rule_type, user_id,
-                               attributes):
+    def _send_impression_event(self, project_config, experiment, variation, flag_key, rule_key, rule_type, enabled,
+                               user_id, attributes):
         """ Helper method to send impression event.
 
     Args:
@@ -171,12 +171,13 @@ class Optimizely(object):
       flag_key: key for a feature flag.
       rule_key: key for an experiment.
       rule_type: type for the source.
+      enabled: boolean representing if feature is enabled
       user_id: ID for user.
       attributes: Dict representing user attributes and values which need to be recorded.
     """
         variation_id = variation.id if variation is not None else None
         user_event = user_event_factory.UserEventFactory.create_impression_event(
-            project_config, experiment, variation_id, flag_key, rule_key, rule_type, user_id, attributes
+            project_config, experiment, variation_id, flag_key, rule_key, rule_type, enabled, user_id, attributes
         )
 
         self.event_processor.process(user_event)
@@ -427,7 +428,7 @@ class Optimizely(object):
         # Create and dispatch impression event
         self.logger.info('Activating user "%s" in experiment "%s".' % (user_id, experiment.key))
         self._send_impression_event(project_config, experiment, variation, '', experiment.key,
-                                    enums.DecisionSources.EXPERIMENT, user_id, attributes)
+                                    enums.DecisionSources.EXPERIMENT, True, user_id, attributes)
 
         return variation.key
 
@@ -580,25 +581,26 @@ class Optimizely(object):
         is_source_experiment = decision.source == enums.DecisionSources.FEATURE_TEST
         is_source_rollout = decision.source == enums.DecisionSources.ROLLOUT
 
-        if (is_source_rollout or not decision.variation) and project_config.get_send_flag_decisions_value():
-            self._send_impression_event(
-                project_config, decision.experiment, decision.variation, feature.key, decision.experiment.key if
-                decision.experiment else '', decision.source, user_id, attributes
-            )
-
         if decision.variation:
             if decision.variation.featureEnabled is True:
                 feature_enabled = True
-            # Send event if Decision came from an experiment.
-            if is_source_experiment:
-                source_info = {
-                    'experiment_key': decision.experiment.key,
-                    'variation_key': decision.variation.key,
-                }
-                self._send_impression_event(
-                    project_config, decision.experiment, decision.variation, feature.key, decision.experiment.key,
-                    decision.source, user_id, attributes
-                )
+
+        if (is_source_rollout or not decision.variation) and project_config.get_send_flag_decisions_value():
+            self._send_impression_event(
+                project_config, decision.experiment, decision.variation, feature.key, decision.experiment.key if
+                decision.experiment else '', decision.source, feature_enabled, user_id, attributes
+            )
+
+        # Send event if Decision came from an experiment.
+        if is_source_experiment and decision.variation:
+            source_info = {
+                'experiment_key': decision.experiment.key,
+                'variation_key': decision.variation.key,
+            }
+            self._send_impression_event(
+                project_config, decision.experiment, decision.variation, feature.key, decision.experiment.key,
+                decision.source, feature_enabled, user_id, attributes
+            )
 
         if feature_enabled:
             self.logger.info('Feature "%s" is enabled for user "%s".' % (feature_key, user_id))

--- a/tests/test_event_factory.py
+++ b/tests/test_event_factory.py
@@ -78,7 +78,8 @@ class EventFactoryTest(base.BaseTest):
                                  'metadata': {'flag_key': 'flag_key',
                                               'rule_key': 'rule_key',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'}}
+                                              'variation_key': 'variation',
+                                              'enabled': False}}
                             ],
                             'events': [
                                 {
@@ -109,6 +110,7 @@ class EventFactoryTest(base.BaseTest):
                 'flag_key',
                 'rule_key',
                 'experiment',
+                False,
                 'test_user',
                 None,
             )
@@ -139,7 +141,8 @@ class EventFactoryTest(base.BaseTest):
                                  'metadata': {'flag_key': 'flag_key',
                                               'rule_key': 'rule_key',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [
@@ -171,6 +174,7 @@ class EventFactoryTest(base.BaseTest):
                 'flag_key',
                 'rule_key',
                 'experiment',
+                True,
                 'test_user',
                 {'test_attribute': 'test_value'},
             )
@@ -199,7 +203,8 @@ class EventFactoryTest(base.BaseTest):
                                  'metadata': {'flag_key': 'flag_key',
                                               'rule_key': 'rule_key',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'}
+                                              'variation_key': 'variation',
+                                              'enabled': True}
                                  }
                             ],
                             'events': [
@@ -231,6 +236,7 @@ class EventFactoryTest(base.BaseTest):
                 'flag_key',
                 'rule_key',
                 'experiment',
+                True,
                 'test_user',
                 {'do_you_know_me': 'test_value'},
             )
@@ -350,7 +356,8 @@ class EventFactoryTest(base.BaseTest):
                                  'metadata': {'flag_key': 'flag_key',
                                               'rule_key': 'rule_key',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': False},
                                  }
                             ],
                             'events': [
@@ -384,6 +391,7 @@ class EventFactoryTest(base.BaseTest):
                 'flag_key',
                 'rule_key',
                 'experiment',
+                False,
                 'test_user',
                 {'$opt_user_agent': 'Edge'},
             )
@@ -420,7 +428,8 @@ class EventFactoryTest(base.BaseTest):
                                  'metadata': {'flag_key': 'flag_key',
                                               'rule_key': 'rule_key',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': False},
                                  }
                             ],
                             'events': [
@@ -454,6 +463,7 @@ class EventFactoryTest(base.BaseTest):
                 'flag_key',
                 'rule_key',
                 'experiment',
+                False,
                 'test_user',
                 None,
             )
@@ -496,7 +506,8 @@ class EventFactoryTest(base.BaseTest):
                                  'metadata': {'flag_key': 'flag_key',
                                               'rule_key': 'rule_key',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [
@@ -530,6 +541,7 @@ class EventFactoryTest(base.BaseTest):
                 'flag_key',
                 'rule_key',
                 'experiment',
+                True,
                 'test_user',
                 {'$opt_user_agent': 'Chrome'},
             )

--- a/tests/test_event_payload.py
+++ b/tests/test_event_payload.py
@@ -34,7 +34,8 @@ class EventPayloadTest(base.BaseTest):
                                  'metadata': {'flag_key': 'flag_key',
                                               'rule_key': 'rule_key',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': False},
                                  }
                             ],
                             'events': [
@@ -59,7 +60,7 @@ class EventPayloadTest(base.BaseTest):
         batch = payload.EventBatch('12001', '111001', '42', 'python-sdk', version.__version__, False, True)
         visitor_attr = payload.VisitorAttribute('111094', 'test_attribute', 'custom', 'test_value')
         event = payload.SnapshotEvent('111182', 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c', 'campaign_activated', 42123,)
-        metadata = payload.Metadata('flag_key', 'rule_key', 'experiment', 'variation')
+        metadata = payload.Metadata('flag_key', 'rule_key', 'experiment', 'variation', False)
         event_decision = payload.Decision('111182', '111127', '111129', metadata)
 
         snapshots = payload.Snapshot([event], [event_decision])

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -325,7 +325,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': '',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [
@@ -703,7 +704,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': '',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [
@@ -785,7 +787,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': '',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [
@@ -981,7 +984,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': '',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'control'},
+                                              'variation_key': 'control',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [
@@ -1056,7 +1060,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': '',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'experiment',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [
@@ -2004,7 +2009,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': 'test_feature_in_experiment',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'feature-test',
-                                              'variation_key': 'variation'}}
+                                              'variation_key': 'variation',
+                                              'enabled': True}}
                             ],
                             'events': [
                                 {
@@ -2102,7 +2108,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': 'test_feature_in_experiment',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'feature-test',
-                                              'variation_key': 'control'}}
+                                              'variation_key': 'control',
+                                              'enabled': False}}
                             ],
                             'events': [
                                 {
@@ -2248,7 +2255,8 @@ class OptimizelyTest(base.BaseTest):
                                  'metadata': {'flag_key': 'test_feature_in_experiment',
                                               'rule_key': 'test_experiment',
                                               'rule_type': 'rollout',
-                                              'variation_key': 'variation'},
+                                              'variation_key': 'variation',
+                                              'enabled': True},
                                  }
                             ],
                             'events': [

--- a/tests/test_user_event_factory.py
+++ b/tests/test_user_event_factory.py
@@ -29,7 +29,7 @@ class UserEventFactoryTest(base.BaseTest):
         user_id = 'test_user'
 
         impression_event = UserEventFactory.create_impression_event(project_config, experiment, '111128', 'flag_key',
-                                                                    'rule_key', 'rule_type', user_id, None)
+                                                                    'rule_key', 'rule_type', True, user_id, None)
 
         self.assertEqual(self.project_config.project_id, impression_event.event_context.project_id)
         self.assertEqual(self.project_config.revision, impression_event.event_context.revision)
@@ -51,7 +51,7 @@ class UserEventFactoryTest(base.BaseTest):
         user_attributes = {'test_attribute': 'test_value', 'boolean_key': True}
 
         impression_event = UserEventFactory.create_impression_event(
-            project_config, experiment, '111128', 'flag_key', 'rule_key', 'rule_type', user_id, user_attributes
+            project_config, experiment, '111128', 'flag_key', 'rule_key', 'rule_type', True, user_id, user_attributes
         )
 
         expected_attrs = EventFactory.build_attribute_list(user_attributes, project_config)


### PR DESCRIPTION
Summary
-------
- This adds 'enabled' field to decision metadata. 
- 'enabled' is set to feature_enabled value for is_feature_enabled and True for activate.

Test plan
---------
- Fixed existing unit tests.
- Manually tested with FSC.