### PR TITLE
refactor: type hints public interface

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.7-v7.3.5", "3.7", "3.8", "3.9", "3.10.0"]
+        python-version: ["pypy-3.7-v7.3.5", "3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10.0"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,11 +24,11 @@ jobs:
         gem install awesome_bot
     - name: Run tests
       run: find . -type f -name '*.md' -exec awesome_bot {} \;
-      
+
   linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3 
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
@@ -44,13 +44,13 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-        
+
   integration_tests:
     uses: optimizely/python-sdk/.github/workflows/integration_test.yml@master
     secrets:
       CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
       TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}
-      
+
   fullstack_production_suite:
     uses: optimizely/python-sdk/.github/workflows/integration_test.yml@master
     with:
@@ -58,7 +58,7 @@ jobs:
     secrets:
       CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
       TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}
-      
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -78,3 +78,25 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=optimizely
+
+  type-check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10.0"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/typing.txt
+    - name: Type check with mypy
+      run: |
+        mypy .
+      # disabled until entire sdk is type hinted
+        # mypy . --exclude "tests/" --strict

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+exclude = (?x)(
+    ^docs/
+    | ^setup\.py$
+  )
+show_error_codes = True
+pretty = True
+
+# suppress error on conditional import of typing_extensions module
+[mypy-optimizely.entities]
+no_warn_unused_ignores = True
+
+# suppress error on conditional import of typing_extensions module
+[mypy-event_dispatcher]
+no_warn_unused_ignores = True
+
+# suppress error on conditional import of typing_extensions module
+[mypy-optimizely.condition]
+no_warn_unused_ignores = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,8 @@
 [mypy]
+# regex to exclude:
+#  - docs folder
+#  - setup.py
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude
 exclude = (?x)(
     ^docs/
     | ^setup\.py$

--- a/optimizely/entities.py
+++ b/optimizely/entities.py
@@ -10,6 +10,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+from typing import Optional
+
+try:
+    # python 3.7
+    from typing_extensions import TypedDict
+except ImportError:
+    # python 3.8 +
+    from typing import TypedDict  # type: ignore
 
 
 class BaseEntity:
@@ -146,3 +155,52 @@ class Variation(BaseEntity):
 
     def __str__(self):
         return self.key
+
+
+class EventDict(TypedDict):
+    id: str
+    key: str
+    experimentIds: list[str]
+
+
+class AttributeDict(TypedDict):
+    id: str
+    key: str
+
+
+class TrafficAllocation(TypedDict):
+    endOfRange: int
+    entityId: str
+
+
+class ExperimentDict(TypedDict):
+    id: str
+    key: str
+    status: str
+    forcedVariations: dict[str, str]
+    variations: list[VariationDict]
+    layerId: str
+    audienceIds: list[str]
+    audienceConditions: list[str | list[str]]
+    trafficAllocation: list[TrafficAllocation]
+
+
+class VariationDict(TypedDict):
+    id: str
+    key: str
+    variables: list[VariableDict]
+    featureEnabled: Optional[bool]
+
+
+class VariableDict(TypedDict):
+    id: str
+    value: str
+    type: str
+    key: str
+    defaultValue: str
+    subType: str
+
+
+class RolloutDict(TypedDict):
+    id: str
+    experiments: list[ExperimentDict]

--- a/optimizely/entities.py
+++ b/optimizely/entities.py
@@ -10,16 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-from typing import Optional
-
-try:
-    # python 3.7
-    from typing_extensions import TypedDict
-except ImportError:
-    # python 3.8 +
-    from typing import TypedDict  # type: ignore
-
 
 class BaseEntity:
     def __eq__(self, other):
@@ -155,52 +145,3 @@ class Variation(BaseEntity):
 
     def __str__(self):
         return self.key
-
-
-class EventDict(TypedDict):
-    id: str
-    key: str
-    experimentIds: list[str]
-
-
-class AttributeDict(TypedDict):
-    id: str
-    key: str
-
-
-class TrafficAllocation(TypedDict):
-    endOfRange: int
-    entityId: str
-
-
-class ExperimentDict(TypedDict):
-    id: str
-    key: str
-    status: str
-    forcedVariations: dict[str, str]
-    variations: list[VariationDict]
-    layerId: str
-    audienceIds: list[str]
-    audienceConditions: list[str | list[str]]
-    trafficAllocation: list[TrafficAllocation]
-
-
-class VariationDict(TypedDict):
-    id: str
-    key: str
-    variables: list[VariableDict]
-    featureEnabled: Optional[bool]
-
-
-class VariableDict(TypedDict):
-    id: str
-    value: str
-    type: str
-    key: str
-    defaultValue: str
-    subType: str
-
-
-class RolloutDict(TypedDict):
-    id: str
-    experiments: list[ExperimentDict]

--- a/optimizely/entities.py
+++ b/optimizely/entities.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021, Optimizely
+# Copyright 2016-2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Optimizely
+# Copyright 2019-2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -62,7 +62,7 @@ class BatchEventProcessor(BaseEventProcessor):
     def __init__(
         self,
         event_dispatcher: Optional[type[EventDispatcher] | CustomEventDispatcher] = None,
-        logger: Any = None,
+        logger: Optional[_logging.Logger] = None,
         start_on_init: bool = False,
         event_queue: Any = None,
         batch_size: Optional[int] = None,
@@ -339,8 +339,10 @@ class ForwardingEventProcessor(BaseEventProcessor):
   """
 
     def __init__(
-        self, event_dispatcher: type[EventDispatcher] | CustomEventDispatcher,
-        logger: Any = None, notification_center: Optional[_notification_center.NotificationCenter] = None
+        self,
+        event_dispatcher: type[EventDispatcher] | CustomEventDispatcher,
+        logger: Optional[_logging.Logger] = None,
+        notification_center: Optional[_notification_center.NotificationCenter] = None
     ):
         """ ForwardingEventProcessor init method to configure event dispatching.
 

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -17,7 +17,7 @@ import numbers
 import threading
 import time
 
-from typing import Any, Optional
+from typing import Optional
 from datetime import timedelta
 import queue
 
@@ -51,12 +51,16 @@ class BatchEventProcessor(BaseEventProcessor):
   maximum duration before the resulting LogEvent is sent to the EventDispatcher.
   """
 
+    class Signal:
+        '''Used to create unique objects for sending signals to event queue.'''
+        pass
+
     _DEFAULT_QUEUE_CAPACITY = 1000
     _DEFAULT_BATCH_SIZE = 10
     _DEFAULT_FLUSH_INTERVAL = 30
     _DEFAULT_TIMEOUT_INTERVAL = 5
-    _SHUTDOWN_SIGNAL = object()
-    _FLUSH_SIGNAL = object()
+    _SHUTDOWN_SIGNAL = Signal()
+    _FLUSH_SIGNAL = Signal()
     LOCK = threading.Lock()
 
     def __init__(
@@ -64,7 +68,7 @@ class BatchEventProcessor(BaseEventProcessor):
         event_dispatcher: Optional[type[EventDispatcher] | CustomEventDispatcher] = None,
         logger: Optional[_logging.Logger] = None,
         start_on_init: bool = False,
-        event_queue: Any = None,
+        event_queue: Optional[queue.Queue[UserEvent | Signal]] = None,
         batch_size: Optional[int] = None,
         flush_interval: Optional[float] = None,
         timeout_interval: Optional[float] = None,

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -357,7 +357,7 @@ class ForwardingEventProcessor(BaseEventProcessor):
             self.logger.error(enums.Errors.INVALID_INPUT.format('notification_center'))
             self.notification_center = _notification_center.NotificationCenter()
 
-    def process(self, user_event: Optional[UserEvent]) -> None:
+    def process(self, user_event: UserEvent) -> None:
         """ Method to process the user_event by dispatching it.
 
     Args:

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -61,7 +61,7 @@ class BatchEventProcessor(BaseEventProcessor):
 
     def __init__(
         self,
-        event_dispatcher: Optional[EventDispatcher | CustomEventDispatcher] = None,
+        event_dispatcher: Optional[type[EventDispatcher] | CustomEventDispatcher] = None,
         logger: Any = None,
         start_on_init: bool = False,
         event_queue: Any = None,

--- a/optimizely/event/event_processor.py
+++ b/optimizely/event/event_processor.py
@@ -244,6 +244,10 @@ class BatchEventProcessor(BaseEventProcessor):
 
         self.notification_center.send_notifications(enums.NotificationTypes.LOG_EVENT, log_event)
 
+        if log_event is None:
+            self.logger.exception('Error dispatching event: Cannot dispatch None event.')
+            return
+
         try:
             self.event_dispatcher.dispatch_event(log_event)
         except Exception as e:
@@ -370,6 +374,10 @@ class ForwardingEventProcessor(BaseEventProcessor):
         log_event = EventFactory.create_log_event(user_event, self.logger)
 
         self.notification_center.send_notifications(enums.NotificationTypes.LOG_EVENT, log_event)
+
+        if log_event is None:
+            self.logger.exception('Error dispatching event: Cannot dispatch None event.')
+            return
 
         try:
             self.event_dispatcher.dispatch_event(log_event)

--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -47,6 +47,8 @@ class EventDispatcher:
     Args:
       event: Object holding information about the request to be dispatched to the Optimizely backend.
     """
+        if not event:
+            raise TypeError("Event 'NoneType' cannot be dispatched.")
 
         try:
             if event.http_verb == enums.HTTPVerbs.GET:

--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Optimizely
+# Copyright 2016, 2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -11,13 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
 import json
 import logging
 import requests
 
 from requests import exceptions as request_exception
-from typing import Optional
 
 from .helpers import enums
 from . import event_builder
@@ -35,21 +33,18 @@ REQUEST_TIMEOUT = 10
 
 class CustomEventDispatcher(Protocol):
     """Interface for a custom event dispatcher and required method `dispatch_event`. """
-    def dispatch_event(self, event: Optional[event_builder.Event]) -> None:
+    def dispatch_event(self, event: event_builder.Event) -> None:
         ...
 
 
 class EventDispatcher:
     @staticmethod
-    def dispatch_event(event: Optional[event_builder.Event]) -> None:
+    def dispatch_event(event: event_builder.Event) -> None:
         """ Dispatch the event being represented by the Event object.
 
     Args:
       event: Object holding information about the request to be dispatched to the Optimizely backend.
     """
-        if not event:
-            raise TypeError("Event 'NoneType' cannot be dispatched.")
-
         try:
             if event.http_verb == enums.HTTPVerbs.GET:
                 requests.get(event.url, params=event.params, timeout=REQUEST_TIMEOUT).raise_for_status()

--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -11,20 +11,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import json
 import logging
 import requests
 
 from requests import exceptions as request_exception
+from typing import Optional
 
 from .helpers import enums
+from . import event_builder
+
+try:
+    # python 3.7
+    from typing_extensions import Protocol
+except ImportError:
+    # python 3.8 +
+    from typing import Protocol  # type: ignore
+
 
 REQUEST_TIMEOUT = 10
 
 
+class CustomEventDispatcher(Protocol):
+    """Interface for a custom event dispatcher and required method `dispatch_event`. """
+    def dispatch_event(self, event: Optional[event_builder.Event]) -> None:
+        ...
+
+
 class EventDispatcher:
     @staticmethod
-    def dispatch_event(event):
+    def dispatch_event(event: Optional[event_builder.Event]) -> None:
         """ Dispatch the event being represented by the Event object.
 
     Args:

--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -16,16 +16,15 @@ import logging
 import requests
 
 from requests import exceptions as request_exception
+from sys import version_info
 
 from .helpers import enums
 from . import event_builder
 
-try:
-    # python 3.7
-    from typing_extensions import Protocol
-except ImportError:
-    # python 3.8 +
-    from typing import Protocol  # type: ignore
+if version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol  # type: ignore[misc]
 
 
 REQUEST_TIMEOUT = 10

--- a/optimizely/helpers/types.py
+++ b/optimizely/helpers/types.py
@@ -1,0 +1,78 @@
+# Copyright 2022, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Optional
+from sys import version_info
+
+
+if version_info >= (3, 8):
+    from typing import TypedDict  # type: ignore[attr-defined]
+else:
+    from typing_extensions import TypedDict
+
+
+# Intermediate types for type checking deserialized datafile json before actual class instantiation.
+# These aren't used for anything other than type signatures
+
+class BaseDict(TypedDict):
+    '''Base type for parsed datafile json, before instantiation of class objects.'''
+    id: str
+    key: str
+
+
+class EventDict(BaseDict):
+    '''Event dict from parsed datafile json.'''
+    experimentIds: list[str]
+
+
+class AttributeDict(BaseDict):
+    '''Attribute dict from parsed datafile json.'''
+    pass
+
+
+class TrafficAllocation(TypedDict):
+    '''Traffic Allocation dict from parsed datafile json.'''
+    endOfRange: int
+    entityId: str
+
+
+class VariableDict(BaseDict):
+    '''Variable dict from parsed datafile json.'''
+    value: str
+    type: str
+    defaultValue: str
+    subType: str
+
+
+class VariationDict(BaseDict):
+    '''Variation dict from parsed datafile json.'''
+    variables: list[VariableDict]
+    featureEnabled: Optional[bool]
+
+
+class ExperimentDict(BaseDict):
+    '''Experiment dict from parsed datafile json.'''
+    status: str
+    forcedVariations: dict[str, str]
+    variations: list[VariationDict]
+    layerId: str
+    audienceIds: list[str]
+    audienceConditions: list[str | list[str]]
+    trafficAllocation: list[TrafficAllocation]
+
+
+class RolloutDict(TypedDict):
+    '''Rollout dict from parsed datafile json.'''
+    id: str
+    experiments: list[ExperimentDict]

--- a/optimizely/logger.py
+++ b/optimizely/logger.py
@@ -1,4 +1,4 @@
-# Copyright 2016, 2018-2019, Optimizely
+# Copyright 2016, 2018-2019, 2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,6 +12,7 @@
 # limitations under the License.
 import logging
 import warnings
+from typing import Union
 
 from .helpers import enums
 
@@ -58,6 +59,10 @@ class BaseLogger:
     @staticmethod
     def log(*args):
         pass  # pragma: no cover
+
+
+# type alias for optimizely logger
+Logger = Union[logging.Logger, BaseLogger]
 
 
 class NoOpLogger(BaseLogger):

--- a/optimizely/notification_center.py
+++ b/optimizely/notification_center.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Optimizely
+# Copyright 2017-2019, 2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/notification_center.py
+++ b/optimizely/notification_center.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 from .helpers import enums
 from . import logger as optimizely_logger
 
@@ -26,7 +26,7 @@ class NotificationCenter:
     """ Class encapsulating methods to manage notifications and their listeners.
   The enums.NotificationTypes includes predefined notifications."""
 
-    def __init__(self, logger: Any = None):
+    def __init__(self, logger: Optional[optimizely_logger.Logger] = None):
         self.listener_id = 1
         self.notification_listeners: dict[str, list[tuple[int, Callable[..., None]]]] = {}
         for notification_type in NOTIFICATION_TYPES:

--- a/optimizely/notification_center.py
+++ b/optimizely/notification_center.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+from typing import Any, Callable
 from .helpers import enums
 from . import logger as optimizely_logger
 
@@ -24,14 +26,14 @@ class NotificationCenter:
     """ Class encapsulating methods to manage notifications and their listeners.
   The enums.NotificationTypes includes predefined notifications."""
 
-    def __init__(self, logger=None):
+    def __init__(self, logger: Any = None):
         self.listener_id = 1
-        self.notification_listeners = {}
+        self.notification_listeners: dict[str, list[tuple[int, Callable[..., None]]]] = {}
         for notification_type in NOTIFICATION_TYPES:
             self.notification_listeners[notification_type] = []
         self.logger = optimizely_logger.adapt_logger(logger or optimizely_logger.NoOpLogger())
 
-    def add_notification_listener(self, notification_type, notification_callback):
+    def add_notification_listener(self, notification_type: str, notification_callback: Callable[..., None]) -> int:
         """ Add a notification callback to the notification center for a given notification type.
 
     Args:
@@ -59,7 +61,7 @@ class NotificationCenter:
 
         return current_listener_id
 
-    def remove_notification_listener(self, notification_id):
+    def remove_notification_listener(self, notification_id: int) -> bool:
         """ Remove a previously added notification callback.
 
     Args:
@@ -77,7 +79,7 @@ class NotificationCenter:
 
         return False
 
-    def clear_notification_listeners(self, notification_type):
+    def clear_notification_listeners(self, notification_type: str) -> None:
         """ Remove notification listeners for a certain notification type.
 
     Args:
@@ -90,7 +92,7 @@ class NotificationCenter:
             )
         self.notification_listeners[notification_type] = []
 
-    def clear_notifications(self, notification_type):
+    def clear_notifications(self, notification_type: str) -> None:
         """ (DEPRECATED since 3.2.0, use clear_notification_listeners)
     Remove notification listeners for a certain notification type.
 
@@ -99,17 +101,17 @@ class NotificationCenter:
     """
         self.clear_notification_listeners(notification_type)
 
-    def clear_all_notification_listeners(self):
+    def clear_all_notification_listeners(self) -> None:
         """ Remove all notification listeners. """
         for notification_type in self.notification_listeners.keys():
             self.clear_notification_listeners(notification_type)
 
-    def clear_all_notifications(self):
+    def clear_all_notifications(self) -> None:
         """ (DEPRECATED since 3.2.0, use clear_all_notification_listeners)
     Remove all notification listeners. """
         self.clear_all_notification_listeners()
 
-    def send_notifications(self, notification_type, *args):
+    def send_notifications(self, notification_type: str, *args: Any) -> None:
         """ Fires off the notification for the specific event.  Uses var args to pass in a
         arbitrary list of parameter according to which notification type was fired.
 

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -283,6 +283,9 @@ class Optimizely:
         variable_value = variable.defaultValue
 
         user_context = self.create_user_context(user_id, attributes)
+        # error is logged in create_user_context
+        if user_context is None:
+            return None
         decision, _ = self.decision_service.get_variation_for_feature(project_config, feature_flag, user_context)
 
         if decision.variation:
@@ -307,8 +310,8 @@ class Optimizely:
 
         if decision.source == enums.DecisionSources.FEATURE_TEST:
             source_info = {
-                'experiment_key': decision.experiment.key,
-                'variation_key': decision.variation.key,
+                'experiment_key': decision.experiment.key if decision.experiment else None,
+                'variation_key': decision.variation.key if decision.variation else None,
             }
 
         try:
@@ -369,6 +372,9 @@ class Optimizely:
         source_info = {}
 
         user_context = self.create_user_context(user_id, attributes)
+        # error is logged in create_user_context
+        if user_context is None:
+            return None
         decision, _ = self.decision_service.get_variation_for_feature(project_config, feature_flag, user_context)
 
         if decision.variation:
@@ -389,8 +395,7 @@ class Optimizely:
             )
 
         all_variables = {}
-        for variable_key in feature_flag.variables:
-            variable = project_config.get_variable_for_feature(feature_key, variable_key)
+        for variable_key, variable in feature_flag.variables.items():
             variable_value = variable.defaultValue
             if feature_enabled:
                 variable_value = project_config.get_variable_value_for_variation(variable, decision.variation)
@@ -409,8 +414,8 @@ class Optimizely:
 
         if decision.source == enums.DecisionSources.FEATURE_TEST:
             source_info = {
-                'experiment_key': decision.experiment.key,
-                'variation_key': decision.variation.key,
+                'experiment_key': decision.experiment.key if decision.experiment else None,
+                'variation_key': decision.variation.key if decision.variation else None,
             }
 
         self.notification_center.send_notifications(
@@ -466,6 +471,9 @@ class Optimizely:
 
         experiment = project_config.get_experiment_from_key(experiment_key)
         variation = project_config.get_variation_from_key(experiment_key, variation_key)
+        if not variation or not experiment:
+            self.logger.info(f'Not activating user "{user_id}".')
+            return None
 
         # Create and dispatch impression event
         self.logger.info(f'Activating user "{user_id}" in experiment "{experiment.key}".')
@@ -569,6 +577,9 @@ class Optimizely:
             return None
 
         user_context = self.create_user_context(user_id, attributes)
+        # error is logged in create_user_context
+        if not user_context:
+            return None
 
         variation, _ = self.decision_service.get_variation(project_config, experiment, user_context)
         if variation:
@@ -628,6 +639,10 @@ class Optimizely:
         feature_enabled = False
         source_info = {}
         user_context = self.create_user_context(user_id, attributes)
+        # error is logged in create_user_context
+        if not user_context:
+            return False
+
         decision, _ = self.decision_service.get_variation_for_feature(project_config, feature, user_context)
         is_source_experiment = decision.source == enums.DecisionSources.FEATURE_TEST
         is_source_rollout = decision.source == enums.DecisionSources.ROLLOUT
@@ -643,7 +658,7 @@ class Optimizely:
             )
 
         # Send event if Decision came from an experiment.
-        if is_source_experiment and decision.variation:
+        if is_source_experiment and decision.variation and decision.experiment:
             source_info = {
                 'experiment_key': decision.experiment.key,
                 'variation_key': decision.variation.key,
@@ -1112,8 +1127,7 @@ class Optimizely:
 
         # Generate all variables map if decide options doesn't include excludeVariables
         if OptimizelyDecideOption.EXCLUDE_VARIABLES not in decide_options:
-            for variable_key in feature_flag.variables:
-                variable = config.get_variable_for_feature(flag_key, variable_key)
+            for variable_key, variable in feature_flag.variables.items():
                 variable_value = variable.defaultValue
                 if feature_enabled:
                     variable_value = config.get_variable_value_for_variation(variable, decision.variation)

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -58,7 +58,7 @@ class Optimizely:
             notification_center: Optional[NotificationCenter] = None,
             event_processor: Optional[BaseEventProcessor] = None,
             datafile_access_token: Optional[str] = None,
-            default_decide_options: Optional[list[str]] = None
+            default_decide_options: Optional[list[str]] = None,
             event_processor_options=None
     ) -> None:
         """ Optimizely init method for managing Custom projects.

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -19,7 +19,6 @@ from . import entities
 from . import event_builder
 from . import exceptions
 from . import logger as _logging
-from logging import Logger
 from .config_manager import BaseConfigManager
 from .config_manager import AuthDatafilePollingConfigManager
 from .config_manager import PollingConfigManager
@@ -49,7 +48,7 @@ class Optimizely:
             self,
             datafile: Optional[str] = None,
             event_dispatcher: Optional[CustomEventDispatcher] = None,
-            logger: Optional[Logger | _logging.BaseLogger] = None,
+            logger: Optional[_logging.Logger] = None,
             error_handler: Optional[BaseErrorHandler] = None,
             skip_json_validation: Optional[bool] = False,
             user_profile_service: Optional[UserProfileService] = None,

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -31,7 +31,7 @@ from .decision_service import Decision
 from .error_handler import NoOpErrorHandler, BaseErrorHandler
 from .event import event_factory, user_event_factory
 from .event.event_processor import BatchEventProcessor, BaseEventProcessor
-from .event_dispatcher import EventDispatcher as default_event_dispatcher, CustomEventDispatcher
+from .event_dispatcher import EventDispatcher, CustomEventDispatcher
 
 from .helpers import enums, validator
 from .helpers.enums import DecisionSources
@@ -59,7 +59,7 @@ class Optimizely:
             event_processor: Optional[BaseEventProcessor] = None,
             datafile_access_token: Optional[str] = None,
             default_decide_options: Optional[list[str]] = None,
-            event_processor_options=None
+            event_processor_options: Optional[dict[str, Any]] = None
     ) -> None:
         """ Optimizely init method for managing Custom projects.
 
@@ -91,7 +91,7 @@ class Optimizely:
         """
         self.logger_name = '.'.join([__name__, self.__class__.__name__])
         self.is_valid = True
-        self.event_dispatcher = event_dispatcher or default_event_dispatcher
+        self.event_dispatcher = event_dispatcher or EventDispatcher
         self.logger = _logging.adapt_logger(logger or _logging.NoOpLogger())
         self.error_handler = error_handler or NoOpErrorHandler
         self.config_manager: BaseConfigManager = config_manager  # type: ignore
@@ -104,11 +104,12 @@ class Optimizely:
         }
         if event_processor_options:
             event_processor_defaults.update(event_processor_options)
+
         self.event_processor = event_processor or BatchEventProcessor(
             self.event_dispatcher,
             logger=self.logger,
             notification_center=self.notification_center,
-            **event_processor_defaults
+            **event_processor_defaults  # type: ignore[arg-type]
         )
         self.default_decide_options: list[str]
 

--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -319,7 +319,7 @@ class OptimizelyConfigService:
 
     def _get_variables_map(
         self, experiment: ExperimentDict, variation: VariationDict, feature_id: Optional[str] = None
-    ) -> dict[str, Any]:
+    ) -> dict[str, OptimizelyVariable]:
         """ Gets variables map for given experiment and variation.
 
         Args:
@@ -329,7 +329,7 @@ class OptimizelyConfigService:
         Returns:
             dict - Map of variable key to OptimizelyVariable for the given variation.
         """
-        variables_map: dict[str, Any] = {}
+        variables_map: dict[str, OptimizelyVariable] = {}
 
         feature_flag = self.exp_id_to_feature_map.get(experiment['id'], None)
         if feature_flag is None and feature_id is None:
@@ -360,7 +360,7 @@ class OptimizelyConfigService:
         Returns:
             dict -- Map of variation key to OptimizelyVariation.
         """
-        variations_map = {}
+        variations_map: dict[str, OptimizelyVariation] = {}
 
         for variation in experiment.get('variations', []):
             variables_map = self._get_variables_map(experiment, variation, feature_id)

--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021, Optimizely
+# Copyright 2020-2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -11,16 +11,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import copy
-from .helpers.condition import ConditionOperatorTypes
+from typing import Any, Optional
 
+from .helpers.condition import ConditionOperatorTypes
 from .project_config import ProjectConfig
+from . import entities
 
 
 class OptimizelyConfig:
-    def __init__(self, revision, experiments_map, features_map, datafile=None,
-                 sdk_key=None, environment_key=None, attributes=None, events=None,
-                 audiences=None):
+    def __init__(
+        self, revision: str,
+        experiments_map: dict[str, OptimizelyExperiment],
+        features_map: dict[str, OptimizelyFeature],
+        datafile: Optional[str] = None,
+        sdk_key: Optional[str] = None,
+        environment_key: Optional[str] = None,
+        attributes: Optional[list[OptimizelyAttribute]] = None,
+        events: Optional[list[OptimizelyEvent]] = None,
+        audiences: Optional[list[OptimizelyAudience]] = None
+    ):
         self.revision = revision
 
         # This experiments_map is for experiments of legacy projects only.
@@ -37,7 +48,7 @@ class OptimizelyConfig:
         self.events = events or []
         self.audiences = audiences or []
 
-    def get_datafile(self):
+    def get_datafile(self) -> Optional[str]:
         """ Get the datafile associated with OptimizelyConfig.
 
         Returns:
@@ -47,7 +58,7 @@ class OptimizelyConfig:
 
 
 class OptimizelyExperiment:
-    def __init__(self, id, key, variations_map, audiences=''):
+    def __init__(self, id: str, key: str, variations_map: dict[str, OptimizelyVariation], audiences: str = ''):
         self.id = id
         self.key = key
         self.variations_map = variations_map
@@ -55,7 +66,13 @@ class OptimizelyExperiment:
 
 
 class OptimizelyFeature:
-    def __init__(self, id, key, experiments_map, variables_map):
+    def __init__(
+        self,
+        id: str,
+        key: str,
+        experiments_map: dict[str, OptimizelyExperiment],
+        variables_map: dict[str, OptimizelyVariable]
+    ):
         self.id = id
         self.key = key
 
@@ -64,12 +81,14 @@ class OptimizelyFeature:
         self.experiments_map = experiments_map
 
         self.variables_map = variables_map
-        self.delivery_rules = []
-        self.experiment_rules = []
+        self.delivery_rules: list[OptimizelyExperiment] = []
+        self.experiment_rules: list[OptimizelyExperiment] = []
 
 
 class OptimizelyVariation:
-    def __init__(self, id, key, feature_enabled, variables_map):
+    def __init__(
+        self, id: str, key: str, feature_enabled: Optional[bool], variables_map: dict[str, OptimizelyVariable]
+    ):
         self.id = id
         self.key = key
         self.feature_enabled = feature_enabled
@@ -77,7 +96,7 @@ class OptimizelyVariation:
 
 
 class OptimizelyVariable:
-    def __init__(self, id, key, variable_type, value):
+    def __init__(self, id: str, key: str, variable_type: str, value: Any):
         self.id = id
         self.key = key
         self.type = variable_type
@@ -85,20 +104,20 @@ class OptimizelyVariable:
 
 
 class OptimizelyAttribute:
-    def __init__(self, id, key):
+    def __init__(self, id: str, key: str):
         self.id = id
         self.key = key
 
 
 class OptimizelyEvent:
-    def __init__(self, id, key, experiment_ids):
+    def __init__(self, id: str, key: str, experiment_ids: list[str]):
         self.id = id
         self.key = key
         self.experiment_ids = experiment_ids
 
 
 class OptimizelyAudience:
-    def __init__(self, id, name, conditions):
+    def __init__(self, id: Optional[str], name: Optional[str], conditions: Optional[list[Any] | str]):
         self.id = id
         self.name = name
         self.conditions = conditions
@@ -107,7 +126,7 @@ class OptimizelyAudience:
 class OptimizelyConfigService:
     """ Class encapsulating methods to be used in creating instance of OptimizelyConfig. """
 
-    def __init__(self, project_config):
+    def __init__(self, project_config: ProjectConfig):
         """
         Args:
             project_config ProjectConfig
@@ -135,7 +154,7 @@ class OptimizelyConfigService:
             Merging typed_audiences with audiences from project_config.
             The typed_audiences has higher precedence.
         '''
-        optly_typed_audiences = []
+        optly_typed_audiences: list[OptimizelyAudience] = []
         id_lookup_dict = {}
         for typed_audience in project_config.typed_audiences:
             optly_audience = OptimizelyAudience(
@@ -159,7 +178,7 @@ class OptimizelyConfigService:
 
         self.audiences = optly_typed_audiences
 
-    def replace_ids_with_names(self, conditions, audiences_map):
+    def replace_ids_with_names(self, conditions: str | list[Any], audiences_map: dict[str, str]) -> str:
         '''
             Gets conditions and audiences_map [id:name]
 
@@ -173,7 +192,7 @@ class OptimizelyConfigService:
         else:
             return ''
 
-    def lookup_name_from_id(self, audience_id, audiences_map):
+    def lookup_name_from_id(self, audience_id: str, audiences_map: dict[str, str]) -> str:
         '''
             Gets and audience ID and audiences map
 
@@ -189,7 +208,7 @@ class OptimizelyConfigService:
 
         return name
 
-    def stringify_conditions(self, conditions, audiences_map):
+    def stringify_conditions(self, conditions: str | list[Any], audiences_map: dict[str, str]) -> str:
         '''
             Gets a list of conditions from an entities.Experiment
             and an audiences_map [id:name]
@@ -246,7 +265,7 @@ class OptimizelyConfigService:
 
         return conditions_str or ''
 
-    def get_config(self):
+    def get_config(self) -> Optional[OptimizelyConfig]:
         """ Gets instance of OptimizelyConfig
 
         Returns:
@@ -271,7 +290,7 @@ class OptimizelyConfigService:
             self.audiences
         )
 
-    def _create_lookup_maps(self):
+    def _create_lookup_maps(self) -> None:
         """ Creates lookup maps to avoid redundant iteration of config objects.  """
 
         self.exp_id_to_feature_map = {}
@@ -298,7 +317,9 @@ class OptimizelyConfigService:
             self.feature_key_variable_key_to_variable_map[feature['key']] = variables_key_map
             self.feature_key_variable_id_to_variable_map[feature['key']] = variables_id_map
 
-    def _get_variables_map(self, experiment, variation, feature_id=None):
+    def _get_variables_map(
+        self, experiment: entities.ExperimentDict, variation: entities.VariationDict, feature_id: Optional[str] = None
+    ) -> dict[str, Any]:
         """ Gets variables map for given experiment and variation.
 
         Args:
@@ -308,7 +329,7 @@ class OptimizelyConfigService:
         Returns:
             dict - Map of variable key to OptimizelyVariable for the given variation.
         """
-        variables_map = {}
+        variables_map: dict[str, Any] = {}
 
         feature_flag = self.exp_id_to_feature_map.get(experiment['id'], None)
         if feature_flag is None and feature_id is None:
@@ -328,7 +349,9 @@ class OptimizelyConfigService:
 
         return variables_map
 
-    def _get_variations_map(self, experiment, feature_id=None):
+    def _get_variations_map(
+        self, experiment: entities.ExperimentDict, feature_id: Optional[str] = None
+    ) -> dict[str, OptimizelyVariation]:
         """ Gets variation map for the given experiment.
 
         Args:
@@ -351,7 +374,7 @@ class OptimizelyConfigService:
 
         return variations_map
 
-    def _get_all_experiments(self):
+    def _get_all_experiments(self) -> list[entities.ExperimentDict]:
         """ Gets all experiments in the project config.
 
         Returns:
@@ -364,7 +387,7 @@ class OptimizelyConfigService:
 
         return experiments
 
-    def _get_experiments_maps(self):
+    def _get_experiments_maps(self) -> tuple[dict[str, OptimizelyExperiment], dict[str, OptimizelyExperiment]]:
         """ Gets maps for all the experiments in the project config and
         updates the experiment with updated experiment audiences string.
 
@@ -376,7 +399,7 @@ class OptimizelyConfigService:
         # Id map comes in handy to figure out feature experiment.
         experiments_id_map = {}
         # Audiences map to use for updating experiments with new audience conditions string
-        audiences_map = {}
+        audiences_map: dict[str, str] = {}
 
         # Build map from OptimizelyAudience array
         for optly_audience in self.audiences:
@@ -396,7 +419,7 @@ class OptimizelyConfigService:
 
         return experiments_key_map, experiments_id_map
 
-    def _get_features_map(self, experiments_id_map):
+    def _get_features_map(self, experiments_id_map: dict[str, OptimizelyExperiment]) -> dict[str, OptimizelyFeature]:
         """ Gets features map for the project config.
 
         Args:
@@ -406,7 +429,7 @@ class OptimizelyConfigService:
             dict -- feaure key to OptimizelyFeature map
         """
         features_map = {}
-        experiment_rules = []
+        experiment_rules: list[OptimizelyExperiment] = []
 
         for feature in self.feature_flags:
 
@@ -431,7 +454,9 @@ class OptimizelyConfigService:
 
         return features_map
 
-    def _get_delivery_rules(self, rollouts, rollout_id, feature_id):
+    def _get_delivery_rules(
+        self, rollouts: list[entities.RolloutDict], rollout_id: Optional[str], feature_id: str
+    ) -> list[OptimizelyExperiment]:
         """ Gets an array of rollouts for the project config
 
         returns:
@@ -440,7 +465,7 @@ class OptimizelyConfigService:
         # Return list for delivery rules
         delivery_rules = []
         # Audiences map to use for updating experiments with new audience conditions string
-        audiences_map = {}
+        audiences_map: dict[str, str] = {}
 
         # Gets a rollout based on provided rollout_id
         rollout = [rollout for rollout in rollouts if rollout.get('id') == rollout_id]
@@ -465,7 +490,7 @@ class OptimizelyConfigService:
 
         return delivery_rules
 
-    def _get_attributes_list(self, attributes):
+    def _get_attributes_list(self, attributes: list[entities.AttributeDict]) -> list[OptimizelyAttribute]:
         """ Gets attributes list for the project config
 
         Returns:
@@ -482,7 +507,7 @@ class OptimizelyConfigService:
 
         return attributes_list
 
-    def _get_events_list(self, events):
+    def _get_events_list(self, events: list[entities.EventDict]) -> list[OptimizelyEvent]:
         """ Gets events list for the project_config
 
         Returns:

--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -16,8 +16,8 @@ import copy
 from typing import Any, Optional
 
 from .helpers.condition import ConditionOperatorTypes
+from .helpers.types import VariationDict, ExperimentDict, RolloutDict, AttributeDict, EventDict
 from .project_config import ProjectConfig
-from . import entities
 
 
 class OptimizelyConfig:
@@ -318,7 +318,7 @@ class OptimizelyConfigService:
             self.feature_key_variable_id_to_variable_map[feature['key']] = variables_id_map
 
     def _get_variables_map(
-        self, experiment: entities.ExperimentDict, variation: entities.VariationDict, feature_id: Optional[str] = None
+        self, experiment: ExperimentDict, variation: VariationDict, feature_id: Optional[str] = None
     ) -> dict[str, Any]:
         """ Gets variables map for given experiment and variation.
 
@@ -350,7 +350,7 @@ class OptimizelyConfigService:
         return variables_map
 
     def _get_variations_map(
-        self, experiment: entities.ExperimentDict, feature_id: Optional[str] = None
+        self, experiment: ExperimentDict, feature_id: Optional[str] = None
     ) -> dict[str, OptimizelyVariation]:
         """ Gets variation map for the given experiment.
 
@@ -374,7 +374,7 @@ class OptimizelyConfigService:
 
         return variations_map
 
-    def _get_all_experiments(self) -> list[entities.ExperimentDict]:
+    def _get_all_experiments(self) -> list[ExperimentDict]:
         """ Gets all experiments in the project config.
 
         Returns:
@@ -458,7 +458,7 @@ class OptimizelyConfigService:
         return features_map
 
     def _get_delivery_rules(
-        self, rollouts: list[entities.RolloutDict], rollout_id: Optional[str], feature_id: str
+        self, rollouts: list[RolloutDict], rollout_id: Optional[str], feature_id: str
     ) -> list[OptimizelyExperiment]:
         """ Gets an array of rollouts for the project config
 
@@ -496,7 +496,7 @@ class OptimizelyConfigService:
 
         return delivery_rules
 
-    def _get_attributes_list(self, attributes: list[entities.AttributeDict]) -> list[OptimizelyAttribute]:
+    def _get_attributes_list(self, attributes: list[AttributeDict]) -> list[OptimizelyAttribute]:
         """ Gets attributes list for the project config
 
         Returns:
@@ -513,7 +513,7 @@ class OptimizelyConfigService:
 
         return attributes_list
 
-    def _get_events_list(self, events: list[entities.EventDict]) -> list[OptimizelyEvent]:
+    def _get_events_list(self, events: list[EventDict]) -> list[OptimizelyEvent]:
         """ Gets events list for the project_config
 
         Returns:

--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -338,7 +338,7 @@ class OptimizelyConfigService:
         # set default variables for each variation
         if feature_id:
             variables_map = copy.deepcopy(self.feature_id_variable_key_to_feature_variables_map[feature_id])
-        else:
+        elif feature_flag:
             variables_map = copy.deepcopy(self.feature_key_variable_key_to_variable_map[feature_flag['key']])
 
             # set variation specific variable value if any
@@ -403,7 +403,10 @@ class OptimizelyConfigService:
 
         # Build map from OptimizelyAudience array
         for optly_audience in self.audiences:
-            audiences_map[optly_audience.id] = optly_audience.name
+            audience_id = optly_audience.id
+            audience_name = optly_audience.name
+            if audience_id is not None:
+                audiences_map[audience_id] = audience_name if audience_name is not None else ''
 
         all_experiments = self._get_all_experiments()
         for exp in all_experiments:
@@ -471,13 +474,16 @@ class OptimizelyConfigService:
         rollout = [rollout for rollout in rollouts if rollout.get('id') == rollout_id]
 
         if rollout:
-            rollout = rollout[0]
+            found_rollout = rollout[0]
             # Build map from OptimizelyAudience array
             for optly_audience in self.audiences:
-                audiences_map[optly_audience.id] = optly_audience.name
+                audience_id = optly_audience.id
+                audience_name = optly_audience.name
+                if audience_id is not None:
+                    audiences_map[audience_id] = audience_name if audience_name is not None else ''
 
             # Get the experiments for that rollout
-            experiments = rollout.get('experiments')
+            experiments = found_rollout.get('experiments')
             if experiments:
                 for experiment in experiments:
                     optly_exp = OptimizelyExperiment(

--- a/optimizely/optimizely_user_context.py
+++ b/optimizely/optimizely_user_context.py
@@ -12,9 +12,16 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-
+from __future__ import annotations
 import copy
 import threading
+from typing import Any, Optional, TYPE_CHECKING
+
+from optimizely.decision import optimizely_decision
+
+if TYPE_CHECKING:
+    # prevent circular dependency
+    from optimizely.optimizely import Optimizely
 
 
 class OptimizelyUserContext:
@@ -22,7 +29,10 @@ class OptimizelyUserContext:
     Representation of an Optimizely User Context using which APIs are to be called.
     """
 
-    def __init__(self, optimizely_client, logger, user_id, user_attributes=None):
+    def __init__(
+        self, optimizely_client: Optimizely, logger: Any,
+        user_id: str, user_attributes: Optional[dict[str, Any]] = None
+    ):
         """ Create an instance of the Optimizely User Context.
 
         Args:
@@ -44,7 +54,10 @@ class OptimizelyUserContext:
 
         self._user_attributes = user_attributes.copy() if user_attributes else {}
         self.lock = threading.Lock()
-        self.forced_decisions_map = {}
+        self.forced_decisions_map: dict[
+            OptimizelyUserContext.OptimizelyDecisionContext,
+            OptimizelyUserContext.OptimizelyForcedDecision
+        ] = {}
 
     # decision context
     class OptimizelyDecisionContext:
@@ -52,22 +65,22 @@ class OptimizelyUserContext:
             class is extensible, it's easy to add another attribute if we wanted
             to extend decision context.
         """
-        def __init__(self, flag_key, rule_key=None):
+        def __init__(self, flag_key: str, rule_key: Optional[str] = None):
             self.flag_key = flag_key
             self.rule_key = rule_key
 
-        def __hash__(self):
+        def __hash__(self) -> int:
             return hash((self.flag_key, self.rule_key))
 
-        def __eq__(self, other):
+        def __eq__(self, other: OptimizelyUserContext.OptimizelyDecisionContext) -> bool:  # type: ignore
             return (self.flag_key, self.rule_key) == (other.flag_key, other.rule_key)
 
     # forced decision
     class OptimizelyForcedDecision:
-        def __init__(self, variation_key):
+        def __init__(self, variation_key: str):
             self.variation_key = variation_key
 
-    def _clone(self):
+    def _clone(self) -> Optional[OptimizelyUserContext]:
         if not self.client:
             return None
 
@@ -79,11 +92,11 @@ class OptimizelyUserContext:
 
         return user_context
 
-    def get_user_attributes(self):
+    def get_user_attributes(self) -> dict[str, Any]:
         with self.lock:
             return self._user_attributes.copy()
 
-    def set_attribute(self, attribute_key, attribute_value):
+    def set_attribute(self, attribute_key: str, attribute_value: Any) -> None:
         """
         sets a attribute by key for this user context.
         Args:
@@ -96,7 +109,9 @@ class OptimizelyUserContext:
         with self.lock:
             self._user_attributes[attribute_key] = attribute_value
 
-    def decide(self, key, options=None):
+    def decide(
+        self, key: str, options: Optional[list[str]] = None
+    ) -> optimizely_decision.OptimizelyDecision:
         """
         Call decide on contained Optimizely object
         Args:
@@ -111,7 +126,9 @@ class OptimizelyUserContext:
 
         return self.client._decide(self._clone(), key, options)
 
-    def decide_for_keys(self, keys, options=None):
+    def decide_for_keys(
+        self, keys: list[str], options: Optional[list[str]] = None
+    ) -> dict[str, optimizely_decision.OptimizelyDecision]:
         """
         Call decide_for_keys on contained optimizely object
         Args:
@@ -126,7 +143,7 @@ class OptimizelyUserContext:
 
         return self.client._decide_for_keys(self._clone(), keys, options)
 
-    def decide_all(self, options=None):
+    def decide_all(self, options: Optional[list[str]] = None) -> dict[str, optimizely_decision.OptimizelyDecision]:
         """
         Call decide_all on contained optimizely instance
         Args:
@@ -140,16 +157,18 @@ class OptimizelyUserContext:
 
         return self.client._decide_all(self._clone(), options)
 
-    def track_event(self, event_key, event_tags=None):
+    def track_event(self, event_key: str, event_tags: Optional[dict[str, Any]] = None) -> None:
         return self.client.track(event_key, self.user_id, self.get_user_attributes(), event_tags)
 
-    def as_json(self):
+    def as_json(self) -> dict[str, Any]:
         return {
             'user_id': self.user_id,
             'attributes': self.get_user_attributes(),
         }
 
-    def set_forced_decision(self, decision_context, decision):
+    def set_forced_decision(
+        self, decision_context: OptimizelyDecisionContext, decision: OptimizelyForcedDecision
+    ) -> bool:
         """
         Sets the forced decision for a given decision context.
 
@@ -165,7 +184,7 @@ class OptimizelyUserContext:
 
         return True
 
-    def get_forced_decision(self, decision_context):
+    def get_forced_decision(self, decision_context: OptimizelyDecisionContext) -> Optional[OptimizelyForcedDecision]:
         """
         Gets the forced decision (variation key) for a given decision context.
 
@@ -178,7 +197,7 @@ class OptimizelyUserContext:
         forced_decision = self.find_forced_decision(decision_context)
         return forced_decision
 
-    def remove_forced_decision(self, decision_context):
+    def remove_forced_decision(self, decision_context: OptimizelyDecisionContext) -> bool:
         """
         Removes the forced decision for a given decision context.
 
@@ -195,7 +214,7 @@ class OptimizelyUserContext:
 
         return False
 
-    def remove_all_forced_decisions(self):
+    def remove_all_forced_decisions(self) -> bool:
         """
         Removes all forced decisions bound to this user context.
 
@@ -207,7 +226,7 @@ class OptimizelyUserContext:
 
         return True
 
-    def find_forced_decision(self, decision_context):
+    def find_forced_decision(self, decision_context: OptimizelyDecisionContext) -> Optional[OptimizelyForcedDecision]:
         """
         Gets forced decision from forced decision map.
 

--- a/optimizely/optimizely_user_context.py
+++ b/optimizely/optimizely_user_context.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 
 from optimizely.decision import optimizely_decision
 from . import optimizely
+from .logger import Logger
 
 
 class OptimizelyUserContext:
@@ -27,7 +28,7 @@ class OptimizelyUserContext:
     """
 
     def __init__(
-        self, optimizely_client: optimizely.Optimizely, logger: Any,
+        self, optimizely_client: optimizely.Optimizely, logger: Logger,
         user_id: str, user_attributes: Optional[dict[str, Any]] = None
     ):
         """ Create an instance of the Optimizely User Context.

--- a/optimizely/optimizely_user_context.py
+++ b/optimizely/optimizely_user_context.py
@@ -15,13 +15,10 @@
 from __future__ import annotations
 import copy
 import threading
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional
 
 from optimizely.decision import optimizely_decision
-
-if TYPE_CHECKING:
-    # prevent circular dependency
-    from optimizely.optimizely import Optimizely
+from . import optimizely
 
 
 class OptimizelyUserContext:
@@ -30,7 +27,7 @@ class OptimizelyUserContext:
     """
 
     def __init__(
-        self, optimizely_client: Optimizely, logger: Any,
+        self, optimizely_client: optimizely.Optimizely, logger: Any,
         user_id: str, user_attributes: Optional[dict[str, Any]] = None
     ):
         """ Create an instance of the Optimizely User Context.

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -1,0 +1,4 @@
+mypy
+types-jsonschema
+types-requests
+types-Flask

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -3021,7 +3021,8 @@ class OptimizelyTest(base.BaseTest):
             'Got variable value "staging" for variable "environment" of feature flag "test_feature_in_experiment".'
         )
 
-        mock_broadcast_decision.assert_called_once_with(
+        # sometimes event processor flushes before this check, so can't assert called once
+        mock_broadcast_decision.assert_any_call(
             enums.NotificationTypes.DECISION,
             'feature-variable',
             'test_user',
@@ -3696,7 +3697,8 @@ class OptimizelyTest(base.BaseTest):
             'Returning default value for variable "count" of feature flag "test_feature_in_experiment".'
         )
 
-        mock_broadcast_decision.assert_called_once_with(
+        # sometimes event processor flushes before this check, so can't assert called once
+        mock_broadcast_decision.assert_any_call(
             enums.NotificationTypes.DECISION,
             'feature-variable',
             'test_user',


### PR DESCRIPTION
Summary
-------

-  Add type hints to the public interface of SDK.
-  Add mypy check to github actions
-  Additional type hints to be submitted in second PR

Allows automatic static type checking to prevent bugs as well as type hints for users of the SDK. Remaining type hints will be added in subsequent PR. At that time, we can enable mypy --strict, enforcing type hinting going forward.
