### PR TITLE
feat: add odp event manager

### DIFF
--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -123,7 +123,7 @@ class Errors:
     INVALID_SEGMENT_IDENTIFIER: Final = 'Audience segments fetch failed (invalid identifier).'
     FETCH_SEGMENTS_FAILED: Final = 'Audience segments fetch failed ({}).'
     ODP_EVENT_FAILED: Final = 'ODP event send failed ({}).'
-    ODP_NOT_ENABLED: Final = 'ODP is not enabled. '
+    ODP_NOT_INTEGRATED: Final = 'ODP is not integrated.'
 
 
 class ForcedDecisionLogs:
@@ -211,4 +211,4 @@ class OdpEventManagerConfig:
     """ODP Event Manager configs."""
     DEFAULT_QUEUE_CAPACITY: Final = 1000
     DEFAULT_BATCH_SIZE: Final = 10
-    DEFAULT_FLUSH_INTERVAL: Final = 15
+    DEFAULT_FLUSH_INTERVAL: Final = 10

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -120,10 +120,10 @@ class Errors:
     NONE_VARIABLE_KEY_PARAMETER: Final = '"None" is an invalid value for variable key.'
     UNSUPPORTED_DATAFILE_VERSION: Final = (
         'This version of the Python SDK does not support the given datafile version: "{}".')
-    INVALID_SEGMENT_IDENTIFIER = 'Audience segments fetch failed (invalid identifier).'
-    FETCH_SEGMENTS_FAILED = 'Audience segments fetch failed ({}).'
-    ODP_EVENT_FAILED = 'ODP event send failed ({}).'
-    ODP_NOT_ENABLED = 'ODP is not enabled. '
+    INVALID_SEGMENT_IDENTIFIER: Final = 'Audience segments fetch failed (invalid identifier).'
+    FETCH_SEGMENTS_FAILED: Final = 'Audience segments fetch failed ({}).'
+    ODP_EVENT_FAILED: Final = 'ODP event send failed ({}).'
+    ODP_NOT_ENABLED: Final = 'ODP is not enabled. '
 
 
 class ForcedDecisionLogs:
@@ -205,3 +205,9 @@ class OdpRestApiConfig:
 class OdpGraphQLApiConfig:
     """ODP GraphQL API configs."""
     REQUEST_TIMEOUT: Final = 10
+
+
+class OdpEventManagerConfig:
+    """ODP Event Manager configs."""
+    DEFAULT_QUEUE_CAPACITY: Final = 1000
+    DEFAULT_BATCH_SIZE: Final = 10

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -212,5 +212,5 @@ class OdpEventManagerConfig:
     """ODP Event Manager configs."""
     DEFAULT_QUEUE_CAPACITY: Final = 1000
     DEFAULT_BATCH_SIZE: Final = 10
-    DEFAULT_FLUSH_INTERVAL: Final = 10
+    DEFAULT_FLUSH_INTERVAL: Final = 1
     DEFAULT_RETRY_COUNT: Final = 3

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -123,6 +123,7 @@ class Errors:
     INVALID_SEGMENT_IDENTIFIER: Final = 'Audience segments fetch failed (invalid identifier).'
     FETCH_SEGMENTS_FAILED: Final = 'Audience segments fetch failed ({}).'
     ODP_EVENT_FAILED: Final = 'ODP event send failed ({}).'
+    ODP_NOT_ENABLED: Final = 'ODP is not enabled.'
     ODP_NOT_INTEGRATED: Final = 'ODP is not integrated.'
 
 
@@ -212,3 +213,4 @@ class OdpEventManagerConfig:
     DEFAULT_QUEUE_CAPACITY: Final = 1000
     DEFAULT_BATCH_SIZE: Final = 10
     DEFAULT_FLUSH_INTERVAL: Final = 10
+    DEFAULT_RETRY_COUNT: Final = 3

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -211,3 +211,4 @@ class OdpEventManagerConfig:
     """ODP Event Manager configs."""
     DEFAULT_QUEUE_CAPACITY: Final = 1000
     DEFAULT_BATCH_SIZE: Final = 10
+    DEFAULT_FLUSH_INTERVAL: Final = 15

--- a/optimizely/helpers/validator.py
+++ b/optimizely/helpers/validator.py
@@ -306,3 +306,8 @@ def are_values_same_type(first_val: Any, second_val: Any) -> bool:
         return True
 
     return False
+
+
+def are_odp_data_types_valid(data: dict[str, Any]) -> bool:
+    valid_types = (str, int, float, bool, type(None))
+    return all(isinstance(v, valid_types) for v in data.values())

--- a/optimizely/helpers/validator.py
+++ b/optimizely/helpers/validator.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from optimizely.event.event_processor import BaseEventProcessor
     from optimizely.helpers.event_tag_utils import EventTags
     from optimizely.optimizely_user_context import UserAttributes
+    from optimizely.odp.odp_event import OdpDataDict
 
 
 def is_datafile_valid(datafile: Optional[str | bytes]) -> bool:
@@ -308,6 +309,6 @@ def are_values_same_type(first_val: Any, second_val: Any) -> bool:
     return False
 
 
-def are_odp_data_types_valid(data: dict[str, Any]) -> bool:
+def are_odp_data_types_valid(data: OdpDataDict) -> bool:
     valid_types = (str, int, float, bool, type(None))
     return all(isinstance(v, valid_types) for v in data.values())

--- a/optimizely/odp/odp_event.py
+++ b/optimizely/odp/odp_event.py
@@ -13,21 +13,21 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Union
 import uuid
 import json
 from optimizely import version
+
+OdpDataType = Union[str, int, float, bool, None]
 
 
 class OdpEvent:
     """ Representation of an odp event which can be sent to the Optimizely odp platform. """
 
-    def __init__(self, type: str, action: str,
-                 identifiers: dict[str, str], data: dict[str, Any]) -> None:
+    def __init__(self, type: str, action: str, identifiers: dict[str, str], data: dict[str, OdpDataType]) -> None:
         self.type = type
         self.action = action
         self.identifiers = identifiers
-        self._validate_data_types(data)
         self.data = self._add_common_event_data(data)
 
     def __repr__(self) -> str:
@@ -41,13 +41,8 @@ class OdpEvent:
         else:
             return False
 
-    def _validate_data_types(self, data: dict[str, Any]) -> None:
-        valid_types = (str, int, float, type(None))
-        if any(not isinstance(v, valid_types) for v in data.values()):
-            raise TypeError('ODP event data values can only be str, int, float and None')
-
-    def _add_common_event_data(self, custom_data: dict[str, Any]) -> dict[str, Any]:
-        data = {
+    def _add_common_event_data(self, custom_data: dict[str, OdpDataType]) -> dict[str, OdpDataType]:
+        data: dict[str, OdpDataType] = {
             'idempotence_id': str(uuid.uuid4()),
             'data_source_type': 'sdk',
             'data_source': 'python-sdk',

--- a/optimizely/odp/odp_event.py
+++ b/optimizely/odp/odp_event.py
@@ -27,6 +27,7 @@ class OdpEvent:
         self.type = type
         self.action = action
         self.identifiers = identifiers
+        self._validate_data_types(data)
         self.data = self._add_common_event_data(data)
 
     def __repr__(self) -> str:
@@ -39,6 +40,11 @@ class OdpEvent:
             return self.__dict__ == other
         else:
             return False
+
+    def _validate_data_types(self, data: dict[str, Any]) -> None:
+        valid_types = (str, int, float, type(None))
+        if any(not isinstance(v, valid_types) for v in data.values()):
+            raise TypeError('ODP event data values can only be str, int, float and None')
 
     def _add_common_event_data(self, custom_data: dict[str, Any]) -> dict[str, Any]:
         data = {

--- a/optimizely/odp/odp_event.py
+++ b/optimizely/odp/odp_event.py
@@ -13,18 +13,18 @@
 
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, Union, Dict
 import uuid
 import json
 from optimizely import version
 
-OdpDataType = Union[str, int, float, bool, None]
+OdpDataDict = Dict[str, Union[str, int, float, bool, None]]
 
 
 class OdpEvent:
     """ Representation of an odp event which can be sent to the Optimizely odp platform. """
 
-    def __init__(self, type: str, action: str, identifiers: dict[str, str], data: dict[str, OdpDataType]) -> None:
+    def __init__(self, type: str, action: str, identifiers: dict[str, str], data: OdpDataDict) -> None:
         self.type = type
         self.action = action
         self.identifiers = identifiers
@@ -41,8 +41,8 @@ class OdpEvent:
         else:
             return False
 
-    def _add_common_event_data(self, custom_data: dict[str, OdpDataType]) -> dict[str, OdpDataType]:
-        data: dict[str, OdpDataType] = {
+    def _add_common_event_data(self, custom_data: OdpDataDict) -> OdpDataDict:
+        data: OdpDataDict = {
             'idempotence_id': str(uuid.uuid4()),
             'data_source_type': 'sdk',
             'data_source': 'python-sdk',

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -133,17 +133,16 @@ class OdpEventManager:
 
         self.logger.debug(f'Flushing batch size {batch_len}.')
         should_retry = False
-        event_batch = list(self._current_batch)
         try:
-            should_retry = self.zaius_manager.send_odp_events(api_key, api_host, event_batch)
+            should_retry = self.zaius_manager.send_odp_events(api_key, api_host, self._current_batch)
         except Exception as e:
-            self.logger.error(Errors.ODP_EVENT_FAILED.format(f'{event_batch} {e}'))
+            self.logger.error(Errors.ODP_EVENT_FAILED.format(f'{self._current_batch} {e}'))
 
         if should_retry:
             self.logger.debug('Error dispatching ODP events, scheduled to retry.')
             return
 
-        self._current_batch = []
+        self._current_batch.clear()
 
     def _add_to_batch(self, odp_event: OdpEvent) -> None:
         """ Method to append received odp event to current batch."""

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -1,0 +1,187 @@
+# Copyright 2019-2022, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+from threading import Lock, Thread
+from typing import Any, Optional
+import queue
+from queue import Queue
+from sys import version_info
+
+from optimizely import logger as _logging
+from .odp_event import OdpEvent
+from .odp_config import OdpConfig
+from .zaius_rest_api_manager import ZaiusRestApiManager
+from optimizely.helpers.enums import OdpEventManagerConfig, Errors
+
+
+if version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final  # type: ignore
+
+
+class Signal:
+    '''Used to create unique objects for sending signals to event queue.'''
+    pass
+
+
+class OdpEventManager:
+    """
+    Class that sends batches of ODP events.
+
+    The OdpEventManager maintains a single consumer thread that pulls events off of
+    the queue and buffers them before the events are sent to ODP.
+    """
+
+    _SHUTDOWN_SIGNAL: Final = Signal()
+    _FLUSH_SIGNAL: Final = Signal()
+
+    def __init__(
+        self,
+        odp_config: OdpConfig,
+        logger: Optional[_logging.Logger] = None,
+        api_manager: Optional[ZaiusRestApiManager] = None
+
+    ):
+        """ OdpEventManager init method to configure event batching.
+
+        Args:
+            odp_config: ODP integration config.
+            logger: Optional component which provides a log method to log messages. By default nothing would be logged.
+            api_manager: Optional component which sends events to ODP.
+        """
+        self.logger = logger or _logging.NoOpLogger()
+        self.zaius_manager = api_manager or ZaiusRestApiManager(self.logger)
+        self.odp_config = odp_config
+        self.event_queue: Queue[OdpEvent | Signal] = Queue(OdpEventManagerConfig.DEFAULT_QUEUE_CAPACITY)
+        self.batch_size = OdpEventManagerConfig.DEFAULT_BATCH_SIZE
+        self.lock = Lock()
+
+        self._current_batch: list[OdpEvent] = []
+
+        self.executor = Thread(target=self._run, daemon=True)
+
+    @property
+    def is_running(self) -> bool:
+        """ Property to check if consumer thread is alive or not. """
+        return self.executor.is_alive()
+
+    def start(self) -> None:
+        """ Starts the batch processing thread to batch events. """
+        if self.is_running:
+            self.logger.warning('ODP event processor already started.')
+            return
+
+        self.executor.start()
+
+    def _run(self) -> None:
+        """ Triggered as part of the thread which batches odp events or flushes event_queue and blocks on get
+        for flush interval if queue is empty.
+        """
+        try:
+            while True:
+                item = self.event_queue.get()
+
+                if item == self._SHUTDOWN_SIGNAL:
+                    self.logger.debug('Received ODP event shutdown signal.')
+                    self.event_queue.task_done()
+                    break
+
+                if item is self._FLUSH_SIGNAL:
+                    self.logger.debug('Received ODP event flush signal.')
+                    self._flush_batch()
+                    self.event_queue.task_done()
+                    continue
+
+                if isinstance(item, OdpEvent):
+                    self._add_to_batch(item)
+                    self.event_queue.task_done()
+
+        except Exception as exception:
+            self.logger.error(f'Uncaught exception processing ODP events. Error: {exception}')
+
+        finally:
+            self.logger.info('Exiting ODP event processing loop. Attempting to flush pending events.')
+            self._flush_batch()
+
+    def flush(self) -> None:
+        """ Adds flush signal to event_queue. """
+
+        self.event_queue.put(self._FLUSH_SIGNAL)
+
+    def _flush_batch(self) -> None:
+        """ Flushes current batch by dispatching event. """
+        batch_len = len(self._current_batch)
+        if batch_len == 0:
+            self.logger.debug('Nothing to flush.')
+            return
+
+        api_key = self.odp_config.get_api_key()
+        api_host = self.odp_config.get_api_host()
+
+        if not api_key or not api_host:
+            self.logger.debug('ODP event processing has been disabled.')
+            return
+
+        self.logger.debug(f'Flushing batch size {batch_len}.')
+        should_retry = False
+        with self.lock:
+            event_batch = list(self._current_batch)
+            try:
+                should_retry = self.zaius_manager.send_odp_events(api_key, api_host, event_batch)
+            except Exception as e:
+                self.logger.error(Errors.ODP_EVENT_FAILED.format(f'{event_batch} {e}'))
+
+            if should_retry:
+                self.logger.debug('Error dispatching ODP events, scheduled to retry.')
+                return
+
+            self._current_batch = []
+
+    def _add_to_batch(self, odp_event: OdpEvent) -> None:
+        """ Method to append received odp event to current batch."""
+
+        with self.lock:
+            self._current_batch.append(odp_event)
+        if len(self._current_batch) >= self.batch_size:
+            self.logger.debug('Flushing ODP events on batch size.')
+            self._flush_batch()
+
+    def stop(self) -> None:
+        """ Stops and disposes batch odp event queue."""
+        self.event_queue.put(self._SHUTDOWN_SIGNAL)
+        self.logger.warning('Stopping ODP Event Queue.')
+
+        if self.is_running:
+            self.executor.join()
+
+        if len(self._current_batch) > 0:
+            self.logger.error(Errors.ODP_EVENT_FAILED.format(self._current_batch))
+
+        if self.is_running:
+            self.logger.error('Error stopping ODP event queue.')
+
+    def send_event(self, type: str, action: str, identifiers: dict[str, str], data: dict[str, Any]) -> None:
+        event = OdpEvent(type, action, identifiers, data)
+        self.dispatch(event)
+
+    def dispatch(self, event: OdpEvent) -> None:
+        if not self.odp_config.odp_integrated():
+            self.logger.debug('ODP event processing has been disabled.')
+            return
+
+        try:
+            self.event_queue.put_nowait(event)
+        except queue.Full:
+            self.logger.error(Errors.ODP_EVENT_FAILED.format("Queue is full"))

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, Optimizely
+# Copyright 2022, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -176,6 +176,10 @@ class OdpEventManager:
             self.logger.debug('ODP event processing has been disabled.')
             return
 
+        if not self.is_running:
+            self.logger.warning('ODP event processor is shutdown, not accepting events.')
+            return
+
         try:
             self.event_queue.put_nowait(event)
         except queue.Full:

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -36,8 +36,9 @@ class OdpEventManager:
     Class that sends batches of ODP events.
 
     The OdpEventManager maintains a single consumer thread that pulls events off of
-    the queue and buffers them before the events are sent to ODP. Sends events when
-    the batch size is met or when the flush timeout has elapsed.
+    the queue and buffers them before events are sent to ODP.
+    Waits for odp_config.odp_ready to be set before processing.
+    Sends events when the batch size is met or when the flush timeout has elapsed.
     """
 
     def __init__(

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -19,7 +19,7 @@ import time
 from queue import Empty, Queue, Full
 
 from optimizely import logger as _logging
-from .odp_event import OdpEvent, OdpDataType
+from .odp_event import OdpEvent, OdpDataDict
 from .odp_config import OdpConfig, OdpConfigState
 from .zaius_rest_api_manager import ZaiusRestApiManager
 from optimizely.helpers.enums import OdpEventManagerConfig, Errors
@@ -208,7 +208,7 @@ class OdpEventManager:
         if self.is_running:
             self.logger.error('Error stopping ODP event queue.')
 
-    def send_event(self, type: str, action: str, identifiers: dict[str, str], data: dict[str, OdpDataType]) -> None:
+    def send_event(self, type: str, action: str, identifiers: dict[str, str], data: OdpDataDict) -> None:
         """Create OdpEvent and add it to the event queue."""
         odp_state = self.odp_config.odp_state()
         if odp_state == OdpConfigState.UNDETERMINED:

--- a/optimizely/odp/zaius_rest_api_manager.py
+++ b/optimizely/odp/zaius_rest_api_manager.py
@@ -21,7 +21,7 @@ from requests.exceptions import RequestException, ConnectionError, Timeout
 
 from optimizely import logger as optimizely_logger
 from optimizely.helpers.enums import Errors, OdpRestApiConfig
-from optimizely.odp.odp_event import OdpEvent
+from optimizely.odp.odp_event import OdpEvent, OdpEventEncoder
 
 """
  ODP REST Events API
@@ -60,7 +60,7 @@ class ZaiusRestApiManager:
         request_headers = {'content-type': 'application/json', 'x-api-key': api_key}
 
         try:
-            payload_dict = json.dumps(events)
+            payload_dict = json.dumps(events, cls=OdpEventEncoder)
         except TypeError as err:
             self.logger.error(Errors.ODP_EVENT_FAILED.format(err))
             return should_retry

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,6 +14,8 @@
 import json
 import unittest
 from typing import Optional
+from copy import deepcopy
+from unittest import mock
 
 from requests import Response
 
@@ -22,6 +24,17 @@ from optimizely import optimizely
 
 def long(a):
     raise NotImplementedError('Tests should only call `long` if running in PY2')
+
+
+class CopyingMock(mock.MagicMock):
+    """
+    Forces mock to make a copy of the args instead of keeping a reference.
+    Otherwise mutable args (lists, dicts) can change after they're captured.
+    """
+    def __call__(self, *args, **kwargs):
+        args = deepcopy(args)
+        kwargs = deepcopy(kwargs)
+        return super().__call__(*args, **kwargs)
 
 
 class BaseTest(unittest.TestCase):

--- a/tests/test_odp_event_manager.py
+++ b/tests/test_odp_event_manager.py
@@ -394,15 +394,14 @@ class OdpEventManagerTest(BaseTest):
 
         mock_logger.error.assert_not_called()
         mock_logger.debug.assert_has_calls([
-            mock.call('Adding ODP event to queue.'),
-            mock.call('Adding ODP event to queue.'),
-            mock.call('ODP ready. Starting event processing.'),
+            mock.call('ODP events cannot be sent before the datafile has loaded.'),
+            mock.call('ODP events cannot be sent before the datafile has loaded.'),
             mock.call('Adding ODP event to queue.'),
             mock.call('Adding ODP event to queue.'),
             mock.call('Received ODP event flush signal.'),
-            mock.call('Flushing batch size 4.')
+            mock.call('Flushing batch size 2.')
         ])
-        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events * 2)
+        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
         event_manager.stop()
 
     def test_odp_event_manager_events_before_odp_disabled(self):
@@ -420,18 +419,14 @@ class OdpEventManagerTest(BaseTest):
 
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
-            event_manager.flush()
 
             event_manager.event_queue.join()
 
         mock_logger.error.assert_not_called()
         mock_logger.debug.assert_has_calls([
-            mock.call('Adding ODP event to queue.'),
-            mock.call('Adding ODP event to queue.'),
-            mock.call('ODP ready. Starting event processing.'),
+            mock.call('ODP events cannot be sent before the datafile has loaded.'),
+            mock.call('ODP events cannot be sent before the datafile has loaded.'),
             mock.call('ODP event queue has been disabled.'),
-            mock.call('ODP event queue has been disabled.'),
-            mock.call('Received ODP event flush signal.'),
             mock.call('ODP event queue has been disabled.')
         ])
         self.assertEqual(len(event_manager._current_batch), 0)

--- a/tests/test_odp_event_manager.py
+++ b/tests/test_odp_event_manager.py
@@ -1,0 +1,229 @@
+# Copyright 2022, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+import uuid
+
+from optimizely.odp.odp_event import OdpEvent
+from optimizely.odp.odp_event_manager import OdpEventManager
+from optimizely.odp.odp_config import OdpConfig
+from . import base
+from optimizely.version import __version__
+
+
+class OdpEventManagerTest(base.BaseTest):
+    user_key = "vuid"
+    user_value = "test-user-value"
+    api_key = "test-api-key"
+    api_host = "https://test-host.com"
+    test_uuid = str(uuid.uuid4())
+    odp_config = OdpConfig(api_key, api_host)
+
+    events = [
+        {
+            "type": "t1",
+            "action": "a1",
+            "identifiers": {"id-key-1": "id-value-1"},
+            "data": {"key-1": "value1"}
+        },
+        {
+            "type": "t2",
+            "action": "a2",
+            "identifiers": {"id-key-2": "id-value-2"},
+            "data": {"key-2": "value2"}
+        }
+    ]
+
+    processed_events = [
+        {
+            "type": "t1",
+            "action": "a1",
+            "identifiers": {"id-key-1": "id-value-1"},
+            "data": {
+                "idempotence_id": test_uuid,
+                "data_source_type": "sdk",
+                "data_source": "python-sdk",
+                "data_source_version": __version__,
+                "key-1": "value1"
+            }
+        },
+        {
+            "type": "t2",
+            "action": "a2",
+            "identifiers": {"id-key-2": "id-value-2"},
+            "data": {
+                "idempotence_id": test_uuid,
+                "data_source_type": "sdk",
+                "data_source": "python-sdk",
+                "data_source_version": __version__,
+                "key-2": "value2"
+            }
+        }
+    ]
+
+    def test_odp_event_init(self):
+        with mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event = OdpEvent(**self.events[0])
+        self.assertEqual(event, self.processed_events[0])
+
+    def test_odp_event_manager_success(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager.start()
+
+        with mock.patch(
+            'requests.post', return_value=self.fake_server_response(status_code=200)
+        ), mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.stop()
+
+        self.assertEqual(len(event_manager._current_batch), 0)
+        mock_logger.error.assert_not_called()
+        mock_logger.debug.assert_any_call('Received ODP event shutdown signal.')
+        self.assertStrictFalse(event_manager.is_running)
+
+    def test_odp_event_manager_batch(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager.start()
+
+        event_manager.batch_size = 2
+        with mock.patch.object(
+            event_manager.zaius_manager, 'send_odp_events', return_value=False
+        ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.event_queue.join()
+
+        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
+        self.assertEqual(len(event_manager._current_batch), 0)
+        mock_logger.error.assert_not_called()
+        mock_logger.debug.assert_any_call('Flushing ODP events on batch size.')
+        event_manager.stop()
+
+    def test_odp_event_manager_flush(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager.start()
+
+        with mock.patch.object(
+            event_manager.zaius_manager, 'send_odp_events', return_value=False
+        ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.flush()
+            event_manager.event_queue.join()
+
+        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
+        mock_logger.error.assert_not_called()
+        self.assertEqual(len(event_manager._current_batch), 0)
+        mock_logger.debug.assert_any_call('Received ODP event flush signal.')
+        event_manager.stop()
+
+    def test_odp_event_manager_network_failure(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager.start()
+
+        with mock.patch.object(
+            event_manager.zaius_manager, 'send_odp_events', return_value=True
+        ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.flush()
+            event_manager.event_queue.join()
+
+        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
+        self.assertEqual(len(event_manager._current_batch), 2)
+        mock_logger.debug.assert_any_call('Error dispatching ODP events, scheduled to retry.')
+        self.assertStrictTrue(event_manager.is_running)
+        event_manager.stop()
+
+    def test_odp_event_manager_retry(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager.start()
+
+        with mock.patch.object(
+            event_manager.zaius_manager, 'send_odp_events', return_value=True
+        ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.flush()
+            event_manager.event_queue.join()
+
+        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
+        self.assertEqual(len(event_manager._current_batch), 2)
+        mock_logger.debug.assert_any_call('Error dispatching ODP events, scheduled to retry.')
+
+        mock_logger.reset_mock()
+
+        with mock.patch.object(
+            event_manager.zaius_manager, 'send_odp_events', return_value=False
+        ) as mock_send:
+            event_manager.stop()
+
+        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
+        self.assertEqual(len(event_manager._current_batch), 0)
+        mock_logger.error.assert_not_called()
+
+    def test_odp_event_manager_send_failure(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager.start()
+
+        with mock.patch.object(
+            event_manager.zaius_manager, 'send_odp_events', side_effect=Exception('Unexpected error')
+        ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.flush()
+            event_manager.event_queue.join()
+
+        mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
+        self.assertEqual(len(event_manager._current_batch), 0)
+        mock_logger.error.assert_any_call(f"ODP event send failed ({self.processed_events} Unexpected error).")
+        self.assertStrictTrue(event_manager.is_running)
+        event_manager.stop()
+
+    def test_odp_event_manager_disabled(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(OdpConfig(), mock_logger)
+        event_manager.start()
+
+        with mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.event_queue.join()
+
+        self.assertEqual(len(event_manager._current_batch), 0)
+        mock_logger.error.assert_not_called()
+        mock_logger.debug.assert_any_call('ODP event processing has been disabled.')
+        self.assertStrictTrue(event_manager.is_running)
+        event_manager.stop()
+
+    def test_odp_event_manager_queue_full(self):
+        mock_logger = mock.Mock()
+        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager.event_queue.maxsize = 1
+        event_manager.start()
+
+        with mock.patch('uuid.uuid4', return_value=self.test_uuid):
+            event_manager.send_event(**self.events[0])
+            event_manager.send_event(**self.events[1])
+            event_manager.event_queue.join()
+
+        mock_logger.error.assert_any_call('ODP event send failed (Queue is full).')
+        self.assertStrictTrue(event_manager.is_running)
+        event_manager.stop()

--- a/tests/test_odp_event_manager.py
+++ b/tests/test_odp_event_manager.py
@@ -136,14 +136,8 @@ class OdpEventManagerTest(BaseTest):
         batch_count = 4
 
         with mock.patch.object(
-            event_manager.zaius_manager,
-            'send_odp_events',
-            new_callable=CopyingMock,
-            return_value=False
-        ) as mock_send, mock.patch(
-            'uuid.uuid4',
-            return_value=self.test_uuid
-        ):
+            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
+        ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
             for _ in range(batch_count):
                 event_manager.send_event(**self.events[0])
                 event_manager.send_event(**self.events[1])
@@ -356,6 +350,7 @@ class OdpEventManagerTest(BaseTest):
             event_manager.event_queue.join()
 
         mock_send.assert_called_once_with(self.api_key, self.api_host, [processed_event])
+        event_manager.stop()
 
     def test_odp_event_manager_flush_timeout(self):
         mock_logger = mock.Mock()
@@ -375,7 +370,6 @@ class OdpEventManagerTest(BaseTest):
         mock_logger.error.assert_not_called()
         mock_logger.debug.assert_any_call('Flushing on interval.')
         mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
-        event_manager.stop()
 
     def test_odp_event_manager_events_before_odp_ready(self):
         mock_logger = mock.Mock()
@@ -417,9 +411,7 @@ class OdpEventManagerTest(BaseTest):
         event_manager = OdpEventManager(odp_config, mock_logger)
         event_manager.start()
 
-        with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
-        ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
+        with mock.patch.object(event_manager.zaius_manager, 'send_odp_events') as mock_send:
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
 

--- a/tests/test_odp_event_manager.py
+++ b/tests/test_odp_event_manager.py
@@ -18,11 +18,11 @@ import uuid
 from optimizely.odp.odp_event import OdpEvent
 from optimizely.odp.odp_event_manager import OdpEventManager
 from optimizely.odp.odp_config import OdpConfig
-from . import base
+from .base import BaseTest, CopyingMock
 from optimizely.version import __version__
 
 
-class OdpEventManagerTest(base.BaseTest):
+class OdpEventManagerTest(BaseTest):
     user_key = "vuid"
     user_value = "test-user-value"
     api_key = "test-api-key"
@@ -100,7 +100,7 @@ class OdpEventManagerTest(base.BaseTest):
 
         event_manager.batch_size = 2
         with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', return_value=False
+            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
         ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
@@ -119,7 +119,7 @@ class OdpEventManagerTest(base.BaseTest):
 
         event_manager.batch_size = 2
         with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', return_value=False
+            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
         ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
@@ -142,7 +142,7 @@ class OdpEventManagerTest(base.BaseTest):
         event_manager.start()
 
         with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', return_value=False
+            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
         ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
@@ -161,7 +161,7 @@ class OdpEventManagerTest(base.BaseTest):
         event_manager.start()
 
         with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', return_value=False
+            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
         ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
@@ -204,7 +204,7 @@ class OdpEventManagerTest(base.BaseTest):
         event_manager.start()
 
         with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', return_value=True
+            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=True
         ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
@@ -218,7 +218,7 @@ class OdpEventManagerTest(base.BaseTest):
         mock_logger.reset_mock()
 
         with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', return_value=False
+            event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
         ) as mock_send:
             event_manager.stop()
 
@@ -232,7 +232,10 @@ class OdpEventManagerTest(base.BaseTest):
         event_manager.start()
 
         with mock.patch.object(
-            event_manager.zaius_manager, 'send_odp_events', side_effect=Exception('Unexpected error')
+            event_manager.zaius_manager,
+            'send_odp_events',
+            new_callable=CopyingMock,
+            side_effect=Exception('Unexpected error')
         ) as mock_send, mock.patch('uuid.uuid4', return_value=self.test_uuid):
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])


### PR DESCRIPTION
Summary
-------
OdpEventManager provides internal services for sending ODP events to the ODP server. 
- adds default values to identifiers and data fields for all events.
- stores requested events if they cannot be sent to the server.
- stored events are dispatched when resources are available.

Test plan
---------
- added test_odp_event_manager.py

Ticket
------
[OASIS-8442](https://optimizely.atlassian.net/browse/OASIS-8442)
