### PR TITLE
Bump up PyYaml to recommended version to remediate vulnerability - DROP PYTHON 3.4 SUPPORT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python 
 python:
   - "2.7"
-  - "3.4"
+#  - "3.4"
   - "3.5.5"
   - "3.6"
 # - "3.7" is handled in 'Test' job using xenial as Python 3.7 is not available for trusty.
@@ -15,12 +15,12 @@ after_success:
 
 # Linting and Integration tests need to run first to reset the PR build status to pending.
 stages:
-  - 'Test'
   - 'Source Clear'
   - 'Lint markdown files'
   - 'Linting'
   - 'Integration tests'
   - 'Full stack production tests'
+  - 'Test'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
 # - "3.8" is handled in 'Test' job using xenial as Python 3.8 is not available for trusty.
 #  - "pypy"
 #  - "pypy3"
-before_install:
-  - pip uninstall PyYaml
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ after_success:
 
 # Linting and Integration tests need to run first to reset the PR build status to pending.
 stages:
+  - 'Test'
   - 'Source Clear'
   - 'Lint markdown files'
   - 'Linting'
   - 'Integration tests'
   - 'Full stack production tests'
-  - 'Test'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 # - "3.8" is handled in 'Test' job using xenial as Python 3.8 is not available for trusty.
 #  - "pypy"
 #  - "pypy3"
+before_install:
+  - pip uninstall PyYaml
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
 after_success:

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,5 +2,5 @@ jsonschema==3.2.0
 pyrsistent==0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
-cryptography>=2.8.0
+cryptography>=3.4.8
 idna>=2.10

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,6 +1,6 @@
-jsonschema==4.1.0
+jsonschema==3.2.0
 pyrsistent==0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
-cryptography>=3.4.5
+cryptography>=2.8.0
 idna>=2.10

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
-jsonschema==3.2.0
+jsonschema==4.1.0
 pyrsistent==0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,5 +2,5 @@ jsonschema==3.2.0
 pyrsistent==0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
-cryptography>=3.4.8
+cryptography>=3.4.5
 idna>=2.10

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,4 @@ mock==1.3.0
 pytest>=4.6.0
 pytest-cov
 python-coveralls
-pyyaml==5.2
+pyyaml>=5.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,4 @@ mock==1.3.0
 pytest>=4.6.0
 pytest-cov
 python-coveralls
-pyyaml>=5.4
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,4 @@ mock==1.3.0
 pytest>=4.6.0
 pytest-cov
 python-coveralls
-
+pyyaml>=5.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,4 @@ mock==1.3.0
 pytest>=4.6.0
 pytest-cov
 python-coveralls
-pyyaml>=5.4
+PyYAML>=5.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,4 @@ mock==1.3.0
 pytest>=4.6.0
 pytest-cov
 python-coveralls
-PyYAML>=5.3.1
+pyyaml>=5.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,4 @@ mock==1.3.0
 pytest>=4.6.0
 pytest-cov
 python-coveralls
-PyYAML>=5.4
+PyYAML>=5.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,5 +3,3 @@ flake8==3.6.0
 funcsigs==0.4
 mock==1.3.0
 pytest>=4.6.0
-pytest-cov
-python-coveralls

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,5 @@ flake8==3.6.0
 funcsigs==0.4
 mock==1.3.0
 pytest>=4.6.0
+pytest-cov
+python-coveralls

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,3 @@ mock==1.3.0
 pytest>=4.6.0
 pytest-cov
 python-coveralls
-pyyaml>=5.4


### PR DESCRIPTION
Summary
-------

-  Removing PyYaml from SDK test.txt
-  Dropping  Python 3.4

Dependabot found critical vulnerability in this dependency and it is not needed in the SDK
Python 3.4 no longer supports required libraries to support new and existing features

Note: PyYaml was previously an explicit dependency, however PyYaml is also a transient dependency in python-coverals, which has already upgraded to the latest version of PyYaml. This version of PyYaml no longer supports Python version 3.4. For this reason we have chose to also drop Python 3.4, as we need to continue proper code coverage on our SDKs to ensure the highest quality of code.

Test plan
---------
- FSC

Issues
------

-  “OASIS-8054"
