### PR TITLE
enhancement: Generate OptimizelyConfig object on API Call instead of SDK initialization

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -130,7 +130,8 @@ class StaticConfigManager(BaseConfigManager):
             return
 
         self._config = config
-        self.optimizely_config = OptimizelyConfigService(config).get_config()
+        if self.optimizely_config is not None:
+            self.optimizely_config = OptimizelyConfigService(self._config).get_config()
         self.notification_center.send_notifications(enums.NotificationTypes.OPTIMIZELY_CONFIG_UPDATE)
         self.logger.debug(
             'Received new datafile and updated config. '
@@ -145,6 +146,12 @@ class StaticConfigManager(BaseConfigManager):
         """
 
         return self._config
+
+    def get_optimizely_config(self):
+        if self.optimizely_config is None:
+            self.optimizely_config = OptimizelyConfigService(self._config).get_config()
+
+        return self.optimizely_config
 
 
 class PollingConfigManager(StaticConfigManager):

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -944,7 +944,7 @@ class Optimizely(object):
 
         # Customized Config Manager may not have optimizely_config defined.
         if hasattr(self.config_manager, 'optimizely_config'):
-            return self.config_manager.optimizely_config
+            return self.config_manager.get_optimizely_config()
 
         return OptimizelyConfigService(project_config).get_config()
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -77,7 +77,7 @@ class StaticConfigManagerTest(base.BaseTest):
         mock_notification_center.send_notifications.assert_called_once_with('OPTIMIZELY_CONFIG_UPDATE')
 
         self.assertIsInstance(
-            project_config_manager.optimizely_config,
+            project_config_manager.get_optimizely_config(),
             optimizely_config.OptimizelyConfig
         )
 
@@ -99,7 +99,7 @@ class StaticConfigManagerTest(base.BaseTest):
         )
         self.assertEqual(1, mock_logger.debug.call_count)
         mock_notification_center.send_notifications.assert_called_once_with('OPTIMIZELY_CONFIG_UPDATE')
-        self.assertEqual(1, mock_opt_service.call_count)
+        self.assertEqual(0, mock_opt_service.call_count)
 
         mock_logger.reset_mock()
         mock_notification_center.reset_mock()
@@ -128,7 +128,7 @@ class StaticConfigManagerTest(base.BaseTest):
         )
         self.assertEqual(1, mock_logger.debug.call_count)
         mock_notification_center.send_notifications.assert_called_once_with('OPTIMIZELY_CONFIG_UPDATE')
-        self.assertEqual('1', project_config_manager.optimizely_config.revision)
+        self.assertEqual('1', project_config_manager.get_optimizely_config().revision)
 
         mock_logger.reset_mock()
         mock_notification_center.reset_mock()
@@ -141,7 +141,7 @@ class StaticConfigManagerTest(base.BaseTest):
         )
         self.assertEqual(1, mock_logger.debug.call_count)
         mock_notification_center.send_notifications.assert_called_once_with('OPTIMIZELY_CONFIG_UPDATE')
-        self.assertEqual('42', project_config_manager.optimizely_config.revision)
+        self.assertEqual('42', project_config_manager.get_optimizely_config().revision)
 
     def test_set_config__schema_validation(self):
         """ Test set_config calls or does not call schema validation based on skip_json_validation value. """


### PR DESCRIPTION
## Summary
`OptimizelyConfig` object is generated when SDK is being initialized. This operation is heavy and blocks the SDK from initializing quickly. This object is only used when users explicitly access it using `get_optimizely_config` API call. This PR moves the creation of this object from SDK initialization to the actual API call.

## Test plan
- Manually tested thoroughly
- All unit tests pass
- All FSC tests pass
