### PR TITLE
ci: fix cryptography wheel build for pypy and pypy3

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,4 +2,4 @@ jsonschema==3.2.0
 pyrsistent==0.14.0
 mmh3==2.5.1
 requests[security]>=2.9.1
-cryptography==3.1.1
+cryptography>=1.3.4,<=3.1.1

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,3 +2,4 @@ jsonschema==3.2.0
 pyrsistent==0.14.0
 mmh3==2.5.1
 requests[security]>=2.9.1
+cryptography==3.1.1


### PR DESCRIPTION
Summary
-------
Unit tests on Python pypy and pypy3 have been failing consistently for quite some time. On detailed investigation, cryptography package is required by the requests[security] module. Although the latest cryptography version does support pypy, it doesn't build for some reason. 

Setting cryptography package to a static previous version revealed that Python 3.4 support has been dropped after cryptography 2.8.  Therefore, in this PR we specify version bounds that support all of our supported python versions. 


Test plan
---------
All checks continue to pass. 

Issues
------
