### PR TITLE
(feat) add zaius graphql api manager w tests

### DIFF
--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -13,31 +13,29 @@
 
 import json
 import logging
-import requests
-
-from requests import exceptions as request_exception
 from sys import version_info
 
-from .helpers import enums
-from .helpers.enums import EventDispatchTimeout
+import requests
+from requests import exceptions as request_exception
+
 from . import event_builder
+from .helpers.enums import HTTPVerbs, EventDispatchConfig
 
 if version_info < (3, 8):
-    from typing_extensions import Protocol, Final
+    from typing_extensions import Protocol
 else:
-    from typing import Protocol, Final  # type: ignore
-
-
-REQUEST_TIMEOUT: Final = EventDispatchTimeout.REQUEST_TIMEOUT
+    from typing import Protocol  # type: ignore
 
 
 class CustomEventDispatcher(Protocol):
     """Interface for a custom event dispatcher and required method `dispatch_event`. """
+
     def dispatch_event(self, event: event_builder.Event) -> None:
         ...
 
 
 class EventDispatcher:
+
     @staticmethod
     def dispatch_event(event: event_builder.Event) -> None:
         """ Dispatch the event being represented by the Event object.
@@ -46,11 +44,13 @@ class EventDispatcher:
       event: Object holding information about the request to be dispatched to the Optimizely backend.
     """
         try:
-            if event.http_verb == enums.HTTPVerbs.GET:
-                requests.get(event.url, params=event.params, timeout=REQUEST_TIMEOUT).raise_for_status()
-            elif event.http_verb == enums.HTTPVerbs.POST:
+            if event.http_verb == HTTPVerbs.GET:
+                requests.get(event.url, params=event.params,
+                             timeout=EventDispatchConfig.REQUEST_TIMEOUT).raise_for_status()
+            elif event.http_verb == HTTPVerbs.POST:
                 requests.post(
-                    event.url, data=json.dumps(event.params), headers=event.headers, timeout=REQUEST_TIMEOUT,
+                    event.url, data=json.dumps(event.params), headers=event.headers,
+                    timeout=EventDispatchConfig.REQUEST_TIMEOUT,
                 ).raise_for_status()
 
         except request_exception.RequestException as error:

--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -19,6 +19,7 @@ from requests import exceptions as request_exception
 from sys import version_info
 
 from .helpers import enums
+from .helpers.enums import EventDispatchTimeout
 from . import event_builder
 
 if version_info < (3, 8):
@@ -27,7 +28,7 @@ else:
     from typing import Protocol, Final  # type: ignore
 
 
-REQUEST_TIMEOUT: Final = 10
+REQUEST_TIMEOUT: Final = EventDispatchTimeout.REQUEST_TIMEOUT
 
 
 class CustomEventDispatcher(Protocol):

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -190,3 +190,9 @@ class NotificationTypes:
 class VersionType:
     IS_PRE_RELEASE: Final = '-'
     IS_BUILD: Final = '+'
+
+
+class EventDispatchTimeout:
+    """Time before request to send events times out.
+       Applies to anywhere we send events, i.e.: event_dispatcher, fetch_segments (odp)"""
+    REQUEST_TIMEOUT: Final = 10

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -120,6 +120,10 @@ class Errors:
     NONE_VARIABLE_KEY_PARAMETER: Final = '"None" is an invalid value for variable key.'
     UNSUPPORTED_DATAFILE_VERSION: Final = (
         'This version of the Python SDK does not support the given datafile version: "{}".')
+    INVALID_SEGMENT_IDENTIFIER = 'Audience segments fetch failed (invalid identifier).'
+    FETCH_SEGMENTS_FAILED = 'Audience segments fetch failed ({}).'
+    ODP_EVENT_FAILED = 'ODP event send failed (invalid url).'
+    ODP_NOT_ENABLED = 'ODP is not enabled. '
 
 
 class ForcedDecisionLogs:

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -192,7 +192,16 @@ class VersionType:
     IS_BUILD: Final = '+'
 
 
-class EventDispatchTimeout:
-    """Time before request to send events times out.
-       Applies to anywhere we send events, i.e.: event_dispatcher, fetch_segments (odp)"""
+class EventDispatchConfig:
+    """Event dispatching configs."""
+    REQUEST_TIMEOUT: Final = 10
+
+
+class OdpRestApiConfig:
+    """ODP Rest API configs."""
+    REQUEST_TIMEOUT: Final = 10
+
+
+class OdpGraphQlApiConfig:
+    """ODP GraphQL API configs."""
     REQUEST_TIMEOUT: Final = 10

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -202,6 +202,6 @@ class OdpRestApiConfig:
     REQUEST_TIMEOUT: Final = 10
 
 
-class OdpGraphQlApiConfig:
+class OdpGraphQLApiConfig:
     """ODP GraphQL API configs."""
     REQUEST_TIMEOUT: Final = 10

--- a/optimizely/odp/zaius_graphql_api_manager.py
+++ b/optimizely/odp/zaius_graphql_api_manager.py
@@ -14,19 +14,13 @@
 from __future__ import annotations
 
 import json
-from sys import version_info
 from typing import Optional
 
 import requests
-from requests.exceptions import RequestException, ConnectionError, Timeout, JSONDecodeError, InvalidJSONError
+from requests.exceptions import RequestException, ConnectionError, Timeout, JSONDecodeError
 
 from optimizely import logger as optimizely_logger
-from optimizely.helpers.enums import Errors, EventDispatchTimeout
-
-if version_info < (3, 8):
-    from typing_extensions import Final
-else:
-    from typing import Final  # type: ignore
+from optimizely.helpers.enums import Errors, OdpGraphQlApiConfig
 
 """
  ODP GraphQL API
@@ -110,8 +104,6 @@ else:
     }
 """
 
-REQUEST_TIMEOUT: Final = EventDispatchTimeout.REQUEST_TIMEOUT
-
 
 class ZaiusGraphQLApiManager:
     """Interface for manging the fetching of audience segments."""
@@ -148,7 +140,7 @@ class ZaiusGraphQLApiManager:
             response = requests.post(url=url,
                                      headers=request_headers,
                                      data=json.dumps(payload_dict),
-                                     timeout=REQUEST_TIMEOUT)
+                                     timeout=OdpGraphQlApiConfig.REQUEST_TIMEOUT)
 
             response.raise_for_status()
             response_dict = response.json()
@@ -159,8 +151,8 @@ class ZaiusGraphQLApiManager:
             self.logger.debug(f'GraphQL download failed: {err}')
             self.logger.error(Errors.FETCH_SEGMENTS_FAILED.format('network error'))
             return None
-        except (JSONDecodeError, InvalidJSONError, json.JSONDecodeError) as err:
-            self.logger.error(f'JSON decoding error: {err}')
+        except JSONDecodeError:
+            self.logger.error(Errors.FETCH_SEGMENTS_FAILED.format('JSON decode error'))
             return None
         except RequestException as err:
             self.logger.error(Errors.FETCH_SEGMENTS_FAILED.format(err))

--- a/optimizely/odp/zaius_graphql_api_manager.py
+++ b/optimizely/odp/zaius_graphql_api_manager.py
@@ -20,7 +20,7 @@ import requests
 from requests.exceptions import RequestException, ConnectionError, Timeout, JSONDecodeError
 
 from optimizely import logger as optimizely_logger
-from optimizely.helpers.enums import Errors, OdpGraphQlApiConfig
+from optimizely.helpers.enums import Errors, OdpGraphQLApiConfig
 
 """
  ODP GraphQL API
@@ -140,7 +140,7 @@ class ZaiusGraphQLApiManager:
             response = requests.post(url=url,
                                      headers=request_headers,
                                      data=json.dumps(payload_dict),
-                                     timeout=OdpGraphQlApiConfig.REQUEST_TIMEOUT)
+                                     timeout=OdpGraphQLApiConfig.REQUEST_TIMEOUT)
 
             response.raise_for_status()
             response_dict = response.json()

--- a/optimizely/odp/zaius_graphql_api_manager.py
+++ b/optimizely/odp/zaius_graphql_api_manager.py
@@ -1,0 +1,218 @@
+# Copyright 2022, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from sys import version_info
+from typing import Optional, List
+
+import requests
+
+from optimizely import logger as optimizely_logger
+from optimizely.helpers.enums import Errors
+
+if version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final  # type: ignore
+
+"""
+ ODP GraphQL API
+ - https://api.zaius.com/v3/graphql
+ - test ODP public API key = "W4WzcEs-ABgXorzY7h1LCQ"
+
+
+ [GraphQL Request]
+
+ # fetch info with fs_user_id for ["has_email", "has_email_opted_in", "push_on_sale"] segments
+ curl -i -H 'Content-Type: application/json' -H 'x-api-key: W4WzcEs-ABgXorzY7h1LCQ' -X POST -d
+ '{"query":"query {customer(fs_user_id: \"tester-101\") {audiences(subset:[\"has_email\",
+ \"has_email_opted_in\", \"push_on_sale\"]) {edges {node {name state}}}}}"}' https://api.zaius.com/v3/graphql
+ # fetch info with vuid for ["has_email", "has_email_opted_in", "push_on_sale"] segments
+ curl -i -H 'Content-Type: application/json' -H 'x-api-key: W4WzcEs-ABgXorzY7h1LCQ' -X POST -d
+ '{"query":"query {customer(vuid: \"d66a9d81923d4d2f99d8f64338976322\") {audiences(subset:[\"has_email\",
+ \"has_email_opted_in\", \"push_on_sale\"]) {edges {node {name state}}}}}"}' https://api.zaius.com/v3/graphql
+
+    query MyQuery {
+    customer(vuid: "d66a9d81923d4d2f99d8f64338976322") {
+     audiences(subset:["has_email", "has_email_opted_in", "push_on_sale"]) {
+       edges {
+         node {
+           name
+           state
+         }
+       }
+     }
+    }
+    }
+
+
+    [GraphQL Response]
+    {
+    "data": {
+     "customer": {
+       "audiences": {
+         "edges": [
+           {
+             "node": {
+               "name": "has_email",
+               "state": "qualified",
+             }
+           },
+           {
+             "node": {
+               "name": "has_email_opted_in",
+               "state": "qualified",
+             }
+           },
+            ...
+         ]
+       }
+     }
+    }
+    }
+
+    [GraphQL Error Response]
+    {
+    "errors": [
+     {
+       "message": "Exception while fetching data (/customer) : java.lang.RuntimeException:
+       could not resolve _fs_user_id = asdsdaddddd",
+       "locations": [
+         {
+           "line": 2,
+           "column": 3
+         }
+       ],
+       "path": [
+         "customer"
+       ],
+       "extensions": {
+         "classification": "InvalidIdentifierException"
+       }
+     }
+    ],
+    "data": {
+     "customer": null
+    }
+    }
+"""
+
+
+REQUEST_TIMEOUT: Final = 10
+
+
+class ZaiusGraphQLApiManager:
+    """Interface for manging the fetching of audience segments."""
+    def __init__(self, logger: Optional[optimizely_logger.Logger] = None):
+        self.logger = logger or optimizely_logger.NoOpLogger()
+
+    def fetch_segments(self, api_key: str, api_host: str, user_key: str,
+                       user_value: str, segments_to_check: list[str]) -> Optional[list[str]]:
+        """
+        Fetch segments from ODP GraphQL API.
+
+        Args:
+            api_key: public api key
+            api_host: domain url of the host
+            user_key: vuid or fs_user_id (client device id or fullstack id)
+            user_value: vaue of user_key
+            segments_to_check: lit of segments to check
+
+        Returns:
+            Audience segments from GraphQL.
+        """
+        url = f'{api_host}/v3/graphql'
+        request_headers = {'content-type': 'application/json',
+                           'x-api-key': str(api_key)}
+
+        segments_filter = self.make_subset_filter(segments_to_check)
+        payload_dict = {
+            'query': 'query {customer(' + str(user_key) + ': "' + str(user_value) + '") '
+                     '{audiences' + segments_filter + ' {edges {node {name state}}}}}'
+        }
+
+        try:
+            response = requests.post(url=url,
+                                     headers=request_headers,
+                                     data=json.dumps(payload_dict),
+                                     timeout=REQUEST_TIMEOUT)
+
+            response.raise_for_status()
+            response_dict = response.json()
+
+        except requests.exceptions.RequestException as err:
+            # There is no status code with network issues such as ConnectionError or Timeouts
+            # (i.e. no internet, server can't be reached).
+            if isinstance(err, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)):
+                self.logger.debug(f'GraphQL download failed: {err}')
+                self.logger.error(Errors.FETCH_SEGMENTS_FAILED.format('network error'))
+                return None
+            elif err.response.status_code >= 400:
+                self.logger.error(Errors.FETCH_SEGMENTS_FAILED.format(err.response.status_code))
+                return None
+
+        else:
+            if response_dict and 'errors' in response_dict:
+                odp_errors_list = self.extract_components(response_dict, 'errors')
+                error_class = self.extract_components(odp_errors_list[0], 'extensions.classification')
+
+                if error_class == 'InvalidIdentifierException':
+                    self.logger.error(Errors.INVALID_SEGMENT_IDENTIFIER)
+                    return None
+                else:
+                    self.logger.error(Errors.FETCH_SEGMENTS_FAILED.format(error_class))
+                    return None
+            else:
+                audiences = self.extract_components(response_dict, 'data.customer.audiences.edges')
+
+                if audiences is None:
+                    self.logger.error(Errors.FETCH_SEGMENTS_FAILED.format('decode error'))
+                    return None
+
+                segments = [edge['node']['name'] for edge in audiences if edge['node']['state'] == 'qualified']
+                return segments
+
+    @staticmethod
+    def make_subset_filter(segments: list[str]) -> str:
+        """
+        segments = []: (fetch none)
+         --> subsetFilter = "(subset:[])"
+        segments = ["a"]: (fetch one segment)
+         --> subsetFilter = '(subset:["a"])'
+
+         Purposely using .join() method to deal with special cases of
+         any words with apostrophes (i.e. don't). .join() menhod enquotes
+         correctly without conflicting with the apostrophe.
+        """
+        if segments == []:
+            return '(subset:[])'
+        return '(subset:["' + '", "'.join(segments) + '"]' + ')'
+
+    @staticmethod
+    def extract_components(dictionary: dict, key_path: str) -> List[Optional[str]]:
+        """ Takes path to the key in dotted ke_path across nested dicts,
+        slices the path and returns the value of that key.
+        Works on consecutive nested dictionaries. Doesn't work if other
+        data structures are mixed in (i.e. lists). List can be the final
+        value.
+        """
+        current = dictionary
+
+        for component in key_path.split('.'):
+            if component not in current:
+                return None
+            current = current[component]
+        extracted_list = current
+        return extracted_list

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -255,7 +255,8 @@ class Optimizely:
             self, project_config: project_config.ProjectConfig, feature_key: str, variable_key: str,
             variable_type: Optional[str], user_id: str, attributes: Optional[UserAttributes]
     ) -> Any:
-        """ Helper method to determine value for a certain variable attached to a feature flag based on type of variable.
+        """ Helper method to determine value for a certain variable attached to a feature flag based on
+        type of variable.
 
         Args:
           project_config: Instance of ProjectConfig.

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -18,6 +18,7 @@ from requests import exceptions as request_exception
 
 from optimizely import event_builder
 from optimizely import event_dispatcher
+from optimizely.helpers.enums import EventDispatchConfig
 
 
 class EventDispatcherTest(unittest.TestCase):
@@ -31,7 +32,7 @@ class EventDispatcherTest(unittest.TestCase):
         with mock.patch('requests.get') as mock_request_get:
             event_dispatcher.EventDispatcher.dispatch_event(event)
 
-        mock_request_get.assert_called_once_with(url, params=params, timeout=event_dispatcher.REQUEST_TIMEOUT)
+        mock_request_get.assert_called_once_with(url, params=params, timeout=EventDispatchConfig.REQUEST_TIMEOUT)
 
     def test_dispatch_event__post_request(self):
         """ Test that dispatch event fires off requests call with provided URL, params, HTTP verb and headers. """
@@ -52,7 +53,7 @@ class EventDispatcherTest(unittest.TestCase):
             url,
             data=json.dumps(params),
             headers={'Content-Type': 'application/json'},
-            timeout=event_dispatcher.REQUEST_TIMEOUT,
+            timeout=EventDispatchConfig.REQUEST_TIMEOUT,
         )
 
     def test_dispatch_event__handle_request_exception(self):
@@ -76,6 +77,6 @@ class EventDispatcherTest(unittest.TestCase):
             url,
             data=json.dumps(params),
             headers={'Content-Type': 'application/json'},
-            timeout=event_dispatcher.REQUEST_TIMEOUT,
+            timeout=EventDispatchConfig.REQUEST_TIMEOUT,
         )
         mock_log_error.assert_called_once_with('Dispatch event failed. Error: Failed Request')

--- a/tests/test_odp_zaius_graphql_api_manager.py
+++ b/tests/test_odp_zaius_graphql_api_manager.py
@@ -36,7 +36,8 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
 
     def test_fetch_qualified_segments__success(self):
         with mock.patch('requests.post') as mock_request_post:
-            mock_request_post.return_value.json.return_value = json.loads(self.good_response_data)
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.good_response_data.encode('utf-8'))
 
             api = ZaiusGraphQLApiManager()
             response = api.fetch_segments(api_key=self.api_key,
@@ -47,9 +48,75 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
 
         self.assertEqual(response, ['a', 'b'])
 
+    def test_fetch_qualified_segments__node_missing(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.node_missing_response_data.encode('utf-8'))
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=['dummy1', 'dummy2', 'dummy3'])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
+
+    def test_fetch_qualified_segments__name_missing(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.name_missing_response_data.encode('utf-8'))
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=['dummy1', 'dummy2', 'dummy3'])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
+
+    def test_fetch_qualified_segments__state_missing(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.state_missing_response_data.encode('utf-8'))
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=['dummy1', 'dummy2', 'dummy3'])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
+
+    def test_fetch_qualified_segments__mixed_missing_keys(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200,
+                                          _content=self.mixed_missing_keys_response_data.encode('utf-8'))
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=['dummy1', 'dummy2', 'dummy3'])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
+
     def test_fetch_qualified_segments__success_with_empty_segments(self):
         with mock.patch('requests.post') as mock_request_post:
-            mock_request_post.return_value.json.return_value = json.loads(self.good_empty_response_data)
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.good_empty_response_data.encode('utf-8'))
 
             api = ZaiusGraphQLApiManager()
             response = api.fetch_segments(api_key=self.api_key,
@@ -63,7 +130,9 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
     def test_fetch_qualified_segments__invalid_identifier(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-            mock_request_post.return_value.json.return_value = json.loads(self.invalid_identifier_response_data)
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200,
+                                          _content=self.invalid_identifier_response_data.encode('utf-8'))
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -78,7 +147,8 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
     def test_fetch_qualified_segments__other_exception(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-            mock_request_post.return_value.json.return_value = json.loads(self.other_exception_response_data)
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.other_exception_response_data.encode('utf-8'))
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -93,7 +163,8 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
     def test_fetch_qualified_segments__bad_response(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-            mock_request_post.return_value.json.return_value = json.loads(self.bad_response_data)
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.bad_response_data.encode('utf-8'))
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -105,10 +176,27 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         mock_request_post.assert_called_once()
         mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
 
+    def test_fetch_qualified_segments__invalid_json(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value = \
+                self.fake_server_response(status_code=200, _content=self.name_invalid_response_data.encode('utf-8'))
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=[])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with("JSON decoding error: Expecting ',' "
+                                                  "delimiter: line 9 column 48 (char 252)")
+
     def test_fetch_qualified_segments__invalid_key(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-            mock_request_post.return_value.json.return_value = json.loads(self.invalid_key_response_data)
+            mock_request_post.return_value.json.return_value = json.loads(self.invalid_edges_key_response_data)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -139,7 +227,6 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         with mock.patch('requests.post',
                         side_effect=request_exception.ConnectionError('Connection error')) as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
                                api_host=self.api_host,
@@ -154,13 +241,10 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
     def test_fetch_qualified_segments__400(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-
-            def mock_exception(**kwargs):
-                myresponse = Response()
-                myresponse.status_code = 403
-                raise request_exception.HTTPError(response=myresponse)
-
-            mock_request_post.side_effect = mock_exception
+            myresponse = Response()
+            myresponse.status_code = 403
+            myresponse.url = self.api_host
+            mock_request_post.return_value = myresponse
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -174,18 +258,13 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         # we already it assert_called_once_with() in test_fetch_qualified_segments__valid_request()
         mock_request_post.assert_called_once()
         # assert 403 error log
-        mock_logger.error.assert_called_once_with('Audience segments fetch failed (403).')
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed '
+                                                  f'(403 Client Error: None for url: {self.api_host}).')
 
     def test_fetch_qualified_segments__500(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-
-            def mock_exception(**kwargs):
-                myresponse = Response()
-                myresponse.status_code = 500
-                raise request_exception.HTTPError(response=myresponse)
-
-            mock_request_post.side_effect = mock_exception
+            mock_request_post.return_value = self.fake_server_response(status_code=500, url=self.api_host)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -197,7 +276,8 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         # make sure that fetch_segments() is called (once).
         mock_request_post.assert_called_once()
         # assert 500 error log
-        mock_logger.error.assert_called_once_with('Audience segments fetch failed (500).')
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed '
+                                                  f'(500 Server Error: None for url: {self.api_host}).')
 
     def test_make_subset_filter(self):
         api = ZaiusGraphQLApiManager()
@@ -207,6 +287,20 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         self.assertEqual("(subset:[\"a\", \"b\", \"c\"])", api.make_subset_filter(['a', 'b', 'c']))
         self.assertEqual("(subset:[\"a\", \"b\", \"c\"])", api.make_subset_filter(["a", "b", "c"]))
         self.assertEqual("(subset:[\"a\", \"b\", \"don't\"])", api.make_subset_filter(["a", "b", "don't"]))
+
+    # fake server response function and test json responses
+
+    @staticmethod
+    def fake_server_response(**attributes):
+        """Mock the server response.
+           If you wish to include any other response attributes then just add them below.
+           Thera re all attributes of Response object, you can find them in dir(response)"""
+        response = Response()
+        response.status_code = attributes.get('status_code')
+        response._content = attributes.get('_content')
+        response.url = attributes.get('url')
+
+        return response
 
     good_response_data = """
         {
@@ -302,8 +396,8 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
             "data": {}
         }
         """
-    # TODO - for testing key error and log message when getting audiences (dict traversal)
-    invalid_key_response_data = """
+
+    invalid_edges_key_response_data = """
         {
             "data": {
                 "customer": {
@@ -362,3 +456,117 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
           }
     }
     """
+    name_invalid_response_data = """
+        {
+            "data": {
+                "customer": {
+                    "audiences": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "a":::invalid-part-here:::,
+                                    "state": "qualified",
+                                    "description": "qualifed sample 1"
+                                }
+                            },
+                            {
+                                "node": {
+                                    "name": "b",
+                                    "state": "qualified",
+                                    "description": "qualifed sample 2"
+                                }
+                            },
+                            {
+                                "node": {
+                                    "name": "c",
+                                    "state": "not_qualified",
+                                    "description": "not-qualified sample"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        """
+
+    node_missing_response_data = """
+        {
+            "data": {
+                "customer": {
+                    "audiences": {
+                        "edges": [
+                            {}
+                        ]
+                    }
+                }
+            }
+        }
+        """
+
+    name_missing_response_data = """
+        {
+            "data": {
+                "customer": {
+                    "audiences": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "state": "qualified",
+                                    "description": "qualified sample 1"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        """
+
+    state_missing_response_data = """
+        {
+            "data": {
+                "customer": {
+                    "audiences": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "a",
+                                    "description": "qualifed sample 1"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        """
+
+    mixed_missing_keys_response_data = """
+        {
+            "data": {
+                "customer": {
+                    "audiences": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "state": "qualified"
+                                }
+                            },
+                            {
+                                "node": {
+                                    "name": "a"
+                                }
+                            },
+                            {
+                                "other-name": {
+                                    "name": "a",
+                                    "state": "qualified"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        """

--- a/tests/test_odp_zaius_graphql_api_manager.py
+++ b/tests/test_odp_zaius_graphql_api_manager.py
@@ -3,8 +3,8 @@ from unittest import mock
 
 from requests import Response
 from requests import exceptions as request_exception
+from optimizely.helpers.enums import OdpGraphQlApiConfig
 
-from optimizely.odp.zaius_graphql_api_manager import REQUEST_TIMEOUT
 from optimizely.odp.zaius_graphql_api_manager import ZaiusGraphQLApiManager
 from . import base
 
@@ -32,7 +32,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         mock_request_post.assert_called_once_with(url=self.api_host + "/v3/graphql",
                                                   headers=request_headers,
                                                   data=json.dumps(test_payload),
-                                                  timeout=REQUEST_TIMEOUT)
+                                                  timeout=OdpGraphQlApiConfig.REQUEST_TIMEOUT)
 
     def test_fetch_qualified_segments__success(self):
         with mock.patch('requests.post') as mock_request_post:
@@ -53,38 +53,6 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
                 self.fake_server_response(status_code=200, _content=self.node_missing_response_data.encode('utf-8'))
-
-            api = ZaiusGraphQLApiManager(logger=mock_logger)
-            api.fetch_segments(api_key=self.api_key,
-                               api_host=self.api_host,
-                               user_key=self.user_key,
-                               user_value=self.user_value,
-                               segments_to_check=['dummy1', 'dummy2', 'dummy3'])
-
-        mock_request_post.assert_called_once()
-        mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
-
-    def test_fetch_qualified_segments__name_missing(self):
-        with mock.patch('requests.post') as mock_request_post, \
-                mock.patch('optimizely.logger') as mock_logger:
-            mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.name_missing_response_data.encode('utf-8'))
-
-            api = ZaiusGraphQLApiManager(logger=mock_logger)
-            api.fetch_segments(api_key=self.api_key,
-                               api_host=self.api_host,
-                               user_key=self.user_key,
-                               user_value=self.user_value,
-                               segments_to_check=['dummy1', 'dummy2', 'dummy3'])
-
-        mock_request_post.assert_called_once()
-        mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
-
-    def test_fetch_qualified_segments__state_missing(self):
-        with mock.patch('requests.post') as mock_request_post, \
-                mock.patch('optimizely.logger') as mock_logger:
-            mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.state_missing_response_data.encode('utf-8'))
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -176,7 +144,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         mock_request_post.assert_called_once()
         mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
 
-    def test_fetch_qualified_segments__invalid_json(self):
+    def test_fetch_qualified_segments__name_invalid(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
@@ -190,8 +158,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                                segments_to_check=[])
 
         mock_request_post.assert_called_once()
-        mock_logger.error.assert_called_once_with("JSON decoding error: Expecting ',' "
-                                                  "delimiter: line 9 column 48 (char 252)")
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (JSON decode error).')
 
     def test_fetch_qualified_segments__invalid_key(self):
         with mock.patch('requests.post') as mock_request_post, \
@@ -292,14 +259,11 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
 
     @staticmethod
     def fake_server_response(**attributes):
-        """Mock the server response.
-           If you wish to include any other response attributes then just add them below.
-           Thera re all attributes of Response object, you can find them in dir(response)"""
+        """Mock the server response."""
         response = Response()
         response.status_code = attributes.get('status_code')
         response._content = attributes.get('_content')
         response.url = attributes.get('url')
-
         return response
 
     good_response_data = """
@@ -409,20 +373,6 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                                     "state": "qualified",
                                     "description": "qualifed sample 1"
                                 }
-                            },
-                            {
-                                "node": {
-                                    "name": "b",
-                                    "state": "qualified",
-                                    "description": "qualifed sample 2"
-                                }
-                            },
-                            {
-                                "node": {
-                                    "name": "c",
-                                    "state": "not_qualified",
-                                    "description": "not-qualified sample"
-                                }
                             }
                         ]
                     }
@@ -468,20 +418,6 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                                     "state": "qualified",
                                     "description": "qualifed sample 1"
                                 }
-                            },
-                            {
-                                "node": {
-                                    "name": "b",
-                                    "state": "qualified",
-                                    "description": "qualifed sample 2"
-                                }
-                            },
-                            {
-                                "node": {
-                                    "name": "c",
-                                    "state": "not_qualified",
-                                    "description": "not-qualified sample"
-                                }
                             }
                         ]
                     }
@@ -497,44 +433,6 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                     "audiences": {
                         "edges": [
                             {}
-                        ]
-                    }
-                }
-            }
-        }
-        """
-
-    name_missing_response_data = """
-        {
-            "data": {
-                "customer": {
-                    "audiences": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "state": "qualified",
-                                    "description": "qualified sample 1"
-                                }
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-        """
-
-    state_missing_response_data = """
-        {
-            "data": {
-                "customer": {
-                    "audiences": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "name": "a",
-                                    "description": "qualifed sample 1"
-                                }
-                            }
                         ]
                     }
                 }

--- a/tests/test_odp_zaius_graphql_api_manager.py
+++ b/tests/test_odp_zaius_graphql_api_manager.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from requests import Response
 from requests import exceptions as request_exception
-from optimizely.helpers.enums import OdpGraphQlApiConfig
+from optimizely.helpers.enums import OdpGraphQLApiConfig
 
 from optimizely.odp.zaius_graphql_api_manager import ZaiusGraphQLApiManager
 from . import base
@@ -32,12 +32,12 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         mock_request_post.assert_called_once_with(url=self.api_host + "/v3/graphql",
                                                   headers=request_headers,
                                                   data=json.dumps(test_payload),
-                                                  timeout=OdpGraphQlApiConfig.REQUEST_TIMEOUT)
+                                                  timeout=OdpGraphQLApiConfig.REQUEST_TIMEOUT)
 
     def test_fetch_qualified_segments__success(self):
         with mock.patch('requests.post') as mock_request_post:
             mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.good_response_data.encode('utf-8'))
+                self.fake_server_response(status_code=200, content=self.good_response_data)
 
             api = ZaiusGraphQLApiManager()
             response = api.fetch_segments(api_key=self.api_key,
@@ -52,7 +52,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.node_missing_response_data.encode('utf-8'))
+                self.fake_server_response(status_code=200, content=self.node_missing_response_data)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -69,7 +69,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
                 self.fake_server_response(status_code=200,
-                                          _content=self.mixed_missing_keys_response_data.encode('utf-8'))
+                                          content=self.mixed_missing_keys_response_data)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -84,7 +84,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
     def test_fetch_qualified_segments__success_with_empty_segments(self):
         with mock.patch('requests.post') as mock_request_post:
             mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.good_empty_response_data.encode('utf-8'))
+                self.fake_server_response(status_code=200, content=self.good_empty_response_data)
 
             api = ZaiusGraphQLApiManager()
             response = api.fetch_segments(api_key=self.api_key,
@@ -100,7 +100,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
                 self.fake_server_response(status_code=200,
-                                          _content=self.invalid_identifier_response_data.encode('utf-8'))
+                                          content=self.invalid_identifier_response_data)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -116,7 +116,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.other_exception_response_data.encode('utf-8'))
+                self.fake_server_response(status_code=200, content=self.other_exception_response_data)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -132,7 +132,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.bad_response_data.encode('utf-8'))
+                self.fake_server_response(status_code=200, content=self.bad_response_data)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -148,7 +148,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
             mock_request_post.return_value = \
-                self.fake_server_response(status_code=200, _content=self.name_invalid_response_data.encode('utf-8'))
+                self.fake_server_response(status_code=200, content=self.name_invalid_response_data)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,
@@ -258,12 +258,13 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
     # fake server response function and test json responses
 
     @staticmethod
-    def fake_server_response(**attributes):
+    def fake_server_response(status_code=None, content=None, url=None):
         """Mock the server response."""
         response = Response()
-        response.status_code = attributes.get('status_code')
-        response._content = attributes.get('_content')
-        response.url = attributes.get('url')
+        response.status_code = status_code
+        if content:
+            response._content = content.encode('utf-8')
+        response.url = url
         return response
 
     good_response_data = """

--- a/tests/test_odp_zaius_graphql_api_manager.py
+++ b/tests/test_odp_zaius_graphql_api_manager.py
@@ -1,0 +1,284 @@
+import json
+from unittest import mock
+
+from requests import Response
+from requests import exceptions as request_exception
+
+from optimizely.odp.zaius_graphql_api_manager import REQUEST_TIMEOUT
+from optimizely.odp.zaius_graphql_api_manager import ZaiusGraphQLApiManager
+from . import base
+
+
+class ZaiusGraphQLApiManagerTest(base.BaseTest):
+    user_key = "vuid"
+    user_value = "test-user-value"
+    api_key = "test-api-key"
+    api_host = "test-host"
+
+    def test_fetch_qualified_segments__valid_request(self):
+        with mock.patch('requests.post') as mock_request_post:
+            api = ZaiusGraphQLApiManager()
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=["a", "b", "c"])
+
+        test_payload = {
+            'query': 'query {customer(' + self.user_key + ': "' + self.user_value + '") '
+            '{audiences(subset:["a", "b", "c"]) {edges {node {name state}}}}}'
+        }
+        request_headers = {'content-type': 'application/json', 'x-api-key': self.api_key}
+        mock_request_post.assert_called_once_with(url=self.api_host + "/v3/graphql",
+                                                  headers=request_headers,
+                                                  data=json.dumps(test_payload),
+                                                  timeout=REQUEST_TIMEOUT)
+
+    def test_fetch_qualified_segments__success(self):
+        with mock.patch('requests.post') as mock_request_post:
+            mock_request_post.return_value.json.return_value = json.loads(self.good_response_data)
+
+            api = ZaiusGraphQLApiManager()
+            response = api.fetch_segments(api_key=self.api_key,
+                                          api_host=self.api_host,
+                                          user_key=self.user_key,
+                                          user_value=self.user_value,
+                                          segments_to_check=['dummy1', 'dummy2', 'dummy3'])
+
+        self.assertEqual(response, ['a', 'b'])
+
+    def test_fetch_qualified_segments__success_with_empty_segments(self):
+        with mock.patch('requests.post') as mock_request_post:
+            mock_request_post.return_value.json.return_value = json.loads(self.good_empty_response_data)
+
+            api = ZaiusGraphQLApiManager()
+            response = api.fetch_segments(api_key=self.api_key,
+                                          api_host=self.api_host,
+                                          user_key=self.user_key,
+                                          user_value=self.user_value,
+                                          segments_to_check=['dummy'])
+
+        self.assertEqual(response, [])
+
+    def test_fetch_qualified_segments__invalid_identifier(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value.json.return_value = json.loads(self.invalid_identifier_response_data)
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=[])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (invalid identifier).')
+
+    def test_fetch_qualified_segments__other_exception(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value.json.return_value = json.loads(self.other_exception_response_data)
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=[])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (TestExceptionClass).')
+
+    def test_fetch_qualified_segments__bad_response(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+            mock_request_post.return_value.json.return_value = json.loads(self.bad_response_data)
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=[])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (decode error).')
+
+    def test_fetch_qualified_segments__network_error(self):
+        with mock.patch('requests.post',
+                        side_effect=request_exception.ConnectionError('Connection error')) as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=[])
+
+        mock_request_post.assert_called_once()
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (network error).')
+        mock_logger.debug.assert_called_once_with('GraphQL download failed: Connection error')
+
+    def test_fetch_qualified_segments__400(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+
+            def mock_exception(**kwargs):
+                myresponse = Response()
+                myresponse.status_code = 403
+                raise request_exception.HTTPError(response=myresponse)
+
+            mock_request_post.side_effect = mock_exception
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=["a", "b", "c"])
+
+        # make sure that fetch_segments() is called (once).
+        # could use assert_called_once_with() but it's not needed,
+        # we already it assert_called_once_with() in test_fetch_qualified_segments__valid_request()
+        mock_request_post.assert_called_once()
+        # assert 403 error log
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (403).')
+
+    def test_fetch_qualified_segments__500(self):
+        with mock.patch('requests.post') as mock_request_post, \
+                mock.patch('optimizely.logger') as mock_logger:
+
+            def mock_exception(**kwargs):
+                myresponse = Response()
+                myresponse.status_code = 500
+                raise request_exception.HTTPError(response=myresponse)
+
+            mock_request_post.side_effect = mock_exception
+
+            api = ZaiusGraphQLApiManager(logger=mock_logger)
+            api.fetch_segments(api_key=self.api_key,
+                               api_host=self.api_host,
+                               user_key=self.user_key,
+                               user_value=self.user_value,
+                               segments_to_check=["a", "b", "c"])
+
+        # make sure that fetch_segments() is called (once).
+        mock_request_post.assert_called_once()
+        # assert 500 error log
+        mock_logger.error.assert_called_once_with('Audience segments fetch failed (500).')
+
+    def test_make_subset_filter(self):
+        api = ZaiusGraphQLApiManager()
+
+        self.assertEqual("(subset:[])", api.make_subset_filter([]))
+        self.assertEqual("(subset:[\"a\"])", api.make_subset_filter(["a"]))
+        self.assertEqual("(subset:[\"a\", \"b\", \"c\"])", api.make_subset_filter(['a', 'b', 'c']))
+        self.assertEqual("(subset:[\"a\", \"b\", \"c\"])", api.make_subset_filter(["a", "b", "c"]))
+        self.assertEqual("(subset:[\"a\", \"b\", \"don't\"])", api.make_subset_filter(["a", "b", "don't"]))
+
+    def test_extract_component(self):
+        api = ZaiusGraphQLApiManager()
+        dictionary = {'a': {'b': {'c': 'v'}}}
+
+        self.assertEqual({'b': {'c': 'v'}}, api.extract_components(dictionary, 'a'))
+        self.assertEqual({'c': 'v'}, api.extract_components(dictionary, 'a.b'))
+        self.assertEqual('v', api.extract_components(dictionary, 'a.b.c'))
+        self.assertIsNone(api.extract_components(dictionary, 'a.b.c.d'))
+        self.assertIsNone(api.extract_components(dictionary, 'd'))
+
+    good_response_data = """
+        {
+            "data": {
+                "customer": {
+                    "audiences": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": "a",
+                                    "state": "qualified",
+                                    "description": "qualifed sample 1"
+                                }
+                            },
+                            {
+                                "node": {
+                                    "name": "b",
+                                    "state": "qualified",
+                                    "description": "qualifed sample 2"
+                                }
+                            },
+                            {
+                                "node": {
+                                    "name": "c",
+                                    "state": "not_qualified",
+                                    "description": "not-qualified sample"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        """
+
+    good_empty_response_data = """
+        {
+            "data": {
+                "customer": {
+                    "audiences": {
+                        "edges": []
+                    }
+                }
+            }
+        }
+        """
+
+    invalid_identifier_response_data = """
+        {
+          "errors": [
+            {
+              "message": "Exception while fetching data (/customer) :\
+               java.lang.RuntimeException: could not resolve _fs_user_id = asdsdaddddd",
+              "locations": [
+                {
+                  "line": 2,
+                  "column": 3
+                }
+              ],
+              "path": [
+                "customer"
+              ],
+              "extensions": {
+                "classification": "InvalidIdentifierException"
+              }
+            }
+          ],
+          "data": {
+            "customer": null
+          }
+        }
+        """
+
+    other_exception_response_data = """
+        {
+          "errors": [
+            {
+              "message": "Exception while fetching data (/customer) :\
+               java.lang.RuntimeException: could not resolve _fs_user_id = asdsdaddddd",
+              "extensions": {
+                "classification": "TestExceptionClass"
+              }
+            }
+          ],
+          "data": {
+            "customer": null
+          }
+        }
+        """
+
+    bad_response_data = """
+        {
+            "data": {}
+        }
+        """

--- a/tests/test_odp_zaius_graphql_api_manager.py
+++ b/tests/test_odp_zaius_graphql_api_manager.py
@@ -208,10 +208,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
     def test_fetch_qualified_segments__400(self):
         with mock.patch('requests.post') as mock_request_post, \
                 mock.patch('optimizely.logger') as mock_logger:
-            myresponse = Response()
-            myresponse.status_code = 403
-            myresponse.url = self.api_host
-            mock_request_post.return_value = myresponse
+            mock_request_post.return_value = self.fake_server_response(status_code=403, url=self.api_host)
 
             api = ZaiusGraphQLApiManager(logger=mock_logger)
             api.fetch_segments(api_key=self.api_key,


### PR DESCRIPTION
Summary
-------

- Adding a REST API to fetch audience segments from ODPs GraphQL service: zaius_graph_ql_api_manager.py
- Per Jira ticket [OASIS-8403](https://optimizely.atlassian.net/browse/OASIS-8403)  
- Acceptance criteria in the ticket:
>* Endpoint: https://api.zaius.com/v3/graphql
>* See TDD for details (request and response formats) and sample calls.
>* When fetching is completed successfully, it should return valid segments (string array). An empty array is a valid segment set.
>* When fetching fails, it should return a null segments array with the error logged (and/or returned).
>* When the server returns the “InvalidIdentifierException” error, this specific reason should be logged (and/or returned). Other errors can be logged (and/or returned) as “fetchSegmentsFailed”.


Test plan
---------
- unite tests in a new test file: test_odp_zaius_graphql_api_manager.py
- type checking
