### PR TITLE
ci: Install a compatible version of cryptography for pypy and pypy3 in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,10 @@ jobs:
     - stage: 'Test'
       python: "pypy"
       before_install:
+        - pip install "cryptography>=1.3.4,<=3.1.1" # installing in before_install doesn't re-install a latest version of the same package in the next stage.
+    - stage: 'Test'
+      python: "pypy3"
+      before_install:
         - pip install "cryptography>=1.3.4,<=3.1.1"
     - stage: 'Test'
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
         FULLSTACK_TEST_REPO=ProdTesting
     - stage: 'Test'
       python: "pypy"
-      before_script:
+      before_install:
         - pip install "cryptography>=1.3.4,<=3.1.1"
     - stage: 'Test'
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - "3.6"
 # - "3.7" is handled in 'Test' job using xenial as Python 3.7 is not available for trusty.
 # - "3.8" is handled in 'Test' job using xenial as Python 3.8 is not available for trusty.
-  - "pypy"
-  - "pypy3"
+#  - "pypy"
+#  - "pypy3"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
 after_success:
@@ -61,7 +61,10 @@ jobs:
         SDK=python
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
         FULLSTACK_TEST_REPO=ProdTesting
-
+    - stage: 'Test'
+      python: "pypy"
+      before_script:
+        - pip install "cryptography>=1.3.4,<=3.1.1"
     - stage: 'Test'
       dist: xenial
       python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
     - stage: 'Test'
       python: "pypy"
       before_install:
-        - pip install "cryptography>=1.3.4,<=3.1.1" # installing in before_install doesn't re-install a latest version of the same package in the next stage.
+        - pip install "cryptography>=1.3.4,<=3.1.1" # installing in before_install doesn't re-install the latest version of the same package in the next stage.
     - stage: 'Test'
       python: "pypy3"
       before_install:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ To install:
 
     pip install optimizely-sdk
 
+Note:  
+If you are running the SDK with PyPy or PyPy3, install this cryptography package first and then optimizely-sdk package:  
+
+    pip install "cryptography>=1.3.4,<=3.1.1"
+
+
 ### Feature Management Access
 
 To access the Feature Management configuration in the Optimizely

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ To install:
     pip install optimizely-sdk
 
 Note:  
-If you are running the SDK with PyPy or PyPy3, install this cryptography package first and then optimizely-sdk package:  
+If you are running the SDK with PyPy or PyPy3 and you are experiencing issues, install this cryptography package **first** and then optimizely-sdk package:  
 
     pip install "cryptography>=1.3.4,<=3.1.1"
-
 
 ### Feature Management Access
 


### PR DESCRIPTION
Summary
-------
Unit tests on Python pypy and pypy3 have been failing consistently for quite some time. On detailed investigation, cryptography package is required by the requests[security] module. Although the latest cryptography version does support pypy, it doesn't build for some reason. 

Setting cryptography package to a static previous version revealed that Python 3.4 support has been dropped after cryptography 2.8.  

Therefore, instead of modifying requirements file, we install the correct working version of cryptography in before_install phase of pyp build. 


Test plan
---------
All checks continue to pass. 

Issues
------
