### PR TITLE
chore: update tests because of custom json encoder

### DIFF
--- a/.github/workflows/ticket_reference_check.yml
+++ b/.github/workflows/ticket_reference_check.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Check for Jira ticket reference
         uses: optimizely/github-action-ticket-reference-checker-public@master
         with:
-          bodyRegex: 'OASIS-(?<ticketNumber>\d+)' 
+          bodyRegex: 'FSSDK-(?<ticketNumber>\d+)'


### PR DESCRIPTION
Summary
-------

-  An addition of custom JSON encoder in OdpEvent and ZaiusRestApiManager required the ZaiusrestApi tests to be updated.
- Changed event payload from dicts to instances of OdpEvent class.
- One test needed to be updated.


Test plan
---------
- passing unit tests

Issues
------

-  [FSSDK-8447](https://jira.sso.episerver.net/browse/FSSDK-8447 )
