### PR TITLE
fix: tests that utilize threading from failing with pypy

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021, Optimizely
+# Copyright 2019-2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -327,10 +327,12 @@ class PollingConfigManagerTest(base.BaseTest):
     def test_set_update_interval(self, _):
         """ Test set_update_interval with different inputs. """
 
-        # prevent polling thread from running, otherwise it can outlive this test and get out of sync with pytest
-        with mock.patch('threading.Thread.start'):
+        # prevent polling thread from starting in PollingConfigManager.__init__
+        # otherwise it can outlive this test and get out of sync with pytest
+        with mock.patch('threading.Thread.start') as mock_thread:
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
+        mock_thread.assert_called_once()
         # Assert that if invalid update_interval is set, then exception is raised.
         with self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException, 'Invalid update_interval "invalid interval" provided.',
@@ -356,10 +358,12 @@ class PollingConfigManagerTest(base.BaseTest):
     def test_set_blocking_timeout(self, _):
         """ Test set_blocking_timeout with different inputs. """
 
-        # prevent polling thread from running, otherwise it can outlive this test and get out of sync with pytest
-        with mock.patch('threading.Thread.start'):
+        # prevent polling thread from starting in PollingConfigManager.__init__
+        # otherwise it can outlive this test and get out of sync with pytest
+        with mock.patch('threading.Thread.start') as mock_thread:
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
+        mock_thread.assert_called_once()
         # Assert that if invalid blocking_timeout is set, then exception is raised.
         with self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException, 'Invalid blocking timeout "invalid timeout" provided.',
@@ -389,10 +393,12 @@ class PollingConfigManagerTest(base.BaseTest):
     def test_set_last_modified(self, _):
         """ Test that set_last_modified sets last_modified field based on header. """
 
-        # prevent polling thread from running, otherwise it can outlive this test and get out of sync with pytest
-        with mock.patch('threading.Thread.start'):
+        # prevent polling thread from starting in PollingConfigManager.__init__
+        # otherwise it can outlive this test and get out of sync with pytest
+        with mock.patch('threading.Thread.start') as mock_thread:
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
+        mock_thread.assert_called_once()
         last_modified_time = 'Test Last Modified Time'
         test_response_headers = {
             'Last-Modified': last_modified_time,
@@ -416,13 +422,18 @@ class PollingConfigManagerTest(base.BaseTest):
         test_response.status_code = 200
         test_response.headers = test_headers
         test_response._content = test_datafile
-        with mock.patch('requests.get', return_value=test_response):
+        with mock.patch('requests.get', return_value=test_response) as mock_request:
             # manually trigger fetch_datafile in the polling thread
             project_config_manager.run = True
             # Wait for polling thread to finish
             while project_config_manager.run:
                 pass
 
+        mock_request.assert_called_once_with(
+            expected_datafile_url,
+            headers={},
+            timeout=enums.ConfigManager.REQUEST_TIMEOUT
+        )
         self.assertEqual(test_headers['Last-Modified'], project_config_manager.last_modified)
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)
 
@@ -466,13 +477,18 @@ class PollingConfigManagerTest(base.BaseTest):
         # this prevents the polling thread from outliving the test
         # and getting out of sync with pytest
         project_config_manager = MockPollingConfigManager(sdk_key=sdk_key, logger=mock_logger)
-        with mock.patch('requests.get', return_value=test_response):
+        with mock.patch('requests.get', return_value=test_response) as mock_request:
             # manually trigger fetch_datafile in the polling thread
             project_config_manager.run = True
             # Wait for polling thread to finish
             while project_config_manager.run:
                 pass
 
+        mock_request.assert_called_once_with(
+            expected_datafile_url,
+            headers={},
+            timeout=enums.ConfigManager.REQUEST_TIMEOUT
+        )
         self.assertEqual(test_headers['Last-Modified'], project_config_manager.last_modified)
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)
 
@@ -516,13 +532,18 @@ class PollingConfigManagerTest(base.BaseTest):
         test_response.status_code = 200
         test_response.headers = test_headers
         test_response._content = test_datafile
-        with mock.patch('requests.get', return_value=test_response):
+        with mock.patch('requests.get', return_value=test_response) as mock_request:
             # manually trigger fetch_datafile in the polling thread
             project_config_manager.run = True
             # Wait for polling thread to finish
             while project_config_manager.run:
                 pass
 
+        mock_request.assert_called_once_with(
+            expected_datafile_url,
+            headers={},
+            timeout=enums.ConfigManager.REQUEST_TIMEOUT
+        )
         self.assertEqual(test_headers['Last-Modified'], project_config_manager.last_modified)
         self.assertIsInstance(project_config_manager.get_config(), project_config.ProjectConfig)
 
@@ -579,11 +600,13 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
         datafile_access_token = 'some_token'
         sdk_key = 'some_key'
 
-        # prevent polling thread from running, otherwise it can outlive this test and get out of sync with pytest
-        with mock.patch('threading.Thread.start'):
+        # prevent polling thread from starting in PollingConfigManager.__init__
+        # otherwise it can outlive this test and get out of sync with pytest
+        with mock.patch('threading.Thread.start') as mock_thread:
             project_config_manager = config_manager.AuthDatafilePollingConfigManager(
                 datafile_access_token=datafile_access_token, sdk_key=sdk_key)
 
+        mock_thread.assert_called_once()
         self.assertEqual(datafile_access_token, project_config_manager.datafile_access_token)
 
     def test_fetch_datafile(self, _):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -294,7 +294,7 @@ class PollingConfigManagerTest(base.BaseTest):
 
     def test_set_update_interval(self, _):
         """ Test set_update_interval with different inputs. """
-        with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
+        with mock.patch('threading.Thread.start'):
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         # Assert that if invalid update_interval is set, then exception is raised.
@@ -321,7 +321,7 @@ class PollingConfigManagerTest(base.BaseTest):
 
     def test_set_blocking_timeout(self, _):
         """ Test set_blocking_timeout with different inputs. """
-        with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
+        with mock.patch('threading.Thread.start'):
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         # Assert that if invalid blocking_timeout is set, then exception is raised.
@@ -352,7 +352,7 @@ class PollingConfigManagerTest(base.BaseTest):
 
     def test_set_last_modified(self, _):
         """ Test that set_last_modified sets last_modified field based on header. """
-        with mock.patch('optimizely.config_manager.PollingConfigManager.fetch_datafile'):
+        with mock.patch('threading.Thread.start'):
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
 
         last_modified_time = 'Test Last Modified Time'
@@ -479,6 +479,9 @@ class PollingConfigManagerTest(base.BaseTest):
             project_config_manager = config_manager.PollingConfigManager(sdk_key='some_key')
             self.assertTrue(project_config_manager.is_running)
 
+        # Prevent the polling thread from running fetch_datafile if it hasn't already
+        project_config_manager._polling_thread._is_stopped = True
+
 
 @mock.patch('requests.get')
 class AuthDatafilePollingConfigManagerTest(base.BaseTest):
@@ -495,7 +498,7 @@ class AuthDatafilePollingConfigManagerTest(base.BaseTest):
         """ Test that datafile_access_token is properly set as instance variable. """
         datafile_access_token = 'some_token'
         sdk_key = 'some_key'
-        with mock.patch('optimizely.config_manager.AuthDatafilePollingConfigManager.fetch_datafile'):
+        with mock.patch('threading.Thread.start'):
             project_config_manager = config_manager.AuthDatafilePollingConfigManager(
                 datafile_access_token=datafile_access_token, sdk_key=sdk_key)
 

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -1859,6 +1859,28 @@ class UserContextTest(base.BaseTest):
                 for x in range(100):
                     user_context._clone()
 
+            # custom call counter because the mock call_count is not thread safe
+            class MockCounter:
+                def __init__(self):
+                    self.lock = threading.Lock()
+                    self.call_count = 0
+
+                def increment(self, *args):
+                    with self.lock:
+                        self.call_count += 1
+
+            set_forced_decision_counter = MockCounter()
+            get_forced_decision_counter = MockCounter()
+            remove_forced_decision_counter = MockCounter()
+            remove_all_forced_decisions_counter = MockCounter()
+            clone_counter = MockCounter()
+
+            set_forced_decision_mock.side_effect = set_forced_decision_counter.increment
+            get_forced_decision_mock.side_effect = get_forced_decision_counter.increment
+            remove_forced_decision_mock.side_effect = remove_forced_decision_counter.increment
+            remove_all_forced_decisions_mock.side_effect = remove_all_forced_decisions_counter.increment
+            clone_mock.side_effect = clone_counter.increment
+
             set_thread_1 = threading.Thread(target=set_forced_decision_loop, args=(user_context, context_1, decision_1))
             set_thread_2 = threading.Thread(target=set_forced_decision_loop, args=(user_context, context_2, decision_2))
             set_thread_3 = threading.Thread(target=get_forced_decision_loop, args=(user_context, context_1))
@@ -1888,8 +1910,8 @@ class UserContextTest(base.BaseTest):
             set_thread_7.join()
             set_thread_8.join()
 
-        self.assertEqual(200, set_forced_decision_mock.call_count)
-        self.assertEqual(200, get_forced_decision_mock.call_count)
-        self.assertEqual(200, remove_forced_decision_mock.call_count)
-        self.assertEqual(100, remove_all_forced_decisions_mock.call_count)
-        self.assertEqual(100, clone_mock.call_count)
+        self.assertEqual(200, set_forced_decision_counter.call_count)
+        self.assertEqual(200, get_forced_decision_counter.call_count)
+        self.assertEqual(200, remove_forced_decision_counter.call_count)
+        self.assertEqual(100, remove_all_forced_decisions_counter.call_count)
+        self.assertEqual(100, clone_counter.call_count)

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -1,4 +1,4 @@
-# Copyright 2021, Optimizely
+# Copyright 2021-2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Summary
-------

-  Fix forced decision test with thread safe call counter
-  Fix polling config manager tests from interfering with their own results
-  Add wrapper class to allow actual testing of the polling thread

Due to a difference in the way pypy implements threading, tests utilizing threading have been intermittently failing the pypy CI. For the polling config manager, depending on when the polling thread started, it would sometimes poison the results, due to the mock library not interacting with the thread correctly.
For the forced decision test, mock's call_count is not thread safe, so the calls were sometimes not counted correctly.

Additionally, some of the polling config manager tests were calling fetch_datafile manually and then confirming that the polling thread was still alive. Since fetch_datafile wasn't being run by the thread, this check was not actually checking what it was purported to check. 

Issues
------

-  Should address these pypy errors:
FAILED tests/test_config_manager.py::PollingConfigManagerTest::test_fetch_datafile__status_exception_raised
      AssertionError: 'New Time' != <MagicMock name='get().headers.get()' id='157266840'>
FAILED tests/test_user_context.py::UserContextTest::test_forced_decision_sync_return_correct_number_of_calls
     AssertionError: 200 != 137
