### PR TITLE
[OASIS-7808] Upgrade pyrsistent to 0.16.0 to match monolith

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
 jsonschema==3.2.0
-pyrsistent==0.14.0
+pyrsistent==0.16.0
 mmh3==2.5.1
 requests>=2.21
 pyOpenSSL>=19.1.0


### PR DESCRIPTION
Summary
-------

-  Upgrading Py SDK for dogfooding in the monolith. Part of that is upgrading Pyrsistent lib because the version mismatch causes MOnolith to not start.
- So Pyrsistent in Py SDK importer in monolith and Pyrsistent used in the monolith itself need to match.


Test plan
---------

Issues
------

-  https://optimizely.atlassian.net/browse/OASIS-7808
