### PR TITLE
fix: handle datafile provided as bytes

### DIFF
--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -41,7 +41,7 @@ class ProjectConfig(object):
         """
 
         config = json.loads(datafile)
-        self._datafile = u'{}'.format(datafile)
+        self._datafile = datafile.decode('utf-8') if isinstance(datafile, bytes) else datafile
         self.logger = logger
         self.error_handler = error_handler
         self.version = config.get('version')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1011,6 +1011,19 @@ class ConfigTest(base.BaseTest):
 
         self.assertEqual(expected_datafile, actual_datafile)
 
+    def test_to_datafile_from_bytes(self):
+        """ Test that to_datafile returns the expected datafile when given bytes. """
+
+        expected_datafile = json.dumps(self.config_dict_with_features)
+        bytes_datafile = bytes(expected_datafile, 'utf-8')
+
+        opt_obj = optimizely.Optimizely(bytes_datafile)
+        project_config = opt_obj.config_manager.get_config()
+
+        actual_datafile = project_config.to_datafile()
+
+        self.assertEqual(expected_datafile, actual_datafile)
+
 
 class ConfigLoggingTest(base.BaseTest):
     def setUp(self):

--- a/tests/test_optimizely_config.py
+++ b/tests/test_optimizely_config.py
@@ -1525,6 +1525,18 @@ class OptimizelyConfigTest(base.BaseTest):
 
         self.assertEqual(expected_datafile, actual_datafile)
 
+    def test__get_datafile_from_bytes(self):
+        """ Test that get_datafile returns the expected datafile when provided as bytes. """
+
+        expected_datafile = json.dumps(self.config_dict_with_features)
+        bytes_datafile = bytes(expected_datafile, 'utf-8')
+
+        opt_instance = optimizely.Optimizely(bytes_datafile)
+        opt_config = opt_instance.config_manager.optimizely_config
+        actual_datafile = opt_config.get_datafile()
+
+        self.assertEqual(expected_datafile, actual_datafile)
+
     def test__get_sdk_key(self):
         """ Test that get_sdk_key returns the expected value. """
 


### PR DESCRIPTION
Summary
-------

-  If datafile is provided as bytes, convert to str

The `PollingConfigManager` provides the datafile as bytes.

Test plan
---------
- test_config.test_to_datafile_from_bytes
- test_optimizely_config.test__get_datafile_from_bytes

Issues
------
Currently if the datafile is provided as bytes, including using the default `PollingConfigManager`, it is converted to str incorrectly, resulting in an invalid JSON string being returned from `ProjectConfig.to_datafile` and `OptimizelyConfig.get_datafile`.

Steps to replicate:

```python
client = optimizely.Optimizely(sdk_key=sdk_key)
project_config = client.config_manager.get_config()
datafile = project_config.to_datafile()
json.loads(datafile)
```