### PR TITLE
feat: add json encoding validation

### DIFF
--- a/tests/test_odp_zaius_graphql_api_manager.py
+++ b/tests/test_odp_zaius_graphql_api_manager.py
@@ -122,7 +122,7 @@ class ZaiusGraphQLApiManagerTest(base.BaseTest):
                                segments_to_check=[])
 
         mock_request_post.assert_called_once()
-        mock_logger.error.assert_called_once_with('Audience segments fetch failed (invalid identifier).')
+        mock_logger.warning.assert_called_once_with('Audience segments fetch failed (invalid identifier).')
 
     def test_fetch_qualified_segments__other_exception(self):
         with mock.patch('requests.post') as mock_request_post, \


### PR DESCRIPTION
Summary
-------

-  Add additional validation to ODP GraphQL json encoding
-  change log level to warning for invalid identifier
- part of ticket [OASIS-8403 add ODP GraphQLApi interface](https://optimizely.atlassian.net/browse/OASIS-8403)

Test plan
---------
- adjusted unit tests
- FSC tests
