### PR TITLE
ISSUE-232---drop-mmh3-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ To install:
 Note:  
 - If you are running the SDK with PyPy or PyPy3 and you are experiencing issues, install this cryptography package **first** and then optimizely-sdk package:  
 
-    pip install "cryptography>=1.3.4,<=3.1.1"
+    ```pip install "cryptography>=1.3.4,<=3.1.1"```
 
 
 - After v3.0.0 mmh3 is no longer a mandatory dependency to removed to remove the c++ build requirement.
 If you are experiencing (performance) problems, install this explicitly and it will continue to be honoured by code:
 
-     pip install "mmh3==2.5.1"
+     ```pip install "mmh3==2.5.1"```
 
 ### Feature Management Access
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ To install:
     pip install optimizely-sdk
 
 Note:  
-If you are running the SDK with PyPy or PyPy3 and you are experiencing issues, install this cryptography package **first** and then optimizely-sdk package:  
+- If you are running the SDK with PyPy or PyPy3 and you are experiencing issues, install this cryptography package **first** and then optimizely-sdk package:  
 
     pip install "cryptography>=1.3.4,<=3.1.1"
+
+
+- After v3.0.0 mmh3 is no longer a mandatory dependency to removed to remove the c++ build requirement.
+If you are experiencing (performance) problems, install this explicitly and it will continue to be honoured by code:
+
+     pip install "mmh3==2.5.1"
 
 ### Feature Management Access
 
@@ -230,4 +236,4 @@ This software incorporates code from the following open source repos:
 requests (Apache-2.0 License: https://github.com/psf/requests/blob/master/LICENSE)  
 pyOpenSSL (Apache-2.0 License https://github.com/pyca/pyopenssl/blob/main/LICENSE)  
 cryptography (Apache-2.0 https://github.com/pyca/cryptography/blob/main/LICENSE.APACHE)  
-idna (BSD 3-Clause License https://github.com/kjd/idna/blob/master/LICENSE.md) 
+idna (BSD 3-Clause License https://github.com/kjd/idna/blob/master/LICENSE.md)

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,6 +1,5 @@
 jsonschema==3.2.0
 pyrsistent==0.16.0
-mmh3==2.5.1
 requests>=2.21
 pyOpenSSL>=19.1.0
 cryptography>=2.8.0


### PR DESCRIPTION
Summary
-------
What:
This PR is to remove the mmh3 package dependency thus c++  requirement on the build environment. See discussion: in ISSUE-232, https://github.com/optimizely/python-sdk/issues/232#issue-542968370

Why:
Windows OS developers are having to install c++ in order to use the package. It would be ideal to keep the code extendible at the import level but optional by choice for those who need it. 

Test plan
---------

Issues
------

-  “Fixes #232”
