### PR TITLE
[OASIS-7827] fix: make _get_time() value the same throughout the loop

### DIFF
--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -180,14 +180,15 @@ class BatchEventProcessor(BaseEventProcessor):
     """
         try:
             while True:
-                if self._get_time() >= self.flushing_interval_deadline:
+                loop_time = self._get_time()
+                if loop_time >= self.flushing_interval_deadline:
                     self._flush_batch()
                     self.flushing_interval_deadline = self._get_time() + \
                         self._get_time(self.flush_interval.total_seconds())
                     self.logger.debug('Flush interval deadline. Flushed batch.')
 
                 try:
-                    interval = self.flushing_interval_deadline - self._get_time()
+                    interval = self.flushing_interval_deadline - loop_time
                     item = self.event_queue.get(True, interval)
 
                     if item is None:

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -181,10 +181,11 @@ class BatchEventProcessor(BaseEventProcessor):
         try:
             while True:
                 loop_time = self._get_time()
+                loop_time_flush_interval = self._get_time(self.flush_interval.total_seconds())
+
                 if loop_time >= self.flushing_interval_deadline:
                     self._flush_batch()
-                    self.flushing_interval_deadline = self._get_time() + \
-                        self._get_time(self.flush_interval.total_seconds())
+                    self.flushing_interval_deadline = loop_time + loop_time_flush_interval
                     self.logger.debug('Flush interval deadline. Flushed batch.')
 
                 try:


### PR DESCRIPTION
Summary
-------

-  Running event processor would sometimes produce Buffer error with negative timeout interval for retrieving an event from the queue. Reported by a Github user (customer). See https://github.com/optimizely/python-sdk/issues/354 
- If the flushing_interval_deadline is between the first call of _get_time() and the second call of _get_time() then interval will be negative.

Test plan
---------
Unit tests for the _run() function where the change is made already extensively cover the _run() and event processor functionality. 
The change itself should prevent negative interval from occurring. To test that a larger load test would be required. 

Issues
------
-  https://optimizely.atlassian.net/browse/OASIS-7872
