### PR TITLE
avoid b' in get_datafile

### DIFF
--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -13,6 +13,8 @@
 
 import json
 
+import six
+
 from .helpers import condition as condition_helper
 from .helpers import enums
 from . import entities
@@ -40,7 +42,7 @@ class ProjectConfig(object):
         """
 
         config = json.loads(datafile)
-        self._datafile = u'{}'.format(datafile)
+        self._datafile = six.ensure_text(datafile)
         self.logger = logger
         self.error_handler = error_handler
         self.version = config.get('version')


### PR DESCRIPTION
Summary
-------

- get_datafile feature is limited to Python 2. When Py 2 is used to fetch the datafile using get_datafile() the returned datafile is unicode string.
- When Py 3 is used, the get_datafile() method returns 'bytes' type, a binary string), not a regular text. This requires extra encoding to convert. The patchmakes datafile json string compatible with both Py2 and Py3.
- ProjectConfig's __init__ sets self._datafile = u'{}'.format(datafile) but the next line does self._datafile = u'{}'.format(datafile)
- [PS: bytes/unicode mixups happen a lot when porting py2 code to py3]


Test plan
---------
- fix to be tested in both Py2 and Py3.


Issues
------

-  “THING-1234” or “Fixes #123”
