### PR TITLE
refactor: remove odp config from constructors

### DIFF
--- a/optimizely/odp/odp_manager.py
+++ b/optimizely/odp/odp_manager.py
@@ -23,7 +23,6 @@ from optimizely.odp.lru_cache import OptimizelySegmentsCache, LRUCache
 from optimizely.odp.odp_config import OdpConfig, OdpConfigState
 from optimizely.odp.odp_event_manager import OdpEventManager
 from optimizely.odp.odp_segment_manager import OdpSegmentManager
-from optimizely.odp.zaius_graphql_api_manager import ZaiusGraphQLApiManager
 
 
 class OdpManager:
@@ -55,19 +54,14 @@ class OdpManager:
                     OdpSegmentsCacheConfig.DEFAULT_CAPACITY,
                     OdpSegmentsCacheConfig.DEFAULT_TIMEOUT_SECS
                 )
-            self.segment_manager = OdpSegmentManager(
-                self.odp_config,
-                segments_cache,
-                ZaiusGraphQLApiManager(logger), logger
-            )
-        else:
-            self.segment_manager.odp_config = self.odp_config
+            self.segment_manager = OdpSegmentManager(segments_cache, logger=self.logger)
 
         if event_manager:
             self.event_manager = event_manager
         else:
             self.event_manager = OdpEventManager(self.logger)
 
+        self.segment_manager.odp_config = self.odp_config
         self.event_manager.start(self.odp_config)
 
     def fetch_qualified_segments(self, user_id: str, options: list[str]) -> Optional[list[str]]:

--- a/optimizely/odp/odp_manager.py
+++ b/optimizely/odp/odp_manager.py
@@ -64,12 +64,11 @@ class OdpManager:
             self.segment_manager.odp_config = self.odp_config
 
         if event_manager:
-            event_manager.odp_config = self.odp_config
             self.event_manager = event_manager
         else:
-            self.event_manager = OdpEventManager(self.odp_config, logger)
+            self.event_manager = OdpEventManager(self.logger)
 
-        self.event_manager.start()
+        self.event_manager.start(self.odp_config)
 
     def fetch_qualified_segments(self, user_id: str, options: list[str]) -> Optional[list[str]]:
         if not self.enabled or not self.segment_manager:

--- a/tests/test_odp_event_manager.py
+++ b/tests/test_odp_event_manager.py
@@ -526,3 +526,10 @@ class OdpEventManagerTest(BaseTest):
         mock_logger.error.assert_not_called()
         mock_send.assert_called_once_with(self.api_key, self.api_host, self.processed_events)
         event_manager.stop()
+
+    def test_send_event_before_config_set(self, *args):
+        mock_logger = mock.Mock()
+
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.send_event(**self.events[0])
+        mock_logger.debug.assert_called_with('ODP event queue: cannot send before config has been set.')

--- a/tests/test_odp_event_manager.py
+++ b/tests/test_odp_event_manager.py
@@ -100,8 +100,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_success(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         with mock.patch('requests.post', return_value=self.fake_server_response(status_code=200)):
             event_manager.send_event(**self.events[0])
@@ -116,8 +116,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_batch(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         event_manager.batch_size = 2
         with mock.patch.object(
@@ -135,8 +135,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_multiple_batches(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         event_manager.batch_size = 2
         batch_count = 4
@@ -164,7 +164,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_backlog(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.odp_config = self.odp_config
 
         event_manager.batch_size = 2
         batch_count = 4
@@ -178,7 +179,7 @@ class OdpEventManagerTest(BaseTest):
         with mock.patch.object(
             event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
         ) as mock_send:
-            event_manager.start()
+            event_manager.start(self.odp_config)
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
             event_manager.stop()
@@ -198,8 +199,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_flush(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         with mock.patch.object(
             event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
@@ -217,8 +218,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_multiple_flushes(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
         flush_count = 4
 
         with mock.patch.object(
@@ -244,8 +245,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_retry_failure(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         number_of_tries = event_manager.retry_count + 1
 
@@ -269,8 +270,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_retry_success(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         with mock.patch.object(
             event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, side_effect=[True, True, False]
@@ -289,8 +290,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_send_failure(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         with mock.patch.object(
             event_manager.zaius_manager,
@@ -313,8 +314,8 @@ class OdpEventManagerTest(BaseTest):
         mock_logger = mock.Mock()
         odp_config = OdpConfig()
         odp_config.update(None, None, None)
-        event_manager = OdpEventManager(odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(odp_config)
 
         event_manager.send_event(**self.events[0])
         event_manager.send_event(**self.events[1])
@@ -330,7 +331,9 @@ class OdpEventManagerTest(BaseTest):
         mock_logger = mock.Mock()
 
         with mock.patch('optimizely.helpers.enums.OdpEventManagerConfig.DEFAULT_QUEUE_CAPACITY', 1):
-            event_manager = OdpEventManager(self.odp_config, mock_logger)
+            event_manager = OdpEventManager(mock_logger)
+
+        event_manager.odp_config = self.odp_config
 
         with mock.patch('optimizely.odp.odp_event_manager.OdpEventManager.is_running', True):
             event_manager.send_event(**self.events[0])
@@ -344,8 +347,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_thread_exception(self, *args):
         mock_logger = mock.Mock()
-        event_manager = MockOdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = MockOdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         event_manager.send_event(**self.events[0])
         time.sleep(.1)
@@ -360,8 +363,8 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_override_default_data(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(self.odp_config)
 
         event = deepcopy(self.events[0])
         event['data']['data_source'] = 'my-app'
@@ -381,9 +384,9 @@ class OdpEventManagerTest(BaseTest):
 
     def test_odp_event_manager_flush_timeout(self, *args):
         mock_logger = mock.Mock()
-        event_manager = OdpEventManager(self.odp_config, mock_logger)
+        event_manager = OdpEventManager(mock_logger)
         event_manager.flush_interval = .5
-        event_manager.start()
+        event_manager.start(self.odp_config)
 
         with mock.patch.object(
             event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
@@ -401,8 +404,8 @@ class OdpEventManagerTest(BaseTest):
     def test_odp_event_manager_events_before_odp_ready(self, *args):
         mock_logger = mock.Mock()
         odp_config = OdpConfig()
-        event_manager = OdpEventManager(odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(odp_config)
 
         with mock.patch.object(
             event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
@@ -436,8 +439,8 @@ class OdpEventManagerTest(BaseTest):
     def test_odp_event_manager_events_before_odp_disabled(self, *args):
         mock_logger = mock.Mock()
         odp_config = OdpConfig()
-        event_manager = OdpEventManager(odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(odp_config)
 
         with mock.patch.object(event_manager.zaius_manager, 'send_odp_events') as mock_send:
             event_manager.send_event(**self.events[0])
@@ -467,8 +470,8 @@ class OdpEventManagerTest(BaseTest):
     def test_odp_event_manager_disabled_after_init(self, *args):
         mock_logger = mock.Mock()
         odp_config = OdpConfig(self.api_key, self.api_host)
-        event_manager = OdpEventManager(odp_config, mock_logger)
-        event_manager.start()
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.start(odp_config)
         event_manager.batch_size = 2
 
         with mock.patch.object(
@@ -499,19 +502,20 @@ class OdpEventManagerTest(BaseTest):
         mock_logger = mock.Mock()
         odp_config = OdpConfig(self.api_key, self.api_host)
 
-        event_manager = OdpEventManager(odp_config, mock_logger)
+        event_manager = OdpEventManager(mock_logger)
+        event_manager.odp_config = odp_config
         event_manager.batch_size = 3
 
         with mock.patch('optimizely.odp.odp_event_manager.OdpEventManager.is_running', True):
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
-            odp_config.update(None, None, [])
-            event_manager.update_config()
 
         with mock.patch.object(
             event_manager.zaius_manager, 'send_odp_events', new_callable=CopyingMock, return_value=False
         ) as mock_send:
-            event_manager.start()
+            event_manager.start(odp_config)
+            odp_config.update(None, None, [])
+            event_manager.update_config()
             event_manager.send_event(**self.events[0])
             event_manager.send_event(**self.events[1])
             event_manager.send_event(**self.events[0])

--- a/tests/test_odp_manager.py
+++ b/tests/test_odp_manager.py
@@ -53,7 +53,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_fetch_qualified_segments(self):
         mock_logger = mock.MagicMock()
-        segment_manager = OdpSegmentManager(OdpConfig(), OptimizelySegmentsCache,
+        segment_manager = OdpSegmentManager(OptimizelySegmentsCache,
                                             ZaiusGraphQLApiManager(mock_logger), mock_logger)
 
         manager = OdpManager(False, OptimizelySegmentsCache, segment_manager, logger=mock_logger)
@@ -74,7 +74,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_fetch_qualified_segments__disabled(self):
         mock_logger = mock.MagicMock()
-        segment_manager = OdpSegmentManager(OdpConfig(), OptimizelySegmentsCache,
+        segment_manager = OdpSegmentManager(OptimizelySegmentsCache,
                                             ZaiusGraphQLApiManager(mock_logger), mock_logger)
 
         manager = OdpManager(True, OptimizelySegmentsCache, segment_manager, logger=mock_logger)
@@ -284,7 +284,7 @@ class OdpManagerTest(base.BaseTest):
     def test_update_odp_config__reset_called(self):
         # build segment manager
         mock_logger = mock.MagicMock()
-        segment_manager = OdpSegmentManager(OdpConfig(), OptimizelySegmentsCache,
+        segment_manager = OdpSegmentManager(OptimizelySegmentsCache,
                                             ZaiusGraphQLApiManager(mock_logger), mock_logger)
         # build event manager
         event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())

--- a/tests/test_odp_manager.py
+++ b/tests/test_odp_manager.py
@@ -129,7 +129,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_identify_user_odp_integrated(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config('key1', 'host1', [])
@@ -151,7 +151,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_identify_user_odp_not_integrated(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config(None, None, [])
@@ -166,7 +166,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_identify_user_odp_disabled(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
         manager.enabled = False
@@ -180,7 +180,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_send_event_datafile_not_ready(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
 
@@ -193,7 +193,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_send_event_odp_integrated(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config('key1', 'host1', [])
@@ -215,7 +215,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_send_event_odp_not_integrated(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config(None, None, [])
@@ -230,7 +230,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_send_event_odp_disabled(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
         manager.enabled = False
@@ -245,7 +245,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_send_event_odp_disabled__event_manager_not_available(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
         manager.event_manager = False
@@ -260,7 +260,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_send_event_invalid_data(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config('key1', 'host1', [])
@@ -274,7 +274,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_config_not_changed(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config(None, None, [])
@@ -287,7 +287,7 @@ class OdpManagerTest(base.BaseTest):
         segment_manager = OdpSegmentManager(OdpConfig(), OptimizelySegmentsCache,
                                             ZaiusGraphQLApiManager(mock_logger), mock_logger)
         # build event manager
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
 
         manager = OdpManager(False, OptimizelySegmentsCache, segment_manager, event_manager, mock_logger)
 
@@ -332,7 +332,7 @@ class OdpManagerTest(base.BaseTest):
         to odp_config is made or not in OdpManager.
         """
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
         manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
 
         with mock.patch.object(event_manager, 'update_config') as mock_update:
@@ -369,7 +369,7 @@ class OdpManagerTest(base.BaseTest):
 
     def test_update_odp_config__odp_config_propagated_properly(self):
         mock_logger = mock.MagicMock()
-        event_manager = OdpEventManager(OdpConfig(), mock_logger, ZaiusRestApiManager())
+        event_manager = OdpEventManager(mock_logger, ZaiusRestApiManager())
         manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config('key1', 'host1', ['a', 'b'])
 


### PR DESCRIPTION
Summary
-------

-  remove odp_config from contructors for odp event manager and odp segment manager

Test plan
---------
all tests pass

Ticket
------

- [OASIS-8405](https://jira.sso.episerver.net/browse/FSSDK-8405)
- [OASIS-8442](https://jira.sso.episerver.net/browse/FSSDK-8442)
