### PR TITLE
ISSUE-326 Expose request timeout configuration for retrieving datafile

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -184,6 +184,8 @@ class PollingConfigManager(StaticConfigManager):
             skip_json_validation: Optional boolean param which allows skipping JSON schema
                                   validation upon object invocation. By default
                                   JSON schema validation will be performed.
+            request_timeout: Optional Time in seconds to block the fetch_datafile call
+                             until datafile object retrieved.
 
         """
         self._config_ready_event = threading.Event()

--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -172,9 +172,9 @@ class PollingConfigManager(StaticConfigManager):
             sdk_key: Optional string uniquely identifying the datafile.
             datafile: Optional JSON string representing the project.
             update_interval: Optional floating point number representing time interval in seconds
-                             at which to request datafile and set ProjectConfig.
+                             at which to request datafile and set ProjectConfig. (Default is 300 secs)
             blocking_timeout: Optional Time in seconds to block the get_config call until config object
-                              has been initialized.
+                              has been initialized. (Default is 10 secs)
             url: Optional string representing URL from where to fetch the datafile. If set it supersedes the sdk_key.
             url_template: Optional string template which in conjunction with sdk_key
                           determines URL from where to fetch the datafile.
@@ -185,7 +185,7 @@ class PollingConfigManager(StaticConfigManager):
                                   validation upon object invocation. By default
                                   JSON schema validation will be performed.
             request_timeout: Optional Time in seconds to block the fetch_datafile call
-                             until datafile object retrieved.
+                             until datafile object retrieved. (Default is 10 secs)
 
         """
         self._config_ready_event = threading.Event()

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -65,7 +65,7 @@ class ConfigManager(object):
     # Default config update interval of 5 minutes
     DEFAULT_UPDATE_INTERVAL = 5 * 60
     # Time in seconds before which request for datafile times out
-    REQUEST_TIMEOUT = 10
+    DEFAULT_REQUEST_TIMEOUT = 10
 
 
 class ControlAttributes(object):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -350,6 +350,37 @@ class PollingConfigManagerTest(base.BaseTest):
         project_config_manager.set_blocking_timeout(5)
         self.assertEqual(5, project_config_manager.blocking_timeout)
 
+    def test_set_request_timeout(self, _):
+        """ Test set_request_timeout with different inputs. """
+        with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
+            project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
+
+        # Assert that if invalid request_timeout is set, then exception is raised.
+        with self.assertRaisesRegexp(
+            optimizely_exceptions.InvalidInputException, 'Invalid request timeout "invalid timeout" provided.',
+        ):
+            project_config_manager.set_request_timeout('invalid timeout')
+
+        # Assert that request_timeout cannot be set to less than allowed minimum and instead is set to default value.
+        project_config_manager.set_request_timeout(-4)
+        self.assertEqual(
+            enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT, project_config_manager.request_timeout,
+        )
+
+        # Assert that request_timeout can be set to 0.
+        project_config_manager.set_request_timeout(0)
+        self.assertIs(0, project_config_manager.request_timeout)
+
+        # Assert that if no request_timeout is provided, it is set to default value.
+        project_config_manager.set_request_timeout(None)
+        self.assertEqual(
+            enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT, project_config_manager.request_timeout,
+        )
+
+        # Assert that if valid request_timeout is provided, it is set to that value.
+        project_config_manager.set_request_timeout(5)
+        self.assertEqual(5, project_config_manager.request_timeout)
+
     def test_set_last_modified(self, _):
         """ Test that set_last_modified sets last_modified field based on header. """
         with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
@@ -388,7 +419,7 @@ class PollingConfigManagerTest(base.BaseTest):
         mock_requests.assert_called_once_with(
             expected_datafile_url,
             headers={'If-Modified-Since': test_headers['Last-Modified']},
-            timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            timeout=enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT,
         )
         self.assertEqual(test_headers['Last-Modified'], project_config_manager.last_modified)
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)
@@ -424,7 +455,7 @@ class PollingConfigManagerTest(base.BaseTest):
         mock_requests.assert_called_once_with(
             expected_datafile_url,
             headers={'If-Modified-Since': test_headers['Last-Modified']},
-            timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            timeout=enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT,
         )
         mock_logger.error.assert_called_once_with('Fetching datafile from {} failed. Error: Error Error !!'.format(
             expected_datafile_url
@@ -463,7 +494,7 @@ class PollingConfigManagerTest(base.BaseTest):
         mock_requests.assert_called_once_with(
             expected_datafile_url,
             headers={'If-Modified-Since': test_headers['Last-Modified']},
-            timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            timeout=enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT,
         )
         mock_logger.error.assert_called_once_with('Fetching datafile from {} failed. Error: Error Error !!'.format(
             expected_datafile_url
@@ -527,7 +558,7 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
             expected_datafile_url,
             headers={'Authorization': 'Bearer {datafile_access_token}'.format(
                 datafile_access_token=datafile_access_token)},
-            timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            timeout=enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT,
         )
 
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)
@@ -558,7 +589,7 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
             expected_datafile_url,
             headers={'Authorization': 'Bearer {datafile_access_token}'.format(
                 datafile_access_token=datafile_access_token)},
-            timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            timeout=enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT,
         )
 
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)
@@ -577,7 +608,7 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
                 'Authorization': 'Bearer {datafile_access_token}'.format(
                     datafile_access_token=datafile_access_token),
             },
-            timeout=enums.ConfigManager.REQUEST_TIMEOUT,
+            timeout=enums.ConfigManager.DEFAULT_REQUEST_TIMEOUT,
         )
         mock_logger.error.assert_called_once_with('Fetching datafile from {} failed. Error: Error Error !!'.format(
             expected_datafile_url


### PR DESCRIPTION
Summary
-------

-  Offer the ability to customise request timeout in ConfigManager.

To have a more predictable duration on experiment variant retrieval duration.

Test plan
---------
Same mimic'd test from blocking_timeout

Fixes #326
