### PR TITLE
fix: make client odp methods private

### DIFF
--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -164,7 +164,7 @@ class Optimizely:
                 self.config_manager = StaticConfigManager(**config_manager_options)
 
         self.odp_manager: OdpManager
-        self.setup_odp(self.config_manager.get_sdk_key())
+        self._setup_odp(self.config_manager.get_sdk_key())
 
         self.event_builder = event_builder.EventBuilder()
         self.decision_service = decision_service.DecisionService(self.logger, user_profile_service)
@@ -1292,7 +1292,7 @@ class Optimizely:
             decisions[key] = decision
         return decisions
 
-    def setup_odp(self, sdk_key: Optional[str]) -> None:
+    def _setup_odp(self, sdk_key: Optional[str]) -> None:
         """
         - Make sure odp manager is instantiated with provided parameters or defaults.
         - Set up listener to update odp_config when datafile is updated.
@@ -1352,14 +1352,14 @@ class Optimizely:
             config.all_segments
         )
 
-    def identify_user(self, user_id: str) -> None:
+    def _identify_user(self, user_id: str) -> None:
         if not self.is_valid:
             self.logger.error(enums.Errors.INVALID_OPTIMIZELY.format('identify_user'))
             return
 
         self.odp_manager.identify_user(user_id)
 
-    def fetch_qualified_segments(self, user_id: str, options: Optional[list[str]] = None) -> Optional[list[str]]:
+    def _fetch_qualified_segments(self, user_id: str, options: Optional[list[str]] = None) -> Optional[list[str]]:
         if not self.is_valid:
             self.logger.error(enums.Errors.INVALID_OPTIMIZELY.format('fetch_qualified_segments'))
             return None

--- a/optimizely/optimizely_user_context.py
+++ b/optimizely/optimizely_user_context.py
@@ -73,7 +73,7 @@ class OptimizelyUserContext:
         ] = {}
 
         if self.client and identify:
-            self.client.identify_user(user_id)
+            self.client._identify_user(user_id)
 
     class OptimizelyDecisionContext:
         """ Using class with attributes here instead of namedtuple because
@@ -327,7 +327,7 @@ class OptimizelyUserContext:
             A boolean value indicating if the fetch was successful.
         """
         def _fetch_qualified_segments() -> bool:
-            segments = self.client.fetch_qualified_segments(self.user_id, options or []) if self.client else None
+            segments = self.client._fetch_qualified_segments(self.user_id, options or []) if self.client else None
             self.set_qualified_segments(segments)
             success = segments is not None
 

--- a/tests/test_notification_center_registry.py
+++ b/tests/test_notification_center_registry.py
@@ -69,8 +69,9 @@ class NotificationCenterRegistryTest(BaseTest):
             mock_send.assert_called_once()
             mock_send.reset_mock()
 
+            self.assertIn(notification_center, _NotificationCenterRegistry._notification_centers.values())
             _NotificationCenterRegistry.remove_notification_center(sdk_key)
-            self.assertNotIn(notification_center, _NotificationCenterRegistry._notification_centers)
+            self.assertNotIn(notification_center, _NotificationCenterRegistry._notification_centers.values())
 
             revised_datafile = copy.deepcopy(self.config_dict_with_audience_segments)
             revised_datafile['revision'] = str(int(revised_datafile['revision']) + 1)

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -5143,7 +5143,7 @@ class OptimizelyWithLoggingTest(base.BaseTest):
     def test_send_identify_event__when_called_with_odp_enabled(self):
         mock_logger = mock.Mock()
         client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments), logger=mock_logger)
-        with mock.patch.object(client, 'identify_user') as identify:
+        with mock.patch.object(client, '_identify_user') as identify:
             client.create_user_context('user-id')
 
         identify.assert_called_once_with('user-id')

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -2014,7 +2014,7 @@ class UserContextTest(base.BaseTest):
     def test_send_identify_event_when_user_context_created(self):
         mock_logger = mock.Mock()
         client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments), logger=mock_logger)
-        with mock.patch.object(client, 'identify_user') as identify:
+        with mock.patch.object(client, '_identify_user') as identify:
             OptimizelyUserContext(client, mock_logger, 'user-id')
 
         identify.assert_called_once_with('user-id')
@@ -2024,13 +2024,13 @@ class UserContextTest(base.BaseTest):
     def test_identify_is_skipped_with_decisions(self):
         mock_logger = mock.Mock()
         client = optimizely.Optimizely(json.dumps(self.config_dict_with_features), logger=mock_logger)
-        with mock.patch.object(client, 'identify_user') as identify:
+        with mock.patch.object(client, '_identify_user') as identify:
             user_context = OptimizelyUserContext(client, mock_logger, 'user-id')
 
         identify.assert_called_once_with('user-id')
         mock_logger.error.assert_not_called()
 
-        with mock.patch.object(client, 'identify_user') as identify:
+        with mock.patch.object(client, '_identify_user') as identify:
             user_context.decide('test_feature_in_rollout')
             user_context.decide_all()
             user_context.decide_for_keys(['test_feature_in_rollout'])


### PR DESCRIPTION
Summary
-------

-  make fetch_qualified_segments, identify_user, setup_odp private methods in Optimizely

Test plan
---------
existing tests should pass

Ticket
------
- [FSSDK-8478](https://jira.sso.episerver.net/browse/FSSDK-8478)
