### PR TITLE
chore: remove old py versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: python 
+dist: focal
+language: python
 python:
 #  - "2.7"
 #  - "3.4"
@@ -72,16 +73,12 @@ jobs:
       before_install:
         - pip install "cryptography>=1.3.4,<=3.1.1"
     - stage: 'Test'
-      dist: focal
       python: "3.7"
     - stage: 'Test'
-      dist: focal
       python: "3.8"
     - stage: 'Test'
-      dist: focal
       python: "3.9"
     - stage: 'Test'
-      dist: focal
       python: "3.10"
 
     - stage: 'Source Clear'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: focal
 language: python
 python:
-  - "pypy3"
+  - "pypy3.7-7.3.5"
   - "3.7"
   - "3.8"
   - "3.9"
@@ -61,7 +61,7 @@ jobs:
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
         FULLSTACK_TEST_REPO=ProdTesting
     - stage: 'Test'
-      python: "pypy3"
+      python: "pypy3.7-7.3.5"
       before_install:
         - pip install "cryptography>=1.3.4,<=3.1.1"
     - stage: 'Test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-#  - "3.10"
-before_install:
-  - python -m pip install --upgrade pip
+  - "3.10"
+before_install: "python -m pip install --upgrade pip"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
 after_success:
@@ -69,10 +68,9 @@ jobs:
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
         FULLSTACK_TEST_REPO=ProdTesting
     - stage: 'Test'
-      python: "pypy3.7-7.3.5"
+      python: "pypy3"
       before_install:
-#        - pip install "cryptography>=1.3.4,<=3.1.1"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
-        - pip install "cryptography>=1.3.4"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
+        - pip install "cryptography>=1.3.4,<=3.1.1"
     - stage: 'Test'
       dist: focal
       python: "3.7"
@@ -82,9 +80,9 @@ jobs:
     - stage: 'Test'
       dist: focal
       python: "3.9"
-#    - stage: 'Test'
-#      dist: focal
-#      python: "3.10"
+    - stage: 'Test'
+      dist: focal
+      python: "3.10"
 
     - stage: 'Source Clear'
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,9 @@ jobs:
 
     - stage: 'Linting'
       language: python
-#      python: "2.7"
       python: "3.9"
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
-#      install: "pip install flake8==3.6.0"
       install: "pip install flake8>=3.6.0"
       script: "flake8"
       after_success: travis_terminate 0
@@ -68,14 +66,11 @@ jobs:
         SDK=python
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
         FULLSTACK_TEST_REPO=ProdTesting
-#    - stage: 'Test'
-#      python: "pypy"
-#      before_install:
-#        - pip install "cryptography>=1.3.4,<=3.1.1" # installing in before_install doesn't re-install the latest version of the same package in the next stage.
     - stage: 'Test'
       python: "pypy3"
       before_install:
-        - pip install "cryptography>=1.3.4,<=3.1.1"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
+#        - pip install "cryptography>=1.3.4,<=3.1.1"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
+        - pip install "cryptography>=1.3.4"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
     - stage: 'Test'
       dist: xenial
       python: "3.7"
@@ -85,9 +80,9 @@ jobs:
     - stage: 'Test'
       dist: xenial
       python: "3.9"
-    - stage: 'Test'
-      dist: xenial
-      python: "3.10"
+#    - stage: 'Test'
+#      dist: xenial
+#      python: "3.10"
 
     - stage: 'Source Clear'
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10"
+#  - "3.10"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
 
     - stage: 'Linting'
       language: python
-      python: "3.9"
+      python: "3.9.0"
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
       install: "pip install flake8>=3.6.0"
@@ -79,7 +79,7 @@ jobs:
     - stage: 'Test'
       python: "3.9"
     - stage: 'Test'
-      python: "3.10"
+      python: "3.10.0"
 
     - stage: 'Source Clear'
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       python: "3.9"
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
-      install: "pip install flake8>=3.6.0"
+      install: "pip install flake8>=4.1.0"
       script: "flake8"
       after_success: travis_terminate 0
     
@@ -62,8 +62,8 @@ jobs:
         FULLSTACK_TEST_REPO=ProdTesting
     - stage: 'Test'
       python: "pypy3.7-7.3.5"
-      before_install:
-        - pip install "cryptography>=1.3.4"
+#      before_install:
+#        - pip install "cryptography>=1.3.4"
     - stage: 'Test'
       python: "3.7"
     - stage: 'Test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: python 
 python:
-  - "2.7"
+#  - "2.7"
 #  - "3.4"
-  - "3.5.5"
-  - "3.6"
+#  - "3.5.5"
+#  - "3.6"
 # - "3.7" is handled in 'Test' job using xenial as Python 3.7 is not available for trusty.
 # - "3.8" is handled in 'Test' job using xenial as Python 3.8 is not available for trusty.
 #  - "pypy"
 #  - "pypy3"
+  - "pypy3"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
 after_success:
@@ -35,10 +40,12 @@ jobs:
 
     - stage: 'Linting'
       language: python
-      python: "2.7"
+#      python: "2.7"
+      python: "3.9"
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
-      install: "pip install flake8==3.6.0" 
+#      install: "pip install flake8==3.6.0"
+      install: "pip install flake8>=3.6.0"
       script: "flake8"
       after_success: travis_terminate 0
     
@@ -61,20 +68,26 @@ jobs:
         SDK=python
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
         FULLSTACK_TEST_REPO=ProdTesting
-    - stage: 'Test'
-      python: "pypy"
-      before_install:
-        - pip install "cryptography>=1.3.4,<=3.1.1" # installing in before_install doesn't re-install the latest version of the same package in the next stage.
+#    - stage: 'Test'
+#      python: "pypy"
+#      before_install:
+#        - pip install "cryptography>=1.3.4,<=3.1.1" # installing in before_install doesn't re-install the latest version of the same package in the next stage.
     - stage: 'Test'
       python: "pypy3"
       before_install:
-        - pip install "cryptography>=1.3.4,<=3.1.1"
+        - pip install "cryptography>=1.3.4,<=3.1.1"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
     - stage: 'Test'
       dist: xenial
       python: "3.7"
     - stage: 'Test'
       dist: xenial
       python: "3.8"
+    - stage: 'Test'
+      dist: xenial
+      python: "3.9"
+    - stage: 'Test'
+      dist: xenial
+      python: "3.10"
 
     - stage: 'Source Clear'
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,11 @@
 dist: focal
 language: python
 python:
-#  - "2.7"
-#  - "3.4"
-#  - "3.5.5"
-#  - "3.6"
-# - "3.7" is handled in 'Test' job using xenial as Python 3.7 is not available for trusty.
-# - "3.8" is handled in 'Test' job using xenial as Python 3.8 is not available for trusty.
-#  - "pypy"
-#  - "pypy3"
   - "pypy3"
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10"
+  - "3.10.0"
 before_install: "python -m pip install --upgrade pip"
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
@@ -42,7 +34,7 @@ jobs:
 
     - stage: 'Linting'
       language: python
-      python: "3.9.0"
+      python: "3.9"
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
       install: "pip install flake8>=3.6.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
     - stage: 'Test'
       python: "pypy3.7-7.3.5"
       before_install:
-        - pip install "cryptography>=1.3.4,<=3.1.1"
+        - pip install "cryptography>=1.3.4"
     - stage: 'Test'
       python: "3.7"
     - stage: 'Test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ python:
   - "3.8"
   - "3.9"
 #  - "3.10"
+before_install:
+  - python -m pip install --upgrade pip
 install: "pip install -r requirements/core.txt;pip install -r requirements/test.txt"
 script: "pytest --cov=optimizely"
 after_success:
@@ -67,21 +69,21 @@ jobs:
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
         FULLSTACK_TEST_REPO=ProdTesting
     - stage: 'Test'
-      python: "pypy3"
+      python: "pypy3.7-7.3.5"
       before_install:
 #        - pip install "cryptography>=1.3.4,<=3.1.1"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
         - pip install "cryptography>=1.3.4"     # TODO: check if these versions can now be simplified - remove upper boundary <=3.1.1?
     - stage: 'Test'
-      dist: xenial
+      dist: focal
       python: "3.7"
     - stage: 'Test'
-      dist: xenial
+      dist: focal
       python: "3.8"
     - stage: 'Test'
-      dist: xenial
+      dist: focal
       python: "3.9"
 #    - stage: 'Test'
-#      dist: xenial
+#      dist: focal
 #      python: "3.10"
 
     - stage: 'Source Clear'

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,6 +2,6 @@ jsonschema>=3.2.0
 pyrsistent>=0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
-cryptography>=2.8.0
+cryptography>=2.8.0,<=3.1.1
 idna>=2.10
 six>=1.12.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
-jsonschema>=3.2.0,<=4.0.1
-pyrsistent>=0.16.0,<=0.17.3
+jsonschema>=3.2.0
+pyrsistent>=0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
 cryptography>=2.8.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
-jsonschema==3.2.0
-pyrsistent==0.16.0
+jsonschema>=3.2.0
+pyrsistent>=0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
 cryptography>=2.8.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
-jsonschema>=3.2.0
-pyrsistent==0.16.0
+jsonschema>=3.2.0,<=4.01
+pyrsistent>=0.16.0,<=0.17.3
 requests>=2.21
 pyOpenSSL>=19.1.0
 cryptography>=2.8.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
-jsonschema>=3.2.0,<=4.01
+jsonschema>=3.2.0,<=4.0.1
 pyrsistent>=0.16.0,<=0.17.3
 requests>=2.21
 pyOpenSSL>=19.1.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
 jsonschema>=3.2.0
-pyrsistent>=0.16.0
+pyrsistent==0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
 cryptography>=2.8.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,6 +2,6 @@ jsonschema>=3.2.0
 pyrsistent>=0.16.0
 requests>=2.21
 pyOpenSSL>=19.1.0
-cryptography>=2.8.0,<=3.1.1
+cryptography>=2.8.0
 idna>=2.10
 six>=1.12.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 coverage
-flake8 >= 3.6.0
+flake8 >= 4.0.1
 funcsigs >= 0.4
-mock >= 1.3.0
-pytest >= 4.6.0
+mock >= 4.0.0
+pytest >= 6.2.0
 pytest-cov
 python-coveralls

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 coverage
-flake8==3.6.0
-funcsigs==0.4
-mock==1.3.0
-pytest>=4.6.0
+flake8 >= 3.6.0
+funcsigs >= 0.4
+mock >= 1.3.0
+pytest >= 4.6.0
 pytest-cov
 python-coveralls

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ about_text = (
     'Optimizely X Full Stack is A/B testing and feature management for product development teams. '
     'Experiment in any application. Make every feature on your roadmap an opportunity to learn. '
     'Learn more at https://www.optimizely.com/products/full-stack/ or see our documentation at '
-    'https://docs.developers.optimizely.com/full-stack/docs.'
+    'https://docs.developers.optimizely.com/full-stack/docs. '
 )
 
 setup(

--- a/tests/helpers_tests/test_condition.py
+++ b/tests/helpers_tests/test_condition.py
@@ -13,7 +13,6 @@
 
 import json
 import mock
-from six import PY2
 
 from optimizely.helpers import condition as condition_helper
 
@@ -394,13 +393,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
     def test_exact_int__returns_true__when_user_provided_value_is_equal_to_condition_value(self, ):
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                exact_int_condition_list, {'lasers_count': long(9000)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
             exact_int_condition_list, {'lasers_count': 9000}, self.mock_client_logger
         )
@@ -414,13 +406,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exact_float__returns_true__when_user_provided_value_is_equal_to_condition_value(self, ):
-
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                exact_float_condition_list, {'lasers_count': long(9000)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
             exact_float_condition_list, {'lasers_count': 9000}, self.mock_client_logger
@@ -599,13 +584,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                gt_int_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
     def test_greater_than_float__returns_true__when_user_value_greater_than_condition_value(self, ):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -619,13 +597,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
-
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                gt_float_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_greater_than_int__returns_false__when_user_value_not_greater_than_condition_value(self, ):
 
@@ -641,13 +612,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                gt_int_condition_list, {'meters_travelled': long(47)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
-
     def test_greater_than_float__returns_false__when_user_value_not_greater_than_condition_value(self, ):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -661,13 +625,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
-
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                gt_float_condition_list, {'meters_travelled': long(48)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_greater_than_int__returns_null__when_user_value_is_not_a_number(self):
 
@@ -733,13 +690,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                gt_int_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
     def test_greater_than_or_equal_float__returns_true__when_user_value_greater_than_or_equal_condition_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -760,13 +710,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                ge_float_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
     def test_greater_than_or_equal_int__returns_false__when_user_value_not_greater_than_or_equal_condition_value(
             self):
 
@@ -782,13 +725,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                ge_int_condition_list, {'meters_travelled': long(47)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
-
     def test_greater_than_or_equal_float__returns_false__when_user_value_not_greater_than_or_equal_condition_value(
             self):
 
@@ -803,13 +739,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
-
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                ge_float_condition_list, {'meters_travelled': long(48)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_greater_than_or_equal_int__returns_null__when_user_value_is_not_a_number(self):
 
@@ -869,13 +798,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                lt_int_condition_list, {'meters_travelled': long(47)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
     def test_less_than_float__returns_true__when_user_value_less_than_condition_value(self, ):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -889,13 +811,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
-
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                lt_float_condition_list, {'meters_travelled': long(48)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_less_than_int__returns_false__when_user_value_not_less_than_condition_value(self, ):
 
@@ -911,13 +826,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                lt_int_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
-
     def test_less_than_float__returns_false__when_user_value_not_less_than_condition_value(self, ):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -931,13 +839,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
-
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                lt_float_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_less_than_int__returns_null__when_user_value_is_not_a_number(self):
 
@@ -991,19 +892,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                le_int_condition_list, {'meters_travelled': long(47)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                le_int_condition_list, {'meters_travelled': long(48)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
     def test_less_than_or_equal_float__returns_true__when_user_value_less_than_or_equal_condition_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -1024,13 +912,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                le_float_condition_list, {'meters_travelled': long(48)}, self.mock_client_logger,
-            )
-
-            self.assertStrictTrue(evaluator.evaluate(0))
-
     def test_less_than_or_equal_int__returns_false__when_user_value_not_less_than_or_equal_condition_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -1045,13 +926,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                le_int_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
-
     def test_less_than_or_equal_float__returns_false__when_user_value_not_less_than_or_equal_condition_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
@@ -1065,13 +939,6 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
-
-        if PY2:
-            evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                le_float_condition_list, {'meters_travelled': long(49)}, self.mock_client_logger,
-            )
-
-            self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_less_than_or_equal_int__returns_null__when_user_value_is_not_a_number(self):
 

--- a/tests/helpers_tests/test_validator.py
+++ b/tests/helpers_tests/test_validator.py
@@ -14,8 +14,6 @@
 import json
 import mock
 
-from six import PY2
-
 from optimizely import config_manager
 from optimizely import error_handler
 from optimizely import event_dispatcher
@@ -230,12 +228,6 @@ class ValidatorTest(base.BaseTest):
 
         mock_is_finite.assert_called_once_with(5.5)
 
-        if PY2:
-            with mock.patch('optimizely.helpers.validator.is_finite_number', return_value=None) as mock_is_finite:
-                self.assertIsNone(validator.is_attribute_valid('test_attribute', long(5)))
-
-            mock_is_finite.assert_called_once_with(long(5))
-
     def test_is_finite_number(self):
         """ Test that it returns true if value is a number and not NAN, INF, -INF or greater than 2^53.
         Otherwise False.
@@ -257,9 +249,6 @@ class ValidatorTest(base.BaseTest):
         self.assertFalse(validator.is_finite_number(-int(2 ** 53) - 1))
         self.assertFalse(validator.is_finite_number(float(2 ** 53) + 2.0))
         self.assertFalse(validator.is_finite_number(-float(2 ** 53) - 2.0))
-        if PY2:
-            self.assertFalse(validator.is_finite_number(long(2 ** 53) + 1))
-            self.assertFalse(validator.is_finite_number(-long(2 ** 53) - 1))
 
         # test valid numbers
         self.assertTrue(validator.is_finite_number(0))
@@ -269,8 +258,6 @@ class ValidatorTest(base.BaseTest):
         self.assertTrue(validator.is_finite_number(float(2 ** 53) + 1.0))
         self.assertTrue(validator.is_finite_number(-float(2 ** 53) - 1.0))
         self.assertTrue(validator.is_finite_number(int(2 ** 53)))
-        if PY2:
-            self.assertTrue(validator.is_finite_number(long(2 ** 53)))
 
 
 class DatafileValidationTests(base.BaseTest):

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -15,6 +15,7 @@ import json
 from operator import itemgetter
 
 import mock
+import six
 
 from optimizely import config_manager
 from optimizely import decision_service
@@ -36,12 +37,12 @@ class OptimizelyTest(base.BaseTest):
     strTest = None
 
     try:
-        isinstance("test", basestring)  # attempt to evaluate basestring
+        isinstance("test", six.string_types)  # attempt to evaluate string
 
         _expected_notification_failure = 'Problem calling notify callback.'
 
         def isstr(self, s):
-            return isinstance(s, basestring)
+            return isinstance(s, six.string_types)
 
         strTest = isstr
 


### PR DESCRIPTION
Summary
-------

-  Old python versions for Py SDK are causing security risks and cap using more up to date library versions. This creates issues for customers. 
For example we removed Py v3.4 already because PyYaml library in Py 3.4 can only be less than v5.4 which doesn't have a necessary security patch that versions 5.4 and greater do.
Another example is customer issue [issue link here] that required more up to date jsonschema lib version. But we could not provide that up to date version because Py 2.7 and 3.5 were capping it. See issue [370](https://github.com/optimizely/python-sdk/issues/370)
These are all issues related to supporting older Py versions that only work with libraries up certain version number. So we get a discrepancy between which library versions old Py and new Py support. Then we decided to remove support for older py version in order to free up support for up to date libraries. 
- We're removing Py 2, 3.5, 3.6, PyPy2. These are fairly old, none of them are officially supported in most libraries.

Test plan
---------
Unit tests, FSC

Issues
------

-  [OASIS-8124](https://optimizely.atlassian.net/browse/OASIS-8124)
