### PR TITLE
Add license notice to graphgl test file

### DIFF
--- a/tests/test_odp_zaius_graphql_api_manager.py
+++ b/tests/test_odp_zaius_graphql_api_manager.py
@@ -1,3 +1,16 @@
+# Copyright 2022, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 from unittest import mock
 


### PR DESCRIPTION
Summary
-------

-  add missing license
- [OASIS-8403 add ODP GraphQLApi interface](https://optimizely.atlassian.net/browse/OASIS-8403)

Test plan
---------
unit tests

