### PR TITLE
[OASIS-7864] fix: update log level from debug to warning

### DIFF
--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -259,7 +259,7 @@ class BatchEventProcessor(BaseEventProcessor):
         try:
             self.event_queue.put_nowait(user_event)
         except queue.Full:
-            self.logger.debug(
+            self.logger.warning(
                 'Payload not accepted by the queue. Current size: {}'.format(str(self.event_queue.qsize()))
             )
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,4 +5,3 @@ requests>=2.21
 pyOpenSSL>=19.1.0
 cryptography>=2.8.0
 idna>=2.10
-typing

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,3 +5,4 @@ requests>=2.21
 pyOpenSSL>=19.1.0
 cryptography>=2.8.0
 idna>=2.10
+typing

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -497,11 +497,9 @@ class BatchEventProcessorTest(base.BaseTest):
     def test_warning_log_level_on_queue_overflow(self):
         """ Test that a warning log is created when events overflow the queue. """
 
-        # create scenario where the batch size (MAX_BATCH_SIZE) is larger than the queue size
+        # create scenario where the batch size (MAX_BATCH_SIZE) is significantly larger than the queue size
         # use smaller batch size and higher timeout to avoid test flakiness
         test_max_queue_size = 2
-        self.MAX_BATCH_SIZE = self.MAX_BATCH_SIZE - 7
-        self.TEST_TIMEOUT = 1
 
         event_dispatcher = CustomEventDispatcher()
 

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -505,11 +505,11 @@ class BatchEventProcessorTest(base.BaseTest):
 
         with mock.patch.object(self.optimizely, 'logger') as mock_config_logging:
             self.event_processor = BatchEventProcessor(
-                    event_dispatcher,
-                    self.optimizely.logger,
-                    True,
-                    queue.Queue(maxsize=test_max_queue_size),
-                )
+                event_dispatcher,
+                self.optimizely.logger,
+                True,
+                queue.Queue(maxsize=test_max_queue_size),
+            )
 
         for i in range(0, self.MAX_BATCH_SIZE):
             user_event = self._build_conversion_event(self.event_name)

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -518,7 +518,7 @@ class BatchEventProcessorTest(base.BaseTest):
 
         time.sleep(self.TEST_TIMEOUT)
 
-        # queue is flushed, even though events overflew
+        # queue is flushed, even though events overflow
         self.assertEqual(0, self.event_processor.event_queue.qsize())
         mock_config_logging.warning.assert_called_with('Payload not accepted by the queue. Current size: {}'
                                                        .format(str(test_max_queue_size)))

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -500,6 +500,7 @@ class BatchEventProcessorTest(base.BaseTest):
         # create scenario where the batch size (MAX_BATCH_SIZE) is significantly larger than the queue size
         # use smaller batch size and higher timeout to avoid test flakiness
         test_max_queue_size = 2
+        self.MAX_BATCH_SIZE = 100
 
         event_dispatcher = CustomEventDispatcher()
 
@@ -510,6 +511,7 @@ class BatchEventProcessorTest(base.BaseTest):
                 True,
                 queue.Queue(maxsize=test_max_queue_size),
             )
+
 
         for i in range(0, self.MAX_BATCH_SIZE):
             user_event = self._build_conversion_event(self.event_name)

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -113,7 +113,6 @@ class CustomEventDispatcher(object):
 class BatchEventProcessorTest(base.BaseTest):
 
     DEFAULT_QUEUE_CAPACITY = 1000
-    # DEFAULT_QUEUE_CAPACITY = 5
     MAX_BATCH_SIZE = 10
     MAX_DURATION_SEC = 0.2
     MAX_TIMEOUT_INTERVAL_SEC = 0.1

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -499,8 +499,8 @@ class BatchEventProcessorTest(base.BaseTest):
 
         # create scenario where the batch size (MAX_BATCH_SIZE) is significantly larger than the queue size
         # use smaller batch size and higher timeout to avoid test flakiness
-        test_max_queue_size = 2
-        self.MAX_BATCH_SIZE = 100
+        test_max_queue_size = 10
+        self.MAX_BATCH_SIZE = 1000
 
         event_dispatcher = CustomEventDispatcher()
 

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -512,7 +512,6 @@ class BatchEventProcessorTest(base.BaseTest):
                 queue.Queue(maxsize=test_max_queue_size),
             )
 
-
         for i in range(0, self.MAX_BATCH_SIZE):
             user_event = self._build_conversion_event(self.event_name)
             self.event_processor.process(user_event)

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -497,8 +497,11 @@ class BatchEventProcessorTest(base.BaseTest):
     def test_warning_log_level_on_queue_overflow(self):
         """ Test that a warning log is created when events overflow the queue. """
 
-        # create scenario where the batch size (MAX_BATCH_SIZE=10) is larger than the queue size (7)
-        test_max_queue_size = 7
+        # create scenario where the batch size (MAX_BATCH_SIZE) is larger than the queue size
+        # use smaller batch size and higher timeout to avoid test flakiness
+        test_max_queue_size = 2
+        self.MAX_BATCH_SIZE = self.MAX_BATCH_SIZE - 7
+        self.TEST_TIMEOUT = 1
 
         event_dispatcher = CustomEventDispatcher()
 


### PR DESCRIPTION
Summary
-------

-  User reported issue on GitHub: https://github.com/optimizely/python-sdk/issues/352
-  events, dropped from the queue should be logged using a warning or error log level, not debug level

Test plan
---------
- add unit test
- manual reproduction of the issue, fix and manual verification of the fix
- unit tests to pass
- FSC tests to pass

Issues
------

-  https://optimizely.atlassian.net/browse/OASIS-7864
