### PR TITLE
[OASIS-7552] fix: update requests library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,10 @@ would be:
 ### Contributing
 
 Please see [CONTRIBUTING](https://github.com/optimizely/python-sdk/blob/master/CONTRIBUTING.md).
+
+### Additional Code
+This software incorporates code from the following open source repos:  
+requests (Apache-2.0 License: https://github.com/psf/requests/blob/master/LICENSE)  
+pyOpenSSL (Apache-2.0 License https://github.com/pyca/pyopenssl/blob/main/LICENSE)  
+cryptography (Apache-2.0 https://github.com/pyca/cryptography/blob/main/LICENSE.APACHE)  
+idna (BSD 3-Clause License https://github.com/kjd/idna/blob/master/LICENSE.md) 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,6 +2,6 @@ jsonschema==3.2.0
 pyrsistent==0.14.0
 mmh3==2.5.1
 requests>=2.21
-pyOpenSSL>=19.1.0           # lates ot greater
-cryptography>=2.8.0      # latest or gerater - >check - we have special import - see readme page. for PyPy, PyPy3. Can we use the latest version for non PyPy?
-idna>=2.10                # latest or gerater
+pyOpenSSL>=19.1.0
+cryptography>=2.8.0
+idna>=2.10

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,7 @@
 jsonschema==3.2.0
 pyrsistent==0.14.0
 mmh3==2.5.1
-requests[security]>=2.9.1
+requests>=2.25
+pyOpenSSL>=20.0.1           # lates ot greater
+cryptography>=3.4.7      # latest or gerater - >check - we have special import - see readme page. for PyPy, PyPy3. Can we use the latest version for non PyPy?
+idna>=3.1                # latest or gerater

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -3,5 +3,5 @@ pyrsistent==0.14.0
 mmh3==2.5.1
 requests>=2.21
 pyOpenSSL>=19.1.0           # lates ot greater
-cryptography>=3.2.1      # latest or gerater - >check - we have special import - see readme page. for PyPy, PyPy3. Can we use the latest version for non PyPy?
+cryptography>=2.8.0      # latest or gerater - >check - we have special import - see readme page. for PyPy, PyPy3. Can we use the latest version for non PyPy?
 idna>=2.10                # latest or gerater

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,6 +2,6 @@ jsonschema==3.2.0
 pyrsistent==0.14.0
 mmh3==2.5.1
 requests>=2.21
-pyOpenSSL>=20.0.1           # lates ot greater
+pyOpenSSL>=19.1.0           # lates ot greater
 cryptography>=3.2.1      # latest or gerater - >check - we have special import - see readme page. for PyPy, PyPy3. Can we use the latest version for non PyPy?
-idna>=3.1                # latest or gerater
+idna>=2.10                # latest or gerater

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,7 +1,7 @@
 jsonschema==3.2.0
 pyrsistent==0.14.0
 mmh3==2.5.1
-requests>=2.25
+requests>=2.21
 pyOpenSSL>=20.0.1           # lates ot greater
-cryptography>=3.4.7      # latest or gerater - >check - we have special import - see readme page. for PyPy, PyPy3. Can we use the latest version for non PyPy?
+cryptography>=3.2.1      # latest or gerater - >check - we have special import - see readme page. for PyPy, PyPy3. Can we use the latest version for non PyPy?
 idna>=3.1                # latest or gerater


### PR DESCRIPTION
Summary
-------

- breaking down module requests[security] into its libraries because requests[security] will no longer be supported with requests version 2.26.
- I unpacked it into libraries: requests, pyOpenSSL, cryptography, idna. Looked for highest versions that work on all Py versions in the SDK (common denominator that works across all Py versions that we support in our SDK)

The “why”, or other context.

Test plan
---------
- FSC compatibility tests passing

Issues
------

-  https://optimizely.atlassian.net/browse/OASIS-7552
