### PR TITLE
feat: odp datafile parsing and audience evaluation

### DIFF
--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -268,7 +268,6 @@ class DecisionService:
           And an array of log messages representing decision making.
         """
         user_id = user_context.user_id
-        attributes = user_context.get_user_attributes()
 
         if options:
             ignore_user_profile = OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE in options
@@ -323,7 +322,7 @@ class DecisionService:
             project_config, audience_conditions,
             enums.ExperimentAudienceEvaluationLogs,
             experiment.key,
-            attributes, self.logger)
+            user_context, self.logger)
         decide_reasons += reasons_received
         if not user_meets_audience_conditions:
             message = f'User "{user_id}" does not meet conditions to be in experiment "{experiment.key}".'
@@ -332,7 +331,7 @@ class DecisionService:
             return None, decide_reasons
 
         # Determine bucketing ID to be used
-        bucketing_id, bucketing_id_reasons = self._get_bucketing_id(user_id, attributes)
+        bucketing_id, bucketing_id_reasons = self._get_bucketing_id(user_id, user_context.get_user_attributes())
         decide_reasons += bucketing_id_reasons
         variation, bucket_reasons = self.bucketer.bucket(project_config, experiment, user_id, bucketing_id)
         decide_reasons += bucket_reasons
@@ -422,7 +421,7 @@ class DecisionService:
 
             audience_decision_response, reasons_received_audience = audience_helper.does_user_meet_audience_conditions(
                 project_config, audience_conditions, enums.RolloutRuleAudienceEvaluationLogs,
-                logging_key, attributes, self.logger)
+                logging_key, user, self.logger)
 
             decide_reasons += reasons_received_audience
 

--- a/optimizely/entities.py
+++ b/optimizely/entities.py
@@ -175,3 +175,10 @@ class Variation(BaseEntity):
 
     def __str__(self) -> str:
         return self.key
+
+
+class Integration(BaseEntity):
+    def __init__(self, key: str, host: str, publicKey: str):
+        self.key = key
+        self.host = host
+        self.publicKey = publicKey

--- a/optimizely/entities.py
+++ b/optimizely/entities.py
@@ -52,6 +52,16 @@ class Audience(BaseEntity):
         self.conditionStructure = conditionStructure
         self.conditionList = conditionList
 
+    def get_segments(self) -> list[str]:
+        """ Extract all audience segments used in the this audience's conditions.
+
+    Returns:
+        List of segment names.
+    """
+        if not self.conditionList:
+            return []
+        return list({c[1] for c in self.conditionList if c[3] == 'qualified'})
+
 
 class Event(BaseEntity):
     def __init__(self, id: str, key: str, experimentIds: list[str], **kwargs: Any):

--- a/optimizely/helpers/audience.py
+++ b/optimizely/helpers/audience.py
@@ -31,7 +31,7 @@ def does_user_meet_audience_conditions(
     audience_conditions: Optional[Sequence[str | list[str]]],
     audience_logs: Type[ExperimentAudienceEvaluationLogs | RolloutRuleAudienceEvaluationLogs],
     logging_key: str,
-    attributes: Optional[optimizely_user_context.UserAttributes],
+    user: optimizely_user_context.OptimizelyUserContext,
     logger: Logger
 ) -> tuple[bool, list[str]]:
     """ Determine for given experiment if user satisfies the audiences for the experiment.
@@ -62,15 +62,12 @@ def does_user_meet_audience_conditions(
 
         return True, decide_reasons
 
-    if attributes is None:
-        attributes = optimizely_user_context.UserAttributes({})
-
     def evaluate_custom_attr(audience_id: str, index: int) -> Optional[bool]:
         audience = config.get_audience(audience_id)
         if not audience or audience.conditionList is None:
             return None
         custom_attr_condition_evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            audience.conditionList, attributes, logger
+            audience.conditionList, user, logger
         )
 
         return custom_attr_condition_evaluator.evaluate(index)

--- a/optimizely/helpers/condition.py
+++ b/optimizely/helpers/condition.py
@@ -55,12 +55,13 @@ class ConditionMatchTypes:
     SEMVER_LE: Final = 'semver_le'
     SEMVER_LT: Final = 'semver_lt'
     SUBSTRING: Final = 'substring'
+    QUALIFIED: Final = 'qualified'
 
 
 class CustomAttributeConditionEvaluator:
     """ Class encapsulating methods to be used in audience leaf condition evaluation. """
 
-    CUSTOM_ATTRIBUTE_CONDITION_TYPE: Final = 'custom_attribute'
+    CONDITION_TYPES: Final = ('custom_attribute', 'third_party_dimension')
 
     def __init__(
         self,
@@ -614,7 +615,27 @@ class CustomAttributeConditionEvaluator:
 
         return result >= 0
 
-    EVALUATORS_BY_MATCH_TYPE = {
+    def qualified_evaluator(self, index: int) -> Optional[bool]:
+        """ Check if the user is qualifed for the given segment.
+
+    Args:
+      index: Index of the condition to be evaluated.
+
+    Returns:
+      Boolean:
+        - True if the user is qualified.
+        - False if the user is not qualified.
+      None: if the condition value isn't a string.
+    """
+        condition_value = self.condition_data[index][1]
+
+        if not isinstance(condition_value, str):
+            self.logger.warning(audience_logs.UNKNOWN_CONDITION_VALUE.format(self._get_condition_json(index),))
+            return None
+
+        return self.user_context.is_qualified_for(condition_value)
+
+    EVALUATORS_BY_MATCH_TYPE: dict[str, Callable[[CustomAttributeConditionEvaluator, int], Optional[bool]]] = {
         ConditionMatchTypes.EXACT: exact_evaluator,
         ConditionMatchTypes.EXISTS: exists_evaluator,
         ConditionMatchTypes.GREATER_THAN: greater_than_evaluator,
@@ -626,7 +647,8 @@ class CustomAttributeConditionEvaluator:
         ConditionMatchTypes.SEMVER_GT: semver_greater_than_evaluator,
         ConditionMatchTypes.SEMVER_LE: semver_less_than_or_equal_evaluator,
         ConditionMatchTypes.SEMVER_LT: semver_less_than_evaluator,
-        ConditionMatchTypes.SUBSTRING: substring_evaluator
+        ConditionMatchTypes.SUBSTRING: substring_evaluator,
+        ConditionMatchTypes.QUALIFIED: qualified_evaluator
     }
 
     def split_version(self, version: str) -> Optional[list[str]]:
@@ -697,7 +719,7 @@ class CustomAttributeConditionEvaluator:
       None: if the user attributes and condition can't be evaluated.
     """
 
-        if self.condition_data[index][2] != self.CUSTOM_ATTRIBUTE_CONDITION_TYPE:
+        if self.condition_data[index][2] not in self.CONDITION_TYPES:
             self.logger.warning(audience_logs.UNKNOWN_CONDITION_TYPE.format(self._get_condition_json(index)))
             return None
 
@@ -709,7 +731,7 @@ class CustomAttributeConditionEvaluator:
             self.logger.warning(audience_logs.UNKNOWN_MATCH_TYPE.format(self._get_condition_json(index)))
             return None
 
-        if condition_match != ConditionMatchTypes.EXISTS:
+        if condition_match not in (ConditionMatchTypes.EXISTS, ConditionMatchTypes.QUALIFIED):
             attribute_key = self.condition_data[index][0]
             if attribute_key not in self.attributes:
                 self.logger.debug(

--- a/optimizely/helpers/condition.py
+++ b/optimizely/helpers/condition.py
@@ -65,11 +65,12 @@ class CustomAttributeConditionEvaluator:
     def __init__(
         self,
         condition_data: list[str | list[str]],
-        attributes: Optional[optimizely_user_context.UserAttributes],
+        user_context: optimizely_user_context.OptimizelyUserContext,
         logger: Logger
     ):
         self.condition_data = condition_data
-        self.attributes = attributes or optimizely_user_context.UserAttributes({})
+        self.user_context = user_context
+        self.attributes = user_context.get_user_attributes()
         self.logger = logger
 
     def _get_condition_json(self, index: int) -> str:

--- a/optimizely/helpers/constants.py
+++ b/optimizely/helpers/constants.py
@@ -149,6 +149,14 @@ JSON_SCHEMA = {
         },
         "version": {"type": "string"},
         "revision": {"type": "string"},
+        "integrations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"key": {"type": "string"}, "host": {"type": "string"}, "publicKey": {"type": "string"}},
+                "required": ["key"],
+            }
+        }
     },
     "required": [
         "projectId",

--- a/optimizely/helpers/types.py
+++ b/optimizely/helpers/types.py
@@ -102,3 +102,10 @@ class AudienceDict(BaseEntity):
     id: str
     name: str
     conditions: list[Any] | str
+
+
+class IntegrationDict(BaseEntity):
+    '''Integration dict from parsed datafile json.'''
+    key: str
+    host: str
+    publicKey: str

--- a/optimizely/optimizely_config.py
+++ b/optimizely/optimizely_config.py
@@ -16,7 +16,7 @@ import copy
 from typing import Any, Optional
 
 from .helpers.condition import ConditionOperatorTypes
-from .helpers.types import VariationDict, ExperimentDict, RolloutDict, AttributeDict, EventDict
+from .helpers.types import IntegrationDict, VariationDict, ExperimentDict, RolloutDict, AttributeDict, EventDict
 from .project_config import ProjectConfig
 
 
@@ -30,7 +30,8 @@ class OptimizelyConfig:
         environment_key: Optional[str] = None,
         attributes: Optional[list[OptimizelyAttribute]] = None,
         events: Optional[list[OptimizelyEvent]] = None,
-        audiences: Optional[list[OptimizelyAudience]] = None
+        audiences: Optional[list[OptimizelyAudience]] = None,
+        integrations: Optional[list[OptimizelyIntegration]] = None
     ):
         self.revision = revision
 
@@ -47,6 +48,7 @@ class OptimizelyConfig:
         self.attributes = attributes or []
         self.events = events or []
         self.audiences = audiences or []
+        self.integrations = integrations or []
 
     def get_datafile(self) -> Optional[str]:
         """ Get the datafile associated with OptimizelyConfig.
@@ -123,6 +125,13 @@ class OptimizelyAudience:
         self.conditions = conditions
 
 
+class OptimizelyIntegration:
+    def __init__(self, key: str, host: str, public_key: str):
+        self.key = key
+        self.host = host
+        self.public_key = public_key
+
+
 class OptimizelyConfigService:
     """ Class encapsulating methods to be used in creating instance of OptimizelyConfig. """
 
@@ -147,6 +156,7 @@ class OptimizelyConfigService:
         self.attributes = project_config.attributes
         self.events = project_config.events
         self.rollouts = project_config.rollouts
+        self.integrations = project_config.integrations
 
         self._create_lookup_maps()
 
@@ -287,7 +297,8 @@ class OptimizelyConfigService:
             self.environment_key,
             self._get_attributes_list(self.attributes),
             self._get_events_list(self.events),
-            self.audiences
+            self.audiences,
+            self._get_integrations_list(self.integrations)
         )
 
     def _create_lookup_maps(self) -> None:
@@ -530,3 +541,21 @@ class OptimizelyConfigService:
             events_list.append(optly_event)
 
         return events_list
+
+    def _get_integrations_list(self, integrations: list[IntegrationDict]) -> list[OptimizelyIntegration]:
+        """ Converts a list of integration dicts from the datafile into a list of OptimizelyIntegrations
+
+        Returns:
+            List - OptimizelyIntegrations
+        """
+        integrations_list = []
+
+        for integration in integrations:
+            optly_integration = OptimizelyIntegration(
+                integration['key'],
+                integration['host'],
+                integration['publicKey']
+            )
+            integrations_list.append(optly_integration)
+
+        return integrations_list

--- a/optimizely/optimizely_user_context.py
+++ b/optimizely/optimizely_user_context.py
@@ -54,6 +54,7 @@ class OptimizelyUserContext:
         self.client = optimizely_client
         self.logger = logger
         self.user_id = user_id
+        self.qualified_segments: list[str] = []
 
         if not isinstance(user_attributes, dict):
             user_attributes = UserAttributes({})
@@ -95,6 +96,8 @@ class OptimizelyUserContext:
         with self.lock:
             if self.forced_decisions_map:
                 user_context.forced_decisions_map = copy.deepcopy(self.forced_decisions_map)
+            if self.qualified_segments:
+                user_context.qualified_segments = self.qualified_segments.copy()
 
         return user_context
 
@@ -248,3 +251,16 @@ class OptimizelyUserContext:
 
             # must allow None to be returned for the Flags only case
             return self.forced_decisions_map.get(decision_context)
+
+    def is_qualified_for(self, segment: str) -> bool:
+        """
+        Checks is the provided segment is in the qualified_segments list.
+
+        Args:
+            segment: a segment name.
+
+        Returns:
+            Returns: true if the segment is in the qualified segments list.
+        """
+        with self.lock:
+            return segment in self.qualified_segments

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -83,6 +83,7 @@ class ProjectConfig:
         self.bot_filtering: Optional[bool] = config.get('botFiltering', None)
         self.public_key_for_odp: Optional[str] = None
         self.host_for_odp: Optional[str] = None
+        self.all_segments: list[str] = []
 
         # Utility maps for quick lookup
         self.group_id_map: dict[str, entities.Group] = self._generate_key_map(self.groups, 'id', entities.Group)
@@ -123,6 +124,9 @@ class ProjectConfig:
             for experiment in experiments_in_group_id_map.values():
                 experiment.__dict__.update({'groupId': group.id, 'groupPolicy': group.policy})
             self.experiment_id_map.update(experiments_in_group_id_map)
+
+        for audience in self.audience_id_map.values():
+            self.all_segments += audience.get_segments()
 
         self.experiment_key_map: dict[str, entities.Experiment] = {}
         self.variation_key_map: dict[str, dict[str, entities.Variation]] = {}

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -77,9 +77,12 @@ class ProjectConfig:
         self.typed_audiences: list[types.AudienceDict] = config.get('typedAudiences', [])
         self.feature_flags: list[types.FeatureFlagDict] = config.get('featureFlags', [])
         self.rollouts: list[types.RolloutDict] = config.get('rollouts', [])
+        self.integrations: list[types.IntegrationDict] = config.get('integrations', [])
         self.anonymize_ip: bool = config.get('anonymizeIP', False)
         self.send_flag_decisions: bool = config.get('sendFlagDecisions', False)
         self.bot_filtering: Optional[bool] = config.get('botFiltering', None)
+        self.public_key_for_odp: Optional[str] = None
+        self.host_for_odp: Optional[str] = None
 
         # Utility maps for quick lookup
         self.group_id_map: dict[str, entities.Group] = self._generate_key_map(self.groups, 'id', entities.Group)
@@ -106,6 +109,13 @@ class ProjectConfig:
         for layer in self.rollout_id_map.values():
             for experiment_dict in layer.experiments:
                 self.experiment_id_map[experiment_dict['id']] = entities.Experiment(**experiment_dict)
+
+        if self.integrations:
+            self.integration_key_map = self._generate_key_map(self.integrations, 'key', entities.Integration)
+            odp_integration = self.integration_key_map.get('odp')
+            if odp_integration:
+                self.public_key_for_odp = odp_integration.publicKey
+                self.host_for_odp = odp_integration.host
 
         self.audience_id_map = self._deserialize_audience(self.audience_id_map)
         for group in self.group_id_map.values():

--- a/tests/base.py
+++ b/tests/base.py
@@ -1048,6 +1048,196 @@ class BaseTest(unittest.TestCase):
             'revision': '3',
         }
 
+        self.config_dict_with_audience_segments = {
+            'version': '4',
+            'sendFlagDecisions': True,
+            'rollouts': [
+                {
+                    'experiments': [
+                        {
+                            'audienceIds': ['13389130056'],
+                            'forcedVariations': {},
+                            'id': '3332020515',
+                            'key': 'rollout-rule-1',
+                            'layerId': '3319450668',
+                            'status': 'Running',
+                            'trafficAllocation': [
+                                {
+                                    'endOfRange': 10000,
+                                    'entityId': '3324490633'
+                                }
+                            ],
+                            'variations': [
+                                {
+                                    'featureEnabled': True,
+                                    'id': '3324490633',
+                                    'key': 'rollout-variation-on',
+                                    'variables': []
+                                }
+                            ]
+                        },
+                        {
+                            'audienceIds': [],
+                            'forcedVariations': {},
+                            'id': '3332020556',
+                            'key': 'rollout-rule-2',
+                            'layerId': '3319450668',
+                            'status': 'Running',
+                            'trafficAllocation': [
+                                {
+                                    'endOfRange': 10000,
+                                    'entityId': '3324490644'
+                                }
+                            ],
+                            'variations': [
+                                {
+                                    'featureEnabled': False,
+                                    'id': '3324490644',
+                                    'key': 'rollout-variation-off',
+                                    'variables': []
+                                }
+                            ]
+                        }
+                    ],
+                    'id': '3319450668'
+                }
+            ],
+            'anonymizeIP': True,
+            'botFiltering': True,
+            'projectId': '10431130345',
+            'variables': [],
+            'featureFlags': [
+                {
+                    'experimentIds': ['10390977673'],
+                    'id': '4482920077',
+                    'key': 'flag-segment',
+                    'rolloutId': '3319450668',
+                    'variables': [
+                        {
+                            'defaultValue': '42',
+                            'id': '2687470095',
+                            'key': 'i_42',
+                            'type': 'integer'
+                        }
+                    ]
+                }
+            ],
+            'experiments': [
+                {
+                    'status': 'Running',
+                    'key': 'experiment-segment',
+                    'layerId': '10420273888',
+                    'trafficAllocation': [
+                        {
+                            'entityId': '10389729780',
+                            'endOfRange': 10000
+                        }
+                    ],
+                    'audienceIds': ['$opt_dummy_audience'],
+                    'audienceConditions': ['or', '13389142234', '13389141123'],
+                    'variations': [
+                        {
+                            'variables': [],
+                            'featureEnabled': True,
+                            'id': '10389729780',
+                            'key': 'variation-a'
+                        },
+                        {
+                            'variables': [],
+                            'id': '10416523121',
+                            'key': 'variation-b'
+                        }
+                    ],
+                    'forcedVariations': {},
+                    'id': '10390977673'
+                }
+            ],
+            'groups': [],
+            'integrations': [
+                {
+                    'key': 'odp',
+                    'host': 'https://api.zaius.com',
+                    'publicKey': 'W4WzcEs-ABgXorzY7h1LCQ'
+                }
+            ],
+            'typedAudiences': [
+                {
+                    'id': '13389142234',
+                    'conditions': [
+                        'and',
+                        [
+                            'or',
+                            [
+                                'or',
+                                {
+                                    'value': 'odp-segment-1',
+                                    'type': 'third_party_dimension',
+                                    'name': 'odp.audiences',
+                                    'match': 'qualified'
+                                }
+                            ]
+                        ]
+                    ],
+                    'name': 'odp-segment-1'
+                },
+                {
+                    'id': '13389130056',
+                    'conditions': [
+                        'and',
+                        [
+                            'or',
+                            [
+                                'or',
+                                {
+                                    'value': 'odp-segment-2',
+                                    'type': 'third_party_dimension',
+                                    'name': 'odp.audiences',
+                                    'match': 'qualified'
+                                },
+                                {
+                                    'value': 'us',
+                                    'type': 'custom_attribute',
+                                    'name': 'country',
+                                    'match': 'exact'
+                                }
+                            ],
+                            [
+                                'or',
+                                {
+                                    'value': 'odp-segment-3',
+                                    'type': 'third_party_dimension',
+                                    'name': 'odp.audiences',
+                                    'match': 'qualified'
+                                }
+                            ]
+                        ]
+                    ],
+                    'name': 'odp-segment-2'
+                }
+            ],
+            'audiences': [
+                {
+                    'id': '13389141123',
+                    'name': 'adult',
+                    'conditions': '["and", ["or", ["or", '
+                                  '{"match": "gt", "name": "age", "type": "custom_attribute", "value": 20}]]]'
+                }
+            ],
+            'attributes': [
+                {
+                    'id': '10401066117',
+                    'key': 'gender'
+                },
+                {
+                    'id': '10401066170',
+                    'key': 'testvar'
+                }
+            ],
+            'accountId': '10367498574',
+            'events': [],
+            'revision': '101'
+        }
+
         config = getattr(self, config_dict)
         self.optimizely = optimizely.Optimizely(json.dumps(config))
         self.project_config = self.optimizely.config_manager.get_config()

--- a/tests/helpers_tests/test_audience.py
+++ b/tests/helpers_tests/test_audience.py
@@ -289,6 +289,28 @@ class AudienceTest(base.BaseTest):
             any_order=True,
         )
 
+    def test_get_segments(self):
+        seg1 = ['odp.audiences', 'seg1', 'third_party_dimension', 'qualified']
+        seg2 = ['odp.audiences', 'seg2', 'third_party_dimension', 'qualified']
+        seg3 = ['odp.audiences', 'seg3', 'third_party_dimension', 'qualified']
+        other = ['other', 'a', 'custom_attribute', 'eq']
+
+        def make_audience(conditions):
+            return Audience('12345', 'group-a', '', conditionList=conditions)
+
+        audience = make_audience([seg1])
+        self.assertEqual(['seg1'], audience.get_segments())
+
+        audience = make_audience([seg1, seg2, other])
+        self.assertEqual(['seg1', 'seg2'], sorted(audience.get_segments()))
+
+        audience = make_audience([seg1, other, seg2])
+        self.assertEqual(['seg1', 'seg2'], sorted(audience.get_segments()))
+
+        audience = make_audience([seg1, other, seg2, seg1, seg2, seg3])
+        self.assertEqual(3, len(audience.get_segments()))
+        self.assertEqual(['seg1', 'seg2', 'seg3'], sorted(audience.get_segments()))
+
 
 class ExperimentAudienceLoggingTest(base.BaseTest):
     def setUp(self):

--- a/tests/helpers_tests/test_condition.py
+++ b/tests/helpers_tests/test_condition.py
@@ -49,23 +49,26 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
             doubleCondition,
         ]
         self.mock_client_logger = mock.MagicMock()
+        self.user_context = self.optimizely.create_user_context('any-user')
 
     def test_evaluate__returns_true__when_attributes_pass_audience_condition(self):
+        self.user_context._user_attributes = {'browser_type': 'safari'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            self.condition_list, {'browser_type': 'safari'}, self.mock_client_logger
+            self.condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_evaluate__returns_false__when_attributes_fail_audience_condition(self):
+        self.user_context._user_attributes = {'browser_type': 'chrome'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            self.condition_list, {'browser_type': 'chrome'}, self.mock_client_logger
+            self.condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_evaluate__evaluates__different_typed_attributes(self):
-        userAttributes = {
+        self.user_context._user_attributes = {
             'browser_type': 'safari',
             'is_firefox': True,
             'num_users': 10,
@@ -73,7 +76,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         }
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            self.condition_list, userAttributes, self.mock_client_logger
+            self.condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
@@ -84,9 +87,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_evaluate__returns_null__when_condition_has_an_invalid_match_property(self):
 
         condition_list = [['weird_condition', 'hi', 'custom_attribute', 'weird_match']]
-
+        self.user_context._user_attributes = {'weird_condition': 'hi'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            condition_list, {'weird_condition': 'hi'}, self.mock_client_logger
+            condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -94,9 +97,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_evaluate__assumes_exact__when_condition_match_property_is_none(self):
 
         condition_list = [['favorite_constellation', 'Lacerta', 'custom_attribute', None]]
-
+        self.user_context._user_attributes = {'favorite_constellation': 'Lacerta'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            condition_list, {'favorite_constellation': 'Lacerta'}, self.mock_client_logger,
+            condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
@@ -104,9 +107,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_evaluate__returns_null__when_condition_has_an_invalid_type_property(self):
 
         condition_list = [['weird_condition', 'hi', 'weird_type', 'exact']]
-
+        self.user_context._user_attributes = {'weird_condition': 'hi'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            condition_list, {'weird_condition': 'hi'}, self.mock_client_logger
+            condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -115,8 +118,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_equal_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_eq']]
         user_versions = ['2.0.0', '2.0']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_equal_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_equal_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertTrue(result, custom_err_msg)
@@ -125,8 +129,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_equal_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_eq']]
         user_versions = ['2.9', '1.9']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_equal_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_equal_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertFalse(result, custom_err_msg)
@@ -135,8 +140,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_less_than_or_equal_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_le']]
         user_versions = ['2.0.0', '1.9']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_less_than_or_equal_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_less_than_or_equal_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertTrue(result, custom_err_msg)
@@ -145,8 +151,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_less_than_or_equal_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_le']]
         user_versions = ['2.5.1']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_less_than_or_equal_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_less_than_or_equal_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertFalse(result, custom_err_msg)
@@ -155,8 +162,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_greater_than_or_equal_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_ge']]
         user_versions = ['2.0.0', '2.9']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_or_equal_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_or_equal_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertTrue(result, custom_err_msg)
@@ -165,8 +173,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_greater_than_or_equal_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_ge']]
         user_versions = ['1.9']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_or_equal_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_or_equal_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertFalse(result, custom_err_msg)
@@ -175,8 +184,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_less_than_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_lt']]
         user_versions = ['1.9']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_less_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_less_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertTrue(result, custom_err_msg)
@@ -185,8 +195,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_less_than_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_lt']]
         user_versions = ['2.0.0', '2.5.1']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_less_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_less_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertFalse(result, custom_err_msg)
@@ -195,8 +206,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_greater_than_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_gt']]
         user_versions = ['2.9']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertTrue(result, custom_err_msg)
@@ -205,8 +217,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_greater_than_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_gt']]
         user_versions = ['2.0.0', '1.9']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertFalse(result, custom_err_msg)
@@ -215,8 +228,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_greater_than_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_gt']]
         user_versions = [True, 37]
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertIsNone(result, custom_err_msg)
@@ -225,8 +239,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         semver_greater_than_2_0_condition_list = [['Android', "2.0", 'custom_attribute', 'semver_gt']]
         user_versions = ['3.7.2.2', '+']
         for user_version in user_versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertIsNone(result, custom_err_msg)
@@ -242,8 +257,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
             ('2.9.1', '2.9.1+beta')
         ]
         for target_version, user_version in versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.compare_user_version_with_target_version(target_version, user_version)
             custom_err_msg = f"Got {result} in result. Failed for user version:" \
                              f" {user_version} and target version: {target_version}"
@@ -264,8 +280,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
             ('2.2.3+beta2-beta1', '2.2.3+beta3-beta2')
         ]
         for target_version, user_version in versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.compare_user_version_with_target_version(target_version, user_version)
             custom_err_msg = f"Got {result} in result. Failed for user version:" \
                              f" {user_version} and target version: {target_version}"
@@ -286,8 +303,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
             ('2.1.3-beta1+beta3', '2.1.3-beta1+beta2')
         ]
         for target_version, user_version in versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.compare_user_version_with_target_version(target_version, user_version)
             custom_err_msg = f"Got {result} in result. Failed for user version:" \
                              f" {user_version} and target version: {target_version}"
@@ -300,8 +318,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         target_version = '2.1.0'
 
         for user_version in versions:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_greater_than_2_0_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_greater_than_2_0_condition_list, self.user_context, self.mock_client_logger)
             result = evaluator.compare_user_version_with_target_version(user_version, target_version)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
             self.assertIsNone(result, custom_err_msg)
@@ -309,69 +328,71 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_exists__returns_false__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, {}, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_exists__returns_false__when_user_provided_value_is_null(self):
-
+        self.user_context._user_attributes = {'input_value': None}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, {'input_value': None}, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_exists__returns_true__when_user_provided_value_is_string(self):
 
+        self.user_context._user_attributes = {'input_value': 'hi'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, {'input_value': 'hi'}, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exists__returns_true__when_user_provided_value_is_number(self):
-
+        self.user_context._user_attributes = {'input_value': 10}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, {'input_value': 10}, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'input_value': 10.0}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, {'input_value': 10.0}, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exists__returns_true__when_user_provided_value_is_boolean(self):
-
+        self.user_context._user_attributes = {'input_value': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, {'input_value': False}, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exact_string__returns_true__when_user_provided_value_is_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'favorite_constellation': 'Lacerta'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_string_condition_list, {'favorite_constellation': 'Lacerta'}, self.mock_client_logger,
+            exact_string_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exact_string__returns_false__when_user_provided_value_is_not_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'favorite_constellation': 'The Big Dipper'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_string_condition_list, {'favorite_constellation': 'The Big Dipper'}, self.mock_client_logger,
+            exact_string_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_exact_string__returns_null__when_user_provided_value_is_different_type_from_condition_value(self, ):
-
+        self.user_context._user_attributes = {'favorite_constellation': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_string_condition_list, {'favorite_constellation': False}, self.mock_client_logger,
+            exact_string_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -379,79 +400,83 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_exact_string__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_string_condition_list, {}, self.mock_client_logger
+            exact_string_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_exact_int__returns_true__when_user_provided_value_is_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'lasers_count': 9000}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_int_condition_list, {'lasers_count': 9000}, self.mock_client_logger
+            exact_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'lasers_count': 9000.0}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_int_condition_list, {'lasers_count': 9000.0}, self.mock_client_logger
+            exact_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exact_float__returns_true__when_user_provided_value_is_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'lasers_count': 9000}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_float_condition_list, {'lasers_count': 9000}, self.mock_client_logger
+            exact_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'lasers_count': 9000.0}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_float_condition_list, {'lasers_count': 9000.0}, self.mock_client_logger,
+            exact_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exact_int__returns_false__when_user_provided_value_is_not_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'lasers_count': 8000}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_int_condition_list, {'lasers_count': 8000}, self.mock_client_logger
+            exact_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_exact_float__returns_false__when_user_provided_value_is_not_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'lasers_count': 8000.0}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_float_condition_list, {'lasers_count': 8000.0}, self.mock_client_logger,
+            exact_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_exact_int__returns_null__when_user_provided_value_is_different_type_from_condition_value(self, ):
-
+        self.user_context._user_attributes = {'lasers_count': 'hi'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_int_condition_list, {'lasers_count': 'hi'}, self.mock_client_logger
+            exact_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'lasers_count': True}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_int_condition_list, {'lasers_count': True}, self.mock_client_logger
+            exact_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_exact_float__returns_null__when_user_provided_value_is_different_type_from_condition_value(self, ):
-
+        self.user_context._user_attributes = {'lasers_count': 'hi'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_float_condition_list, {'lasers_count': 'hi'}, self.mock_client_logger
+            exact_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'lasers_count': True}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_float_condition_list, {'lasers_count': True}, self.mock_client_logger
+            exact_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -459,7 +484,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_exact_int__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_int_condition_list, {}, self.mock_client_logger
+            exact_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -467,7 +492,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_exact_float__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_float_condition_list, {}, self.mock_client_logger
+            exact_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -475,9 +500,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_exact__given_number_values__calls_is_finite_number(self):
         """ Test that CustomAttributeConditionEvaluator.evaluate returns True
         if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
+        self.user_context._user_attributes = {'lasers_count': 9000}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_int_condition_list, {'lasers_count': 9000}, self.mock_client_logger
+            exact_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         # assert that isFiniteNumber only needs to reject condition value to stop evaluation.
@@ -500,57 +525,56 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
         mock_is_finite.assert_has_calls([mock.call(9000), mock.call(9000)])
 
     def test_exact_bool__returns_true__when_user_provided_value_is_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'did_register_user': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_bool_condition_list, {'did_register_user': False}, self.mock_client_logger,
+            exact_bool_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_exact_bool__returns_false__when_user_provided_value_is_not_equal_to_condition_value(self, ):
-
+        self.user_context._user_attributes = {'did_register_user': True}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_bool_condition_list, {'did_register_user': True}, self.mock_client_logger,
+            exact_bool_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_exact_bool__returns_null__when_user_provided_value_is_different_type_from_condition_value(self, ):
-
+        self.user_context._user_attributes = {'did_register_user': 0}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_bool_condition_list, {'did_register_user': 0}, self.mock_client_logger
+            exact_bool_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_exact_bool__returns_null__when_no_user_provided_value(self):
-
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_bool_condition_list, {}, self.mock_client_logger
+            exact_bool_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_substring__returns_true__when_condition_value_is_substring_of_user_value(self, ):
-
+        self.user_context._user_attributes = {'headline_text': 'Limited time, buy now!'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, {'headline_text': 'Limited time, buy now!'}, self.mock_client_logger,
+            substring_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_substring__returns_false__when_condition_value_is_not_a_substring_of_user_value(self, ):
-
+        self.user_context._user_attributes = {'headline_text': 'Breaking news!'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, {'headline_text': 'Breaking news!'}, self.mock_client_logger,
+            substring_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_substring__returns_null__when_user_provided_value_not_a_string(self):
-
+        self.user_context._user_attributes = {'headline_text': 10}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, {'headline_text': 10}, self.mock_client_logger
+            substring_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -558,91 +582,96 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_substring__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, {}, self.mock_client_logger
+            substring_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_greater_than_int__returns_true__when_user_value_greater_than_condition_value(self, ):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            gt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            gt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_greater_than_float__returns_true__when_user_value_greater_than_condition_value(self, ):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.3}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_float_condition_list, {'meters_travelled': 48.3}, self.mock_client_logger
+            gt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_float_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            gt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_greater_than_int__returns_false__when_user_value_not_greater_than_condition_value(self, ):
-
+        self.user_context._user_attributes = {'meters_travelled': 47.9}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {'meters_travelled': 47.9}, self.mock_client_logger
+            gt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
-
+        self.user_context._user_attributes = {'meters_travelled': 47}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {'meters_travelled': 47}, self.mock_client_logger
+            gt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_greater_than_float__returns_false__when_user_value_not_greater_than_condition_value(self, ):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.2}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_float_condition_list, {'meters_travelled': 48.2}, self.mock_client_logger
+            gt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_float_condition_list, {'meters_travelled': 48}, self.mock_client_logger
+            gt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_greater_than_int__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 'a long way'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {'meters_travelled': 'a long way'}, self.mock_client_logger,
+            gt_int_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {'meters_travelled': False}, self.mock_client_logger
+            gt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_greater_than_float__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 'a long way'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_float_condition_list, {'meters_travelled': 'a long way'}, self.mock_client_logger,
+            gt_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_float_condition_list, {'meters_travelled': False}, self.mock_client_logger,
+            gt_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -650,7 +679,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_greater_than_int__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {}, self.mock_client_logger
+            gt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -658,105 +687,113 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_greater_than_float__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_float_condition_list, {}, self.mock_client_logger
+            gt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_greater_than_or_equal_int__returns_true__when_user_value_greater_than_or_equal_condition_value(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': 48}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_greater_than_or_equal_float__returns_true__when_user_value_greater_than_or_equal_condition_value(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.3}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {'meters_travelled': 48.3}, self.mock_client_logger
+            ge_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48.2}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {'meters_travelled': 48.2}, self.mock_client_logger
+            ge_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            ge_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_greater_than_or_equal_int__returns_false__when_user_value_not_greater_than_or_equal_condition_value(
             self):
-
+        self.user_context._user_attributes = {'meters_travelled': 47.9}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': 47.9}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 47}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': 47}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_greater_than_or_equal_float__returns_false__when_user_value_not_greater_than_or_equal_condition_value(
             self):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            ge_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {'meters_travelled': 48}, self.mock_client_logger
+            ge_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_greater_than_or_equal_int__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 'a long way'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': 'a long way'}, self.mock_client_logger,
+            ge_int_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': False}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_greater_than_or_equal_float__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 'a long way'}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {'meters_travelled': 'a long way'}, self.mock_client_logger,
+            ge_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {'meters_travelled': False}, self.mock_client_logger,
+            ge_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -764,7 +801,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_greater_than_or_equal_int__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -772,79 +809,84 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_greater_than_or_equal_float__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_float_condition_list, {}, self.mock_client_logger
+            ge_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_less_than_int__returns_true__when_user_value_less_than_condition_value(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 47.9}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_int_condition_list, {'meters_travelled': 47.9}, self.mock_client_logger
+            lt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 47}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_int_condition_list, {'meters_travelled': 47}, self.mock_client_logger
+            lt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_less_than_float__returns_true__when_user_value_less_than_condition_value(self, ):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_float_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            lt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_float_condition_list, {'meters_travelled': 48}, self.mock_client_logger
+            lt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_less_than_int__returns_false__when_user_value_not_less_than_condition_value(self, ):
 
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_int_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            lt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_int_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            lt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_less_than_float__returns_false__when_user_value_not_less_than_condition_value(self, ):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.2}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_float_condition_list, {'meters_travelled': 48.2}, self.mock_client_logger
+            lt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_float_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            lt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_less_than_int__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_int_condition_list, {'meters_travelled': False}, self.mock_client_logger
+            lt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_less_than_float__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_float_condition_list, {'meters_travelled': False}, self.mock_client_logger,
+            lt_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -852,7 +894,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_less_than_int__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_int_condition_list, {}, self.mock_client_logger
+            lt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -860,91 +902,97 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_less_than_float__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_float_condition_list, {}, self.mock_client_logger
+            lt_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_less_than_or_equal_int__returns_true__when_user_value_less_than_or_equal_condition_value(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 47.9}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {'meters_travelled': 47.9}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 47}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {'meters_travelled': 47}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {'meters_travelled': 48}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_less_than_or_equal_float__returns_true__when_user_value_less_than_or_equal_condition_value(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 41}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_float_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            le_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48.2}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_float_condition_list, {'meters_travelled': 48.2}, self.mock_client_logger
+            le_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 48}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_float_condition_list, {'meters_travelled': 48}, self.mock_client_logger
+            le_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictTrue(evaluator.evaluate(0))
 
     def test_less_than_or_equal_int__returns_false__when_user_value_not_less_than_or_equal_condition_value(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_less_than_or_equal_float__returns_false__when_user_value_not_less_than_or_equal_condition_value(self):
-
+        self.user_context._user_attributes = {'meters_travelled': 48.3}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_float_condition_list, {'meters_travelled': 48.3}, self.mock_client_logger
+            le_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
+        self.user_context._user_attributes = {'meters_travelled': 49}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_float_condition_list, {'meters_travelled': 49}, self.mock_client_logger
+            le_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
 
     def test_less_than_or_equal_int__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {'meters_travelled': False}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
 
     def test_less_than_or_equal_float__returns_null__when_user_value_is_not_a_number(self):
-
+        self.user_context._user_attributes = {'meters_travelled': False}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_float_condition_list, {'meters_travelled': False}, self.mock_client_logger,
+            le_float_condition_list, self.user_context, self.mock_client_logger,
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -952,7 +1000,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_less_than_or_equal_int__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -960,7 +1008,7 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_less_than_or_equal_float__returns_null__when_no_user_provided_value(self):
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_float_condition_list, {}, self.mock_client_logger
+            le_float_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -968,9 +1016,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_greater_than__calls_is_finite_number(self):
         """ Test that CustomAttributeConditionEvaluator.evaluate returns True
         if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_int_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            gt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         def is_finite_number__rejecting_condition_value(value):
@@ -1012,9 +1060,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_less_than__calls_is_finite_number(self):
         """ Test that CustomAttributeConditionEvaluator.evaluate returns True
         if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
+        self.user_context._user_attributes = {'meters_travelled': 47}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_int_condition_list, {'meters_travelled': 47}, self.mock_client_logger
+            lt_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         def is_finite_number__rejecting_condition_value(value):
@@ -1056,9 +1104,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_greater_than_or_equal__calls_is_finite_number(self):
         """ Test that CustomAttributeConditionEvaluator.evaluate returns True
         if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
+        self.user_context._user_attributes = {'meters_travelled': 48.1}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            ge_int_condition_list, {'meters_travelled': 48.1}, self.mock_client_logger
+            ge_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         def is_finite_number__rejecting_condition_value(value):
@@ -1100,9 +1148,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
     def test_less_than_or_equal__calls_is_finite_number(self):
         """ Test that CustomAttributeConditionEvaluator.evaluate returns True
         if is_finite_number returns True. Returns None if is_finite_number returns False. """
-
+        self.user_context._user_attributes = {'meters_travelled': 47}
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            le_int_condition_list, {'meters_travelled': 47}, self.mock_client_logger
+            le_int_condition_list, self.user_context, self.mock_client_logger
         )
 
         def is_finite_number__rejecting_condition_value(value):
@@ -1148,8 +1196,9 @@ class CustomAttributeConditionEvaluatorTest(base.BaseTest):
                               "+build-prerelease", "2..0"]
 
         for user_version in invalid_test_cases:
+            self.user_context._user_attributes = {'Android': user_version}
             evaluator = condition_helper.CustomAttributeConditionEvaluator(
-                semver_less_than_or_equal_2_0_1_condition_list, {'Android': user_version}, self.mock_client_logger)
+                semver_less_than_or_equal_2_0_1_condition_list, self.user_context, self.mock_client_logger)
 
             result = evaluator.evaluate(0)
             custom_err_msg = f"Got {result} in result. Failed for user version: {user_version}"
@@ -1183,14 +1232,14 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def setUp(self):
         base.BaseTest.setUp(self)
         self.mock_client_logger = mock.MagicMock()
+        self.user_context = self.optimizely.create_user_context('any-user')
 
     def test_evaluate__match_type__invalid(self):
         log_level = 'warning'
         condition_list = [['favorite_constellation', 'Lacerta', 'custom_attribute', 'regex']]
-        user_attributes = {}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            condition_list, user_attributes, self.mock_client_logger
+            condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1211,10 +1260,9 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_evaluate__condition_type__invalid(self):
         log_level = 'warning'
         condition_list = [['favorite_constellation', 'Lacerta', 'sdk_version', 'exact']]
-        user_attributes = {}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            condition_list, user_attributes, self.mock_client_logger
+            condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1235,10 +1283,9 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_exact__user_value__missing(self):
         log_level = 'debug'
         exact_condition_list = [['favorite_constellation', 'Lacerta', 'custom_attribute', 'exact']]
-        user_attributes = {}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_condition_list, user_attributes, self.mock_client_logger
+            exact_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1259,10 +1306,9 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_greater_than__user_value__missing(self):
         log_level = 'debug'
         gt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'gt']]
-        user_attributes = {}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_condition_list, user_attributes, self.mock_client_logger
+            gt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1283,10 +1329,9 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_less_than__user_value__missing(self):
         log_level = 'debug'
         lt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'lt']]
-        user_attributes = {}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_condition_list, user_attributes, self.mock_client_logger
+            lt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1307,10 +1352,9 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_substring__user_value__missing(self):
         log_level = 'debug'
         substring_condition_list = [['headline_text', 'buy now', 'custom_attribute', 'substring']]
-        user_attributes = {}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, user_attributes, self.mock_client_logger
+            substring_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1330,10 +1374,9 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
 
     def test_exists__user_value__missing(self):
         exists_condition_list = [['input_value', None, 'custom_attribute', 'exists']]
-        user_attributes = {}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, user_attributes, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
@@ -1345,10 +1388,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_exact__user_value__None(self):
         log_level = 'debug'
         exact_condition_list = [['favorite_constellation', 'Lacerta', 'custom_attribute', 'exact']]
-        user_attributes = {'favorite_constellation': None}
+        self.user_context._user_attributes = {'favorite_constellation': None}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_condition_list, user_attributes, self.mock_client_logger
+            exact_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1369,10 +1412,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_greater_than__user_value__None(self):
         log_level = 'debug'
         gt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'gt']]
-        user_attributes = {'meters_travelled': None}
+        self.user_context._user_attributes = {'meters_travelled': None}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_condition_list, user_attributes, self.mock_client_logger
+            gt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1393,10 +1436,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_less_than__user_value__None(self):
         log_level = 'debug'
         lt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'lt']]
-        user_attributes = {'meters_travelled': None}
+        self.user_context._user_attributes = {'meters_travelled': None}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_condition_list, user_attributes, self.mock_client_logger
+            lt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1417,10 +1460,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_substring__user_value__None(self):
         log_level = 'debug'
         substring_condition_list = [['headline_text', '12', 'custom_attribute', 'substring']]
-        user_attributes = {'headline_text': None}
+        self.user_context._user_attributes = {'headline_text': None}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, user_attributes, self.mock_client_logger
+            substring_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1440,10 +1483,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
 
     def test_exists__user_value__None(self):
         exists_condition_list = [['input_value', None, 'custom_attribute', 'exists']]
-        user_attributes = {'input_value': None}
+        self.user_context._user_attributes = {'input_value': None}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exists_condition_list, user_attributes, self.mock_client_logger
+            exists_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertStrictFalse(evaluator.evaluate(0))
@@ -1455,10 +1498,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_exact__user_value__unexpected_type(self):
         log_level = 'warning'
         exact_condition_list = [['favorite_constellation', 'Lacerta', 'custom_attribute', 'exact']]
-        user_attributes = {'favorite_constellation': {}}
+        self.user_context._user_attributes = {'favorite_constellation': {}}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_condition_list, user_attributes, self.mock_client_logger
+            exact_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1479,10 +1522,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_greater_than__user_value__unexpected_type(self):
         log_level = 'warning'
         gt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'gt']]
-        user_attributes = {'meters_travelled': '48'}
+        self.user_context._user_attributes = {'meters_travelled': '48'}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_condition_list, user_attributes, self.mock_client_logger
+            gt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1503,10 +1546,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_less_than__user_value__unexpected_type(self):
         log_level = 'warning'
         lt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'lt']]
-        user_attributes = {'meters_travelled': True}
+        self.user_context._user_attributes = {'meters_travelled': True}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_condition_list, user_attributes, self.mock_client_logger
+            lt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1527,10 +1570,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_substring__user_value__unexpected_type(self):
         log_level = 'warning'
         substring_condition_list = [['headline_text', '12', 'custom_attribute', 'substring']]
-        user_attributes = {'headline_text': 1234}
+        self.user_context._user_attributes = {'headline_text': 1234}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, user_attributes, self.mock_client_logger
+            substring_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1551,10 +1594,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_exact__user_value__infinite(self):
         log_level = 'warning'
         exact_condition_list = [['meters_travelled', 48, 'custom_attribute', 'exact']]
-        user_attributes = {'meters_travelled': float("inf")}
+        self.user_context._user_attributes = {'meters_travelled': float("inf")}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_condition_list, user_attributes, self.mock_client_logger
+            exact_condition_list, self.user_context, self.mock_client_logger
         )
 
         self.assertIsNone(evaluator.evaluate(0))
@@ -1575,10 +1618,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_greater_than__user_value__infinite(self):
         log_level = 'warning'
         gt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'gt']]
-        user_attributes = {'meters_travelled': float("nan")}
+        self.user_context._user_attributes = {'meters_travelled': float("nan")}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_condition_list, user_attributes, self.mock_client_logger
+            gt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1600,10 +1643,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_less_than__user_value__infinite(self):
         log_level = 'warning'
         lt_condition_list = [['meters_travelled', 48, 'custom_attribute', 'lt']]
-        user_attributes = {'meters_travelled': float('-inf')}
+        self.user_context._user_attributes = {'meters_travelled': float('-inf')}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            lt_condition_list, user_attributes, self.mock_client_logger
+            lt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1625,10 +1668,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_exact__user_value_type_mismatch(self):
         log_level = 'warning'
         exact_condition_list = [['favorite_constellation', 'Lacerta', 'custom_attribute', 'exact']]
-        user_attributes = {'favorite_constellation': 5}
+        self.user_context._user_attributes = {'favorite_constellation': 5}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_condition_list, user_attributes, self.mock_client_logger
+            exact_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1649,10 +1692,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_exact__condition_value_invalid(self):
         log_level = 'warning'
         exact_condition_list = [['favorite_constellation', {}, 'custom_attribute', 'exact']]
-        user_attributes = {'favorite_constellation': 'Lacerta'}
+        self.user_context._user_attributes = {'favorite_constellation': 'Lacerta'}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_condition_list, user_attributes, self.mock_client_logger
+            exact_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1673,10 +1716,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_exact__condition_value_infinite(self):
         log_level = 'warning'
         exact_condition_list = [['favorite_constellation', float('inf'), 'custom_attribute', 'exact']]
-        user_attributes = {'favorite_constellation': 'Lacerta'}
+        self.user_context._user_attributes = {'favorite_constellation': 'Lacerta'}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            exact_condition_list, user_attributes, self.mock_client_logger
+            exact_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1697,10 +1740,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_greater_than__condition_value_invalid(self):
         log_level = 'warning'
         gt_condition_list = [['meters_travelled', True, 'custom_attribute', 'gt']]
-        user_attributes = {'meters_travelled': 48}
+        self.user_context._user_attributes = {'meters_travelled': 48}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_condition_list, user_attributes, self.mock_client_logger
+            gt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1721,10 +1764,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_less_than__condition_value_invalid(self):
         log_level = 'warning'
         gt_condition_list = [['meters_travelled', float('nan'), 'custom_attribute', 'lt']]
-        user_attributes = {'meters_travelled': 48}
+        self.user_context._user_attributes = {'meters_travelled': 48}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            gt_condition_list, user_attributes, self.mock_client_logger
+            gt_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {
@@ -1745,10 +1788,10 @@ class CustomAttributeConditionEvaluatorLogging(base.BaseTest):
     def test_substring__condition_value_invalid(self):
         log_level = 'warning'
         substring_condition_list = [['headline_text', False, 'custom_attribute', 'substring']]
-        user_attributes = {'headline_text': 'breaking news'}
+        self.user_context._user_attributes = {'headline_text': 'breaking news'}
 
         evaluator = condition_helper.CustomAttributeConditionEvaluator(
-            substring_condition_list, user_attributes, self.mock_client_logger
+            substring_condition_list, self.user_context, self.mock_client_logger
         )
 
         expected_condition_log = {

--- a/tests/helpers_tests/test_validator.py
+++ b/tests/helpers_tests/test_validator.py
@@ -59,6 +59,11 @@ class ValidatorTest(base.BaseTest):
 
         self.assertTrue(validator.is_datafile_valid(json.dumps(self.config_dict)))
 
+    def test_is_datafile_valid__returns_true_with_audience_segments(self):
+        """ Test that valid datafile with audience segments returns True. """
+
+        self.assertTrue(validator.is_datafile_valid(json.dumps(self.config_dict_with_audience_segments)))
+
     def test_is_datafile_valid__returns_false(self):
         """ Test that invalid datafile returns False. """
 

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -647,7 +647,7 @@ class DecisionServiceTest(base.BaseTest):
             experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging
         )
         mock_bucket.assert_called_once_with(
@@ -710,7 +710,7 @@ class DecisionServiceTest(base.BaseTest):
             experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging
         )
         mock_bucket.assert_called_once_with(
@@ -764,7 +764,7 @@ class DecisionServiceTest(base.BaseTest):
             experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging
         )
         self.assertEqual(0, mock_bucket.call_count)
@@ -816,7 +816,7 @@ class DecisionServiceTest(base.BaseTest):
             experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging
         )
         mock_decision_service_logging.warning.assert_called_once_with(
@@ -878,7 +878,7 @@ class DecisionServiceTest(base.BaseTest):
             experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging
         )
         mock_decision_service_logging.exception.assert_called_once_with(
@@ -939,7 +939,7 @@ class DecisionServiceTest(base.BaseTest):
             experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging
         )
 
@@ -999,7 +999,7 @@ class DecisionServiceTest(base.BaseTest):
             experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "test_experiment",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging
         )
         mock_bucket.assert_called_once_with(
@@ -1163,7 +1163,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                     self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
                     enums.RolloutRuleAudienceEvaluationLogs,
                     '1',
-                    user.get_user_attributes(),
+                    user,
                     mock_decision_service_logging,
                 ),
                 mock.call(
@@ -1171,7 +1171,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                     self.project_config.get_experiment_from_key("211147").get_audience_conditions_or_ids(),
                     enums.RolloutRuleAudienceEvaluationLogs,
                     'Everyone Else',
-                    user.get_user_attributes(),
+                    user,
                     mock_decision_service_logging,
                 ),
             ],
@@ -1216,7 +1216,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                     self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
                     enums.RolloutRuleAudienceEvaluationLogs,
                     "1",
-                    user.get_user_attributes(),
+                    user,
                     mock_decision_service_logging,
                 ),
                 mock.call(
@@ -1224,7 +1224,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                     self.project_config.get_experiment_from_key("211137").get_audience_conditions_or_ids(),
                     enums.RolloutRuleAudienceEvaluationLogs,
                     "2",
-                    user.get_user_attributes(),
+                    user,
                     mock_decision_service_logging,
                 ),
                 mock.call(
@@ -1232,7 +1232,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                     self.project_config.get_experiment_from_key("211147").get_audience_conditions_or_ids(),
                     enums.RolloutRuleAudienceEvaluationLogs,
                     "Everyone Else",
-                    user.get_user_attributes(),
+                    user,
                     mock_decision_service_logging,
                 ),
             ],
@@ -1370,7 +1370,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             self.project_config.get_experiment_from_key("group_exp_2").get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             "group_exp_2",
-            {},
+            user,
             mock_decision_service_logging,
         )
 
@@ -1379,7 +1379,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             self.project_config.get_experiment_from_key("211127").get_audience_conditions_or_ids(),
             enums.RolloutRuleAudienceEvaluationLogs,
             "1",
-            user.get_user_attributes(),
+            user,
             mock_decision_service_logging,
         )
 

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -1130,7 +1130,7 @@ class OptimizelyTest(base.BaseTest):
             expected_experiment.get_audience_conditions_or_ids(),
             enums.ExperimentAudienceEvaluationLogs,
             'test_experiment',
-            {'test_attribute': 'test_value'},
+            mock.ANY,
             self.optimizely.logger,
         )
 

--- a/tests/test_optimizely_config.py
+++ b/tests/test_optimizely_config.py
@@ -13,9 +13,10 @@
 
 import json
 
-from optimizely import optimizely, project_config
+from optimizely import entities, optimizely, project_config
 from optimizely import optimizely_config
 from . import base
+import copy
 
 
 class OptimizelyConfigTest(base.BaseTest):
@@ -1230,6 +1231,7 @@ class OptimizelyConfigTest(base.BaseTest):
                     'key': 'test_feature_in_multiple_experiments'
                 }
             },
+            'integrations': [],
             'revision': '1',
             '_datafile': json.dumps(self.config_dict_with_features)
         }
@@ -1800,3 +1802,44 @@ class OptimizelyConfigTest(base.BaseTest):
                 self.assertIsInstance(delivery_rule, optimizely_config.OptimizelyExperiment)
 
         self.assertEqual(expected_features_map_dict, actual_features_map_dict)
+
+    def test_optimizely_integration_conversion(self):
+        ''' Test to confirm that integration conversion works and has expected output '''
+        proj_conf = project_config.ProjectConfig(
+            json.dumps(self.config_dict_with_audience_segments),
+            logger=None,
+            error_handler=None
+        )
+
+        config_service = optimizely_config.OptimizelyConfigService(proj_conf)
+        optly_config = config_service.get_config()
+
+        for integration in proj_conf.integration_key_map.values():
+            self.assertIsInstance(integration, entities.Integration)
+
+        for integration in optly_config.integrations:
+            self.assertIsInstance(integration, optimizely_config.OptimizelyIntegration)
+
+        integrations = self.config_dict_with_audience_segments['integrations']
+        self.assertGreater(len(integrations), 0)
+        self.assertEqual(len(optly_config.integrations), len(integrations))
+        self.assertEqual(len(proj_conf.integrations), len(integrations))
+
+        integration = integrations[0]
+        self.assertEqual(proj_conf.host_for_odp, integration['host'])
+        self.assertEqual(proj_conf.public_key_for_odp, integration['publicKey'])
+
+    def test_optimizely_integration_conversion_no_itegrations(self):
+        ''' Test to confirm that integration conversion works and has expected output '''
+        config_dict_with_audience_segments = copy.deepcopy(self.config_dict_with_audience_segments)
+        config_dict_with_audience_segments['integrations'] = []
+        proj_conf = project_config.ProjectConfig(
+            json.dumps(config_dict_with_audience_segments),
+            logger=None,
+            error_handler=None
+        )
+
+        config_service = optimizely_config.OptimizelyConfigService(proj_conf)
+        optly_config = config_service.get_config()
+
+        self.assertEqual(len(optly_config.integrations), 0)

--- a/tests/test_optimizely_config.py
+++ b/tests/test_optimizely_config.py
@@ -1829,6 +1829,8 @@ class OptimizelyConfigTest(base.BaseTest):
         self.assertEqual(proj_conf.host_for_odp, integration['host'])
         self.assertEqual(proj_conf.public_key_for_odp, integration['publicKey'])
 
+        self.assertEqual(sorted(proj_conf.all_segments), ['odp-segment-1', 'odp-segment-2', 'odp-segment-3'])
+
     def test_optimizely_integration_conversion_no_itegrations(self):
         ''' Test to confirm that integration conversion works and has expected output '''
         config_dict_with_audience_segments = copy.deepcopy(self.config_dict_with_audience_segments)

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -1784,12 +1784,14 @@ class UserContextTest(base.BaseTest):
         status = user_context.remove_all_forced_decisions()
         self.assertTrue(status)
 
-    def test_forced_decision_clone_return_valid_forced_decision(self):
+    def test_user_context_clone_return_valid(self):
         """
-        Should return valid forced decision on cloning.
+        Should return valid objects.
         """
         opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_features))
         user_context = opt_obj.create_user_context("test_user", {})
+        qualified_segments = ['seg1', 'seg2']
+        user_context.qualified_segments = qualified_segments
 
         context_with_flag = OptimizelyUserContext.OptimizelyDecisionContext('f1', None)
         decision_for_flag = OptimizelyUserContext.OptimizelyForcedDecision('v1')
@@ -1806,6 +1808,11 @@ class UserContextTest(base.BaseTest):
         self.assertEqual(user_context_2.user_id, 'test_user')
         self.assertEqual(user_context_2.get_user_attributes(), {})
         self.assertIsNotNone(user_context_2.forced_decisions_map)
+        self.assertIsNot(user_context.forced_decisions_map, user_context_2.forced_decisions_map)
+
+        self.assertTrue(user_context_2.qualified_segments)
+        self.assertEqual(user_context_2.qualified_segments, qualified_segments)
+        self.assertIsNot(user_context.qualified_segments, user_context_2.qualified_segments)
 
         self.assertEqual(user_context_2.get_forced_decision(context_with_flag).variation_key, 'v1')
         self.assertEqual(user_context_2.get_forced_decision(context_with_rule).variation_key, 'v2')
@@ -1915,3 +1922,56 @@ class UserContextTest(base.BaseTest):
         self.assertEqual(200, remove_forced_decision_counter.call_count)
         self.assertEqual(100, remove_all_forced_decisions_counter.call_count)
         self.assertEqual(100, clone_counter.call_count)
+
+    def test_decide_with_qualified_segments_segment_hit_in_ab_test(self):
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments))
+        user = client.create_user_context('user-id')
+        user.qualified_segments = ["odp-segment-1", "odp-segment-none"]
+
+        decision = user.decide('flag-segment', ['IGNORE_USER_PROFILE_SERVICE'])
+
+        self.assertEqual(decision.variation_key, "variation-a")
+
+    def test_decide_with_qualified_segments_other_audience_hit_in_ab_test(self):
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments))
+        user = client.create_user_context('user-id', {"age": 30})
+        user.qualified_segments = ["odp-segment-none"]
+
+        decision = user.decide('flag-segment', ['IGNORE_USER_PROFILE_SERVICE'])
+
+        self.assertEqual(decision.variation_key, "variation-a")
+
+    def test_decide_with_qualified_segments_segment_hit_in_rollout(self):
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments))
+        user = client.create_user_context('user-id')
+        user.qualified_segments = ["odp-segment-2"]
+
+        decision = user.decide('flag-segment', ['IGNORE_USER_PROFILE_SERVICE'])
+
+        self.assertEqual(decision.variation_key, "rollout-variation-on")
+
+    def test_decide_with_qualified_segments_segment_miss_in_rollout(self):
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments))
+        user = client.create_user_context('user-id')
+        user.qualified_segments = ["odp-segment-none"]
+
+        decision = user.decide('flag-segment', ['IGNORE_USER_PROFILE_SERVICE'])
+
+        self.assertEqual(decision.variation_key, "rollout-variation-off")
+
+    def test_decide_with_qualified_segments_empty_segments(self):
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments))
+        user = client.create_user_context('user-id')
+        user.qualified_segments = []
+
+        decision = user.decide('flag-segment', ['IGNORE_USER_PROFILE_SERVICE'])
+
+        self.assertEqual(decision.variation_key, "rollout-variation-off")
+
+    def test_decide_with_qualified_segments_default(self):
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments))
+        user = client.create_user_context('user-id')
+
+        decision = user.decide('flag-segment', ['IGNORE_USER_PROFILE_SERVICE'])
+
+        self.assertEqual(decision.variation_key, "rollout-variation-off")


### PR DESCRIPTION
Summary
-------

- A new field `integrations` and new audience type `odp.audiences` will be added to the datafile schema for ODP integration.

-  parse the odp values (`publicKey` and `host`)

-  accept datafile with and without the `integrations` section or empty section as well.

-  support a new audience with the `odp.audiences` and `qualified` match.

-  support any (allowed) combination of audiences, including ODP and other existing audiences.

Test plan
---------
Added/extended tests in:
- test_optimizely_config.py
- test_validator.py
- test_audience.py
- test_condition.py
- test_user_context.py
