### PR TITLE
Chore(release): Prepare for v3.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ July 14th, 2021
 
 ### Bug Fixes:
 * Fixed issue with serving incorrect variation in projects containing multiple flags with duplicate keys. [#347] (https://github.com/optimizely/python-sdk/pull/347)
+* Fixed issue with serving incorrect variation in create_impression_event in user_event_factory.py. [#350] (https://github.com/optimizely/python-sdk/pull/350)
 
 ## 3.9.0
 June 1st, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Optimizely Python SDK Changelog
 
+## 3.9.1
+July 14th, 2021
+
+### Bug Fixes:
+* Fixed issue with serving incorrect variation in projects containing multiple flags with duplicate keys. [#347] (https://github.com/optimizely/python-sdk/pull/347)
+
 ## 3.9.0
 June 1st, 2021
 
 ### New Features
 * Added support for multiple concurrent prioritized experiments per flag. [#322](https://github.com/optimizely/python-sdk/pull/322)
-
 
 ## 3.8.0
 February 12th, 2021

--- a/optimizely/version.py
+++ b/optimizely/version.py
@@ -11,5 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (3, 9, 0)
+version_info = (3, 9, 1)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
Summary
-------

-  Update Changelog to reflect Buxfix
-  Update version to 3.9.1

Preparing for release v3.9.1

Test plan
---------
-  FSC Suite

Issues
------

Bugfix - Fixed issue with serving incorrect variation in projects containing multiple flags with duplicate keys
