### PR TITLE
fix: add notification center registry

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -201,11 +201,11 @@ class PollingConfigManager(StaticConfigManager):
         notification_center: Optional[NotificationCenter] = None,
         skip_json_validation: Optional[bool] = False,
     ):
-        """ Initialize config manager. One of sdk_key or url has to be set to be able to use.
+        """ Initialize config manager. One of sdk_key or datafile has to be set to be able to use.
 
         Args:
-            sdk_key: Optional string uniquely identifying the datafile.
-            datafile: Optional JSON string representing the project.
+            sdk_key: Optional string uniquely identifying the datafile. If not provided, datafile is required.
+            datafile: Optional JSON string representing the project. If not provided, sdk_key is required.
             update_interval: Optional floating point number representing time interval in seconds
                              at which to request datafile and set ProjectConfig.
             blocking_timeout: Optional Time in seconds to block the get_config call until config object
@@ -230,6 +230,10 @@ class PollingConfigManager(StaticConfigManager):
             skip_json_validation=skip_json_validation,
         )
         self._sdk_key = sdk_key or self._sdk_key
+
+        if sdk_key is None:
+            raise optimizely_exceptions.InvalidInputException('Must provide at least one of sdk_key or datafile.')
+
         self.datafile_url = self.get_datafile_url(
             sdk_key, url, url_template or self.DATAFILE_URL_TEMPLATE
         )
@@ -436,7 +440,7 @@ class AuthDatafilePollingConfigManager(PollingConfigManager):
         *args: Any,
         **kwargs: Any
     ):
-        """ Initialize config manager. One of sdk_key or url has to be set to be able to use.
+        """ Initialize config manager. One of sdk_key or datafile has to be set to be able to use.
 
         Args:
             datafile_access_token: String to be attached to the request header to fetch the authenticated datafile.

--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -82,8 +82,8 @@ class BaseConfigManager(ABC):
     @abstractmethod
     def get_sdk_key(self) -> Optional[str]:
         """ Get sdk_key for use by optimizely.Optimizely.
-        The sdk_key should uniquely identify the datafile for a project and environment
-          combination."""
+        The sdk_key should uniquely identify the datafile for a project and environment combination.
+        """
         pass
 
 

--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -204,7 +204,8 @@ class PollingConfigManager(StaticConfigManager):
         """ Initialize config manager. One of sdk_key or datafile has to be set to be able to use.
 
         Args:
-            sdk_key: Optional string uniquely identifying the datafile. If not provided, datafile is required.
+            sdk_key: Optional string uniquely identifying the datafile. If not provided, datafile must
+                     contain a sdk_key.
             datafile: Optional JSON string representing the project. If not provided, sdk_key is required.
             update_interval: Optional floating point number representing time interval in seconds
                              at which to request datafile and set ProjectConfig.
@@ -231,11 +232,11 @@ class PollingConfigManager(StaticConfigManager):
         )
         self._sdk_key = sdk_key or self._sdk_key
 
-        if sdk_key is None:
-            raise optimizely_exceptions.InvalidInputException('Must provide at least one of sdk_key or datafile.')
+        if self._sdk_key is None:
+            raise optimizely_exceptions.InvalidInputException(enums.Errors.MISSING_SDK_KEY)
 
         self.datafile_url = self.get_datafile_url(
-            sdk_key, url, url_template or self.DATAFILE_URL_TEMPLATE
+            self._sdk_key, url, url_template or self.DATAFILE_URL_TEMPLATE
         )
         self.set_update_interval(update_interval)
         self.set_blocking_timeout(blocking_timeout)

--- a/optimizely/helpers/constants.py
+++ b/optimizely/helpers/constants.py
@@ -149,7 +149,6 @@ JSON_SCHEMA = {
         },
         "version": {"type": "string"},
         "revision": {"type": "string"},
-        "sdkKey": {"type": "string"},
         "integrations": {
             "type": "array",
             "items": {
@@ -169,6 +168,5 @@ JSON_SCHEMA = {
         "attributes",
         "version",
         "revision",
-        "sdkKey",
     ],
 }

--- a/optimizely/helpers/constants.py
+++ b/optimizely/helpers/constants.py
@@ -149,6 +149,7 @@ JSON_SCHEMA = {
         },
         "version": {"type": "string"},
         "revision": {"type": "string"},
+        "sdkKey": {"type": "string"},
         "integrations": {
             "type": "array",
             "items": {
@@ -168,5 +169,6 @@ JSON_SCHEMA = {
         "attributes",
         "version",
         "revision",
+        "sdkKey",
     ],
 }

--- a/optimizely/helpers/enums.py
+++ b/optimizely/helpers/enums.py
@@ -126,6 +126,7 @@ class Errors:
     ODP_NOT_INTEGRATED: Final = 'ODP is not integrated.'
     ODP_NOT_ENABLED: Final = 'ODP is not enabled.'
     ODP_INVALID_DATA: Final = 'ODP data is not valid.'
+    MISSING_SDK_KEY: Final = 'SDK key not provided/cannot be found in the datafile.'
 
 
 class ForcedDecisionLogs:

--- a/optimizely/notification_center_registry.py
+++ b/optimizely/notification_center_registry.py
@@ -16,6 +16,7 @@ from threading import Lock
 from typing import Optional
 from .logger import Logger as OptimizelyLogger
 from .notification_center import NotificationCenter
+from .helpers.enums import Errors
 
 
 class _NotificationCenterRegistry:
@@ -37,7 +38,7 @@ class _NotificationCenterRegistry:
         """
 
         if not sdk_key:
-            logger.error("No SDK key provided to get_notification_center")
+            logger.error(f'{Errors.MISSING_SDK_KEY} ODP may not work properly without it.')
             return None
 
         with cls._lock:

--- a/optimizely/notification_center_registry.py
+++ b/optimizely/notification_center_registry.py
@@ -1,0 +1,66 @@
+# Copyright 2023, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+from threading import Lock
+from typing import Optional
+from .logger import Logger as OptimizelyLogger
+from .notification_center import NotificationCenter
+
+
+class _NotificationCenterRegistry:
+    """ Class managing internal notification centers."""
+    _notification_centers: dict[str, NotificationCenter] = {}
+    _lock = Lock()
+
+    @classmethod
+    def get_notification_center(
+        cls, sdk_key: Optional[str], logger: Optional[OptimizelyLogger] = None
+    ) -> Optional[NotificationCenter]:
+        """Returns an internal notification center for the given sdk_key, creating one
+        if none exists yet.
+
+        Args:
+        sdk_key: An optional string sdk key. If None, nothing is returned.
+        logger: Optional logger.
+
+        Returns:
+        None or NotificationCenter
+        """
+
+        if not sdk_key:
+            if logger:
+                logger.info("No SDK key provided to get_notification_center")
+            return None
+
+        with cls._lock:
+            if sdk_key in cls._notification_centers:
+                notification_center = cls._notification_centers[sdk_key]
+            else:
+                notification_center = NotificationCenter(logger)
+                cls._notification_centers[sdk_key] = notification_center
+
+        return notification_center
+
+    @classmethod
+    def remove_notification_center(cls, sdk_key: str) -> None:
+        """Remove a previously added notification center and clear all its listeners.
+
+        Args:
+        sdk_key: The sdk_key of the notification center to remove.
+        """
+
+        with cls._lock:
+            notification_center = cls._notification_centers.pop(sdk_key, None)
+            if notification_center:
+                notification_center.clear_all_notification_listeners()

--- a/optimizely/notification_center_registry.py
+++ b/optimizely/notification_center_registry.py
@@ -24,14 +24,12 @@ class _NotificationCenterRegistry:
     _lock = Lock()
 
     @classmethod
-    def get_notification_center(
-        cls, sdk_key: Optional[str], logger: Optional[OptimizelyLogger] = None
-    ) -> Optional[NotificationCenter]:
+    def get_notification_center(cls, sdk_key: Optional[str], logger: OptimizelyLogger) -> Optional[NotificationCenter]:
         """Returns an internal notification center for the given sdk_key, creating one
         if none exists yet.
 
         Args:
-        sdk_key: An optional string sdk key. If None, nothing is returned.
+        sdk_key: A string sdk key to uniquely identify the notification center.
         logger: Optional logger.
 
         Returns:
@@ -39,8 +37,7 @@ class _NotificationCenterRegistry:
         """
 
         if not sdk_key:
-            if logger:
-                logger.info("No SDK key provided to get_notification_center")
+            logger.error("No SDK key provided to get_notification_center")
             return None
 
         with cls._lock:

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -164,7 +164,7 @@ class Optimizely:
                 self.config_manager = StaticConfigManager(**config_manager_options)
 
         self.odp_manager: OdpManager
-        self.setup_odp(sdk_key or self.config_manager.get_sdk_key())
+        self.setup_odp(self.config_manager.get_sdk_key())
 
         self.event_builder = event_builder.EventBuilder()
         self.decision_service = decision_service.DecisionService(self.logger, user_profile_service)

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -144,7 +144,7 @@ class Optimizely:
             self.logger.exception(str(error))
             return
 
-        self.setup_odp(sdk_key)
+        self.setup_odp(sdk_key if sdk_key or not config_manager else config_manager.get_sdk_key())
 
         self.odp_manager = OdpManager(
             self.sdk_settings.odp_disabled,

--- a/tests/base.py
+++ b/tests/base.py
@@ -150,6 +150,7 @@ class BaseTest(unittest.TestCase):
         # datafile version 4
         self.config_dict_with_features = {
             'revision': '1',
+            'sdkKey': 'features-test',
             'accountId': '12001',
             'projectId': '111111',
             'version': '4',
@@ -1261,7 +1262,13 @@ class BaseTest(unittest.TestCase):
                 }
             ],
             'accountId': '10367498574',
-            'events': [],
+            'events': [
+                {
+                    "experimentIds": ["10420810910"],
+                    "id": "10404198134",
+                    "key": "event1"
+                }
+            ],
             'revision': '101',
             'sdkKey': 'segments-test'
         }

--- a/tests/base.py
+++ b/tests/base.py
@@ -58,6 +58,7 @@ class BaseTest(unittest.TestCase):
     def setUp(self, config_dict='config_dict'):
         self.config_dict = {
             'revision': '42',
+            'sdkKey': 'basic-test',
             'version': '2',
             'events': [
                 {'key': 'test_event', 'experimentIds': ['111127'], 'id': '111095'},
@@ -553,6 +554,7 @@ class BaseTest(unittest.TestCase):
 
         self.config_dict_with_multiple_experiments = {
             'revision': '42',
+            'sdkKey': 'multiple-experiments',
             'version': '2',
             'events': [
                 {'key': 'test_event', 'experimentIds': ['111127', '111130'], 'id': '111095'},
@@ -658,6 +660,7 @@ class BaseTest(unittest.TestCase):
 
         self.config_dict_with_unsupported_version = {
             'version': '5',
+            'sdkKey': 'unsupported-version',
             'rollouts': [],
             'projectId': '10431130345',
             'variables': [],
@@ -1074,6 +1077,7 @@ class BaseTest(unittest.TestCase):
                 {'key': 'user_signed_up', 'id': '594090', 'experimentIds': ['1323241598', '1323241599']},
             ],
             'revision': '3',
+            'sdkKey': 'typed-audiences',
         }
 
         self.config_dict_with_audience_segments = {

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021, Optimizely
+# Copyright 2016-2023 Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -1262,7 +1262,8 @@ class BaseTest(unittest.TestCase):
             ],
             'accountId': '10367498574',
             'events': [],
-            'revision': '101'
+            'revision': '101',
+            'sdkKey': 'segments-test'
         }
 
         config = getattr(self, config_dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,7 @@ class ConfigTest(base.BaseTest):
         # Adding some additional fields like live variables and IP anonymization
         config_dict = {
             'revision': '42',
+            'sdkKey': 'test',
             'version': '4',
             'anonymizeIP': False,
             'botFiltering': True,

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -220,14 +220,14 @@ class StaticConfigManagerTest(base.BaseTest):
 
 @mock.patch('requests.get')
 class PollingConfigManagerTest(base.BaseTest):
-    def test_init__no_sdk_key_no_url__fails(self, _):
-        """ Test that initialization fails if there is no sdk_key or url provided. """
+    def test_init__no_sdk_key_no_datafile__fails(self, _):
+        """ Test that initialization fails if there is no sdk_key or datafile provided. """
         self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException,
-            'Must provide at least one of sdk_key or url.',
+            'Must provide at least one of sdk_key or datafile.',
             config_manager.PollingConfigManager,
             sdk_key=None,
-            url=None,
+            datafile=None,
         )
 
     def test_get_datafile_url__no_sdk_key_no_url_raises(self, _):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -224,7 +224,7 @@ class PollingConfigManagerTest(base.BaseTest):
         """ Test that initialization fails if there is no sdk_key or datafile provided. """
         self.assertRaisesRegex(
             optimizely_exceptions.InvalidInputException,
-            'Must provide at least one of sdk_key or datafile.',
+            enums.Errors.MISSING_SDK_KEY,
             config_manager.PollingConfigManager,
             sdk_key=None,
             datafile=None,

--- a/tests/test_notification_center_registry.py
+++ b/tests/test_notification_center_registry.py
@@ -18,7 +18,7 @@ import copy
 from optimizely.notification_center_registry import _NotificationCenterRegistry
 from optimizely.notification_center import NotificationCenter
 from optimizely.optimizely import Optimizely
-from optimizely.helpers.enums import NotificationTypes
+from optimizely.helpers.enums import NotificationTypes, Errors
 from .base import BaseTest
 
 
@@ -37,7 +37,7 @@ class NotificationCenterRegistryTest(BaseTest):
 
         _NotificationCenterRegistry.get_notification_center(None, logger)
 
-        logger.error.assert_called_once_with('No SDK key provided to get_notification_center')
+        logger.error.assert_called_once_with(f'{Errors.MISSING_SDK_KEY} ODP may not work properly without it.')
 
         client.close()
 

--- a/tests/test_notification_center_registry.py
+++ b/tests/test_notification_center_registry.py
@@ -1,0 +1,84 @@
+# Copyright 2019, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest import mock
+import copy
+
+from optimizely.notification_center_registry import _NotificationCenterRegistry
+from optimizely.notification_center import NotificationCenter
+from optimizely.optimizely import Optimizely
+from optimizely.helpers.enums import NotificationTypes
+from .base import BaseTest
+
+
+class NotificationCenterRegistryTest(BaseTest):
+    def test_get_notification_center(self):
+        logger = mock.MagicMock()
+        sdk_key = 'test'
+        client = Optimizely(sdk_key=sdk_key, logger=logger)
+        notification_center = _NotificationCenterRegistry.get_notification_center(sdk_key, logger)
+        self.assertIsInstance(notification_center, NotificationCenter)
+        config_notifications = notification_center.notification_listeners[NotificationTypes.OPTIMIZELY_CONFIG_UPDATE]
+
+        self.assertIn((mock.ANY, client._update_odp_config_on_datafile_update), config_notifications)
+
+        logger.error.assert_not_called()
+
+        _NotificationCenterRegistry.get_notification_center(None, logger)
+
+        logger.error.assert_called_once_with('No SDK key provided to get_notification_center')
+
+        client.close()
+
+    def test_only_one_notification_center_created(self):
+        logger = mock.MagicMock()
+        sdk_key = 'single'
+        notification_center = _NotificationCenterRegistry.get_notification_center(sdk_key, logger)
+        client = Optimizely(sdk_key=sdk_key, logger=logger)
+
+        self.assertIs(notification_center, _NotificationCenterRegistry.get_notification_center(sdk_key, logger))
+
+        logger.error.assert_not_called()
+
+        client.close()
+
+    def test_remove_notification_center(self):
+        logger = mock.MagicMock()
+        sdk_key = 'test'
+        test_datafile = json.dumps(self.config_dict_with_audience_segments)
+        test_response = self.fake_server_response(status_code=200, content=test_datafile)
+        notification_center = _NotificationCenterRegistry.get_notification_center(sdk_key, logger)
+
+        with mock.patch('requests.get', return_value=test_response), \
+             mock.patch.object(notification_center, 'send_notifications') as mock_send:
+
+            client = Optimizely(sdk_key=sdk_key, logger=logger)
+            client.config_manager.get_config()
+
+            mock_send.assert_called_once()
+            mock_send.reset_mock()
+
+            _NotificationCenterRegistry.remove_notification_center(sdk_key)
+            self.assertNotIn(notification_center, _NotificationCenterRegistry._notification_centers)
+
+            revised_datafile = copy.deepcopy(self.config_dict_with_audience_segments)
+            revised_datafile['revision'] = str(int(revised_datafile['revision']) + 1)
+
+            # trigger notification
+            client.config_manager._set_config(json.dumps(revised_datafile))
+            mock_send.assert_not_called()
+
+        logger.error.assert_not_called()
+
+        client.close()

--- a/tests/test_notification_center_registry.py
+++ b/tests/test_notification_center_registry.py
@@ -1,4 +1,4 @@
-# Copyright 2019, Optimizely
+# Copyright 2023, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/test_notification_center_registry.py
+++ b/tests/test_notification_center_registry.py
@@ -55,7 +55,7 @@ class NotificationCenterRegistryTest(BaseTest):
 
     def test_remove_notification_center(self):
         logger = mock.MagicMock()
-        sdk_key = 'test'
+        sdk_key = 'segments-test'
         test_datafile = json.dumps(self.config_dict_with_audience_segments)
         test_response = self.fake_server_response(status_code=200, content=test_datafile)
         notification_center = _NotificationCenterRegistry.get_notification_center(sdk_key, logger)

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -4664,7 +4664,7 @@ class OptimizelyTest(base.BaseTest):
 
         with mock.patch('requests.get', return_value=test_response, side_effect=delay):
             # initialize config_manager with delay, so it will receive the datafile after client initialization
-            custom_config_manager = config_manager.PollingConfigManager(sdk_key='sdk_key', logger=logger)
+            custom_config_manager = config_manager.PollingConfigManager(sdk_key='segments-test', logger=logger)
             client = optimizely.Optimizely(config_manager=custom_config_manager)
             odp_manager = client.odp_manager
 

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -96,7 +96,7 @@ class OptimizelyTest(base.BaseTest):
 
         mock_client_logger.error.assert_has_calls([
             mock.call('Provided "datafile" is in an invalid format.'),
-            mock.call('No SDK key provided to get_notification_center')
+            mock.call(f'{enums.Errors.MISSING_SDK_KEY} ODP may not work properly without it.')
         ], any_order=True)
         self.assertIsNone(opt_obj.config_manager.get_config())
 
@@ -109,7 +109,7 @@ class OptimizelyTest(base.BaseTest):
 
         mock_client_logger.error.assert_has_calls([
             mock.call('Provided "datafile" is in an invalid format.'),
-            mock.call('No SDK key provided to get_notification_center')
+            mock.call(f'{enums.Errors.MISSING_SDK_KEY} ODP may not work properly without it.')
         ], any_order=True)
         self.assertIsNone(opt_obj.config_manager.get_config())
 
@@ -122,7 +122,7 @@ class OptimizelyTest(base.BaseTest):
 
         mock_client_logger.error.assert_has_calls([
             mock.call('Provided "datafile" is in an invalid format.'),
-            mock.call('No SDK key provided to get_notification_center')
+            mock.call(f'{enums.Errors.MISSING_SDK_KEY} ODP may not work properly without it.')
         ], any_order=True)
         self.assertIsNone(opt_obj.config_manager.get_config())
 
@@ -216,7 +216,7 @@ class OptimizelyTest(base.BaseTest):
             opt_obj = optimizely.Optimizely(json.dumps(self.config_dict_with_unsupported_version))
 
         mock_client_logger.error.assert_has_calls([
-            mock.call('No SDK key provided to get_notification_center'),
+            mock.call(f'{enums.Errors.MISSING_SDK_KEY} ODP may not work properly without it.'),
             mock.call('This version of the Python SDK does not support the given datafile version: "5".')
         ], any_order=True)
 
@@ -290,7 +290,7 @@ class OptimizelyTest(base.BaseTest):
 
         mock_client_logger.error.assert_has_calls([
             mock.call('Provided "datafile" is in an invalid format.'),
-            mock.call('No SDK key provided to get_notification_center')
+            mock.call(f'{enums.Errors.MISSING_SDK_KEY} ODP may not work properly without it.')
         ], any_order=True)
         args, kwargs = mock_error_handler.call_args
         self.assertIsInstance(args[0], exceptions.InvalidInputException)
@@ -310,7 +310,7 @@ class OptimizelyTest(base.BaseTest):
 
         mock_client_logger.error.assert_has_calls([
             mock.call('Provided "datafile" is in an invalid format.'),
-            mock.call('No SDK key provided to get_notification_center')
+            mock.call(f'{enums.Errors.MISSING_SDK_KEY} ODP may not work properly without it.')
         ], any_order=True)
         args, kwargs = mock_error_handler.call_args
         self.assertIsInstance(args[0], exceptions.InvalidInputException)

--- a/tests/test_optimizely_config.py
+++ b/tests/test_optimizely_config.py
@@ -26,7 +26,7 @@ class OptimizelyConfigTest(base.BaseTest):
         self.opt_config_service = optimizely_config.OptimizelyConfigService(self.project_config)
 
         self.expected_config = {
-            'sdk_key': '',
+            'sdk_key': 'features-test',
             'environment_key': '',
             'attributes': [{'key': 'test_attribute', 'id': '111094'}],
             'events': [{'key': 'test_event', 'experiment_ids': ['111127'], 'id': '111095'}],


### PR DESCRIPTION
Summary
-------
Create a private registry of NotificationCenters for internal use.
- Remove dependence on user supplied NotificationCenter.
- Resolve issue of notifications being registered with one NotificationCenter and sent to a different one.

Test plan
---------
added tests to
- test_notification_center_registry.py
- test_optimizely.py
- test_optimizely_config.py
- test_optimizely_factory.py

Ticket
------

[FSSDK-8773](https://jira.sso.episerver.net/browse/FSSDK-8773)
