### PR TITLE
[MAINTENANCE] Remove Deprecated warnings during build

### DIFF
--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -120,7 +120,7 @@ class BatchEventProcessor(BaseEventProcessor):
     @property
     def is_running(self):
         """ Property to check if consumer thread is alive or not. """
-        return self.executor.isAlive() if self.executor else False
+        return self.executor.is_alive() if self.executor else False
 
     def _validate_instantiation_props(self, prop, prop_name, default_value):
         """ Method to determine if instantiation properties like batch_size, flush_interval

--- a/tests/base.py
+++ b/tests/base.py
@@ -22,6 +22,12 @@ if PY3:
     def long(a):
         raise NotImplementedError('Tests should only call `long` if running in PY2')
 
+# Check to verify if TestCase has the attribute assertRasesRegex or assertRaisesRegexp
+# This check depends on the version of python with assertRaisesRegexp being used by 
+# python2.7. Later versions of python are using the non-deprecated assertRaisesRegex.
+if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
+    unittest.TestCase.assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegexp')
+
 
 class BaseTest(unittest.TestCase):
     def assertStrictTrue(self, to_assert):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1117,7 +1117,7 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_experiment_from_key__invalid_key(self):
         """ Test that exception is raised when provided experiment key is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidExperimentException,
             enums.Errors.INVALID_EXPERIMENT_KEY,
             self.project_config.get_experiment_from_key,
@@ -1127,14 +1127,14 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_audience__invalid_id(self):
         """ Test that message is logged when provided audience ID is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidAudienceException, enums.Errors.INVALID_AUDIENCE, self.project_config.get_audience, '42',
         )
 
     def test_get_variation_from_key__invalid_experiment_key(self):
         """ Test that exception is raised when provided experiment key is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidExperimentException,
             enums.Errors.INVALID_EXPERIMENT_KEY,
             self.project_config.get_variation_from_key,
@@ -1145,7 +1145,7 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_variation_from_key__invalid_variation_key(self):
         """ Test that exception is raised when provided variation key is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidVariationException,
             enums.Errors.INVALID_VARIATION,
             self.project_config.get_variation_from_key,
@@ -1156,7 +1156,7 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_variation_from_id__invalid_experiment_key(self):
         """ Test that exception is raised when provided experiment key is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidExperimentException,
             enums.Errors.INVALID_EXPERIMENT_KEY,
             self.project_config.get_variation_from_id,
@@ -1167,7 +1167,7 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_variation_from_id__invalid_variation_id(self):
         """ Test that exception is raised when provided variation ID is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidVariationException,
             enums.Errors.INVALID_VARIATION,
             self.project_config.get_variation_from_key,
@@ -1178,7 +1178,7 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_event__invalid_key(self):
         """ Test that exception is raised when provided event key is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidEventException,
             enums.Errors.INVALID_EVENT_KEY,
             self.project_config.get_event,
@@ -1188,7 +1188,7 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_attribute_id__invalid_key(self):
         """ Test that exception is raised when provided attribute key is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidAttributeException,
             enums.Errors.INVALID_ATTRIBUTE,
             self.project_config.get_attribute_id,
@@ -1198,7 +1198,7 @@ class ConfigExceptionTest(base.BaseTest):
     def test_get_group__invalid_id(self):
         """ Test that exception is raised when provided group ID is invalid. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidGroupException, enums.Errors.INVALID_GROUP_ID, self.project_config.get_group, '42',
         )
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -32,7 +32,7 @@ class StaticConfigManagerTest(base.BaseTest):
         class InvalidLogger(object):
             pass
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException, 'Provided "logger" is in an invalid format.',
         ):
             config_manager.StaticConfigManager(logger=InvalidLogger())
@@ -43,7 +43,7 @@ class StaticConfigManagerTest(base.BaseTest):
         class InvalidErrorHandler(object):
             pass
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException, 'Provided "error_handler" is in an invalid format.',
         ):
             config_manager.StaticConfigManager(error_handler=InvalidErrorHandler())
@@ -54,7 +54,7 @@ class StaticConfigManagerTest(base.BaseTest):
         class InvalidNotificationCenter(object):
             pass
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException, 'Provided "notification_center" is in an invalid format.',
         ):
             config_manager.StaticConfigManager(notification_center=InvalidNotificationCenter())
@@ -222,7 +222,7 @@ class StaticConfigManagerTest(base.BaseTest):
 class PollingConfigManagerTest(base.BaseTest):
     def test_init__no_sdk_key_no_url__fails(self, _):
         """ Test that initialization fails if there is no sdk_key or url provided. """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException,
             'Must provide at least one of sdk_key or url.',
             config_manager.PollingConfigManager,
@@ -232,7 +232,7 @@ class PollingConfigManagerTest(base.BaseTest):
 
     def test_get_datafile_url__no_sdk_key_no_url_raises(self, _):
         """ Test that get_datafile_url raises exception if no sdk_key or url is provided. """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException,
             'Must provide at least one of sdk_key or url.',
             config_manager.PollingConfigManager.get_datafile_url,
@@ -244,7 +244,7 @@ class PollingConfigManagerTest(base.BaseTest):
     def test_get_datafile_url__invalid_url_template_raises(self, _):
         """ Test that get_datafile_url raises if url_template is invalid. """
         # No url_template provided
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException,
             'Invalid url_template None provided',
             config_manager.PollingConfigManager.get_datafile_url,
@@ -255,7 +255,7 @@ class PollingConfigManagerTest(base.BaseTest):
 
         # Incorrect url_template provided
         test_url_template = 'invalid_url_template_without_sdk_key_field_{key}'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException,
             'Invalid url_template {} provided'.format(test_url_template),
             config_manager.PollingConfigManager.get_datafile_url,
@@ -298,7 +298,7 @@ class PollingConfigManagerTest(base.BaseTest):
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         # Assert that if invalid update_interval is set, then exception is raised.
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException, 'Invalid update_interval "invalid interval" provided.',
         ):
             project_config_manager.set_update_interval('invalid interval')
@@ -325,7 +325,7 @@ class PollingConfigManagerTest(base.BaseTest):
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         # Assert that if invalid blocking_timeout is set, then exception is raised.
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException, 'Invalid blocking timeout "invalid timeout" provided.',
         ):
             project_config_manager.set_blocking_timeout('invalid timeout')
@@ -484,7 +484,7 @@ class PollingConfigManagerTest(base.BaseTest):
 class AuthDatafilePollingConfigManagerTest(base.BaseTest):
     def test_init__datafile_access_token_none__fails(self, _):
         """ Test that initialization fails if datafile_access_token is None. """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException,
             'datafile_access_token cannot be empty or None.',
             config_manager.AuthDatafilePollingConfigManager,

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -4633,7 +4633,7 @@ class OptimizelyWithExceptionTest(base.BaseTest):
     def test_activate__with_attributes__invalid_attributes(self):
         """ Test that activate raises exception if attributes are in invalid format. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidAttributeException,
             enums.Errors.INVALID_ATTRIBUTE_FORMAT,
             self.optimizely.activate,
@@ -4645,7 +4645,7 @@ class OptimizelyWithExceptionTest(base.BaseTest):
     def test_track__with_attributes__invalid_attributes(self):
         """ Test that track raises exception if attributes are in invalid format. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidAttributeException,
             enums.Errors.INVALID_ATTRIBUTE_FORMAT,
             self.optimizely.track,
@@ -4657,7 +4657,7 @@ class OptimizelyWithExceptionTest(base.BaseTest):
     def test_track__with_event_tag__invalid_event_tag(self):
         """ Test that track raises exception if event_tag is in invalid format. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidEventTagException,
             enums.Errors.INVALID_EVENT_TAG_FORMAT,
             self.optimizely.track,
@@ -4669,7 +4669,7 @@ class OptimizelyWithExceptionTest(base.BaseTest):
     def test_get_variation__with_attributes__invalid_attributes(self):
         """ Test that get variation raises exception if attributes are in invalid format. """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidAttributeException,
             enums.Errors.INVALID_ATTRIBUTE_FORMAT,
             self.optimizely.get_variation,

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -759,7 +759,7 @@ class UserContextTest(base.BaseTest):
             'User "test_user" is in variation "control" of experiment test_experiment.'
         ]
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)
 
     def test_decide__option__include_reasons__feature_rollout(self):
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_features))
@@ -775,7 +775,7 @@ class UserContextTest(base.BaseTest):
             'User "test_user" is in the traffic group of targeting rule 1.'
         ]
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)
 
     def test_decide__option__enabled_flags_only(self):
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_features))
@@ -1135,7 +1135,7 @@ class UserContextTest(base.BaseTest):
             'Bucketed into an empty traffic range. Returning nil.'
         ]
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)
 
     def test_decide_reasons__hit_everyone_else_rule(self):
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_features))
@@ -1156,7 +1156,7 @@ class UserContextTest(base.BaseTest):
             'User "abcde" meets conditions for targeting rule "Everyone Else".'
         ]
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)
 
     def test_decide_reasons__hit_rule2__fails_bucketing(self):
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_features))
@@ -1179,7 +1179,7 @@ class UserContextTest(base.BaseTest):
             'Bucketed into an empty traffic range. Returning nil.'
         ]
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)
 
     def test_decide_reasons__hit_user_profile_service(self):
         user_id = 'test_user'
@@ -1215,7 +1215,7 @@ class UserContextTest(base.BaseTest):
         expected_reasons = [('Returning previously activated variation ID "control" of experiment '
                              '"test_experiment" for user "test_user" from user profile.')]
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)
 
     def test_decide_reasons__forced_variation(self):
         user_id = 'test_user'
@@ -1232,7 +1232,7 @@ class UserContextTest(base.BaseTest):
         expected_reasons = [('Variation "control" is mapped to experiment '
                              '"test_experiment" and user "test_user" in the forced variation map')]
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)
 
     def test_decide_reasons__whitelisted_variation(self):
         user_id = 'user_1'
@@ -1246,4 +1246,4 @@ class UserContextTest(base.BaseTest):
 
         expected_reasons = ['User "user_1" is forced in variation "control".']
 
-        self.assertEquals(expected_reasons, actual.reasons)
+        self.assertEqual(expected_reasons, actual.reasons)


### PR DESCRIPTION
Summary
-------
	- assertRaisesRegexp -> assertRaisesRegex
	- assertEquals -> assertEqual
	- isAlive() -> is_alive()
	- Check added to base.py to confirm attribute assertRaisesRegex for backwards compatibility to Python2.7

Test plan
---------

Compatibility test ran through PR
