### PR TITLE
update py version to 3.10 for  gitactions linting

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10.6
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: 3.10.6
+        python-version: '3.10'
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
     - name: pip install flak8

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.10.6
       uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: 3.10.6
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
     - name: pip install flak8

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: 3.10
       # flake8 version should be same as the version in requirements/test.txt
       # to avoid lint errors on CI
     - name: pip install flak8

--- a/tests/base.py
+++ b/tests/base.py
@@ -20,10 +20,6 @@ from requests import Response
 from optimizely import optimizely
 
 
-def long(a):
-    raise NotImplementedError('Tests should only call `long` if running in PY2')
-
-
 class BaseTest(unittest.TestCase):
     def assertStrictTrue(self, to_assert):
         self.assertIs(to_assert, True)


### PR DESCRIPTION
Summary
-------
This changes are part of the ticket to cleanup and put in orer Python language versions (see ticket below).

-  remove last reference to Python 2.7 (2 lines in tests/base.py)
- upgrade py version to 3.10 in gitactions linting


Test plan
---------
- passing unit tests 
- passing FSC tests
- passing linting

Issues
------

-  [OASIS-8470 Update Supported Language Version](https://optimizely.atlassian.net/browse/OASIS-8470)
