### PR TITLE
fix: skip identify on user_context clone

### DIFF
--- a/optimizely/optimizely_user_context.py
+++ b/optimizely/optimizely_user_context.py
@@ -37,8 +37,12 @@ class OptimizelyUserContext:
     """
 
     def __init__(
-        self, optimizely_client: optimizely.Optimizely, logger: Logger,
-        user_id: str, user_attributes: Optional[UserAttributes] = None
+        self,
+        optimizely_client: optimizely.Optimizely,
+        logger: Logger,
+        user_id: str,
+        user_attributes: Optional[UserAttributes] = None,
+        identify: bool = True
     ):
         """ Create an instance of the Optimizely User Context.
 
@@ -47,6 +51,7 @@ class OptimizelyUserContext:
           logger: logger for logging
           user_id: user id of this user context
           user_attributes: user attributes to use for this user context
+          identify: True to send identify event to ODP.
 
         Returns:
           UserContext instance
@@ -67,7 +72,7 @@ class OptimizelyUserContext:
             OptimizelyUserContext.OptimizelyForcedDecision
         ] = {}
 
-        if self.client:
+        if self.client and identify:
             self.client.identify_user(user_id)
 
     class OptimizelyDecisionContext:
@@ -94,7 +99,13 @@ class OptimizelyUserContext:
         if not self.client:
             return None
 
-        user_context = OptimizelyUserContext(self.client, self.logger, self.user_id, self.get_user_attributes())
+        user_context = OptimizelyUserContext(
+            self.client,
+            self.logger,
+            self.user_id,
+            self.get_user_attributes(),
+            identify=False
+        )
 
         with self.lock:
             if self.forced_decisions_map:

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -2021,6 +2021,24 @@ class UserContextTest(base.BaseTest):
         mock_logger.error.assert_not_called()
         client.close()
 
+    def test_identify_is_skipped_with_decisions(self):
+        mock_logger = mock.Mock()
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_features), logger=mock_logger)
+        with mock.patch.object(client, 'identify_user') as identify:
+            user_context = OptimizelyUserContext(client, mock_logger, 'user-id')
+
+        identify.assert_called_once_with('user-id')
+        mock_logger.error.assert_not_called()
+
+        with mock.patch.object(client, 'identify_user') as identify:
+            user_context.decide('test_feature_in_rollout')
+            user_context.decide_all()
+            user_context.decide_for_keys(['test_feature_in_rollout'])
+
+        identify.assert_not_called()
+        mock_logger.error.assert_not_called()
+        client.close()
+
     # fetch qualified segments
     def test_fetch_segments(self):
         mock_logger = mock.Mock()


### PR DESCRIPTION
Summary
-------

-  Skip sending identify user event to odp when user_context is cloned.

Prevents duplicate identify calls from being made.

Test plan
---------
added test to test_user_context.py

Ticket
------
[FSSDK-8478](https://jira.sso.episerver.net/browse/FSSDK-8478)
