### PR TITLE
[FSSDK-8946] fix: make odp event identifiers required

### DIFF
--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1369,8 +1369,8 @@ class Optimizely:
     def send_odp_event(
         self,
         action: str,
+        identifiers: dict[str, str],
         type: str = enums.OdpManagerConfig.EVENT_TYPE,
-        identifiers: Optional[dict[str, str]] = None,
         data: Optional[dict[str, str | int | float | bool | None]] = None
     ) -> None:
         """
@@ -1378,8 +1378,8 @@ class Optimizely:
 
         Args:
             action: The event action name.
+            identifiers: A dictionary for identifiers. The caller must provide at least one key-value pair.
             type: The event type. Default 'fullstack'.
-            identifiers: An optional dictionary for identifiers.
             data: An optional dictionary for associated data. The default event data will be added to this data
             before sending to the ODP server.
         """
@@ -1387,7 +1387,11 @@ class Optimizely:
             self.logger.error(enums.Errors.INVALID_OPTIMIZELY.format('send_odp_event'))
             return
 
-        self.odp_manager.send_event(type, action, identifiers or {}, data or {})
+        if not identifiers:
+            self.logger.error('ODP events must have at least one key-value pair in identifiers.')
+            return
+
+        self.odp_manager.send_event(type, action, identifiers, data or {})
 
     def close(self) -> None:
         if callable(getattr(self.event_processor, 'stop', None)):

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1387,7 +1387,7 @@ class Optimizely:
             self.logger.error(enums.Errors.INVALID_OPTIMIZELY.format('send_odp_event'))
             return
 
-        if not identifiers:
+        if not identifiers or not isinstance(identifiers, dict):
             self.logger.error('ODP events must have at least one key-value pair in identifiers.')
             return
 

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -5386,7 +5386,7 @@ class OptimizelyWithLoggingTest(base.BaseTest):
             logger=mock_logger,
         )
         with mock.patch('requests.post', return_value=self.fake_server_response(status_code=200)):
-            client.send_odp_event(type='wow', action='great', identifiers={}, data={})
+            client.send_odp_event(type='wow', action='great', identifiers={'amazing': 'fantastic'}, data={})
             client.close()
         mock_logger.error.assert_not_called()
         mock_logger.debug.assert_called_with('ODP event queue: flushing batch size 1.')
@@ -5405,7 +5405,7 @@ class OptimizelyWithLoggingTest(base.BaseTest):
             client.config_manager.get_config()
 
         with mock.patch('requests.post', return_value=self.fake_server_response(status_code=200)):
-            client.send_odp_event(type='wow', action='great', identifiers={}, data={})
+            client.send_odp_event(type='wow', action='great', identifiers={'amazing': 'fantastic'}, data={})
             client.close()
 
         mock_logger.error.assert_not_called()
@@ -5419,14 +5419,14 @@ class OptimizelyWithLoggingTest(base.BaseTest):
             settings=OptimizelySdkSettings(odp_disabled=True)
         )
         with mock.patch('requests.post', return_value=self.fake_server_response(status_code=200)):
-            client.send_odp_event(type='wow', action='great', identifiers={}, data={})
+            client.send_odp_event(type='wow', action='great', identifiers={'amazing': 'fantastic'}, data={})
             client.close()
         mock_logger.error.assert_called_with('ODP is not enabled.')
 
     def test_send_odp_event__log_debug_if_datafile_not_ready(self):
         mock_logger = mock.Mock()
         client = optimizely.Optimizely(sdk_key='test', logger=mock_logger)
-        client.send_odp_event(type='wow', action='great', identifiers={}, data={})
+        client.send_odp_event(type='wow', action='great', identifiers={'amazing': 'fantastic'}, data={})
 
         mock_logger.debug.assert_called_with('ODP event queue: cannot send before config has been set.')
         client.close()
@@ -5449,7 +5449,7 @@ class OptimizelyWithLoggingTest(base.BaseTest):
             client.config_manager.get_config()
 
         with mock.patch('requests.post', return_value=self.fake_server_response(status_code=200)):
-            client.send_odp_event(type='wow', action='great', identifiers={}, data={})
+            client.send_odp_event(type='wow', action='great', identifiers={'amazing': 'fantastic'}, data={})
             client.close()
 
         mock_logger.error.assert_called_with('ODP is not enabled.')
@@ -5458,15 +5458,33 @@ class OptimizelyWithLoggingTest(base.BaseTest):
         mock_logger = mock.Mock()
         client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments), logger=mock_logger)
 
-        client.send_odp_event(type='wow', action='great', identifiers={}, data={'test': {}})
+        client.send_odp_event(type='wow', action='great', identifiers={'amazing': 'fantastic'}, data={'test': {}})
         client.close()
 
         mock_logger.error.assert_called_with('ODP data is not valid.')
 
+    def test_send_odp_event__log_error_with_empty_identifiers(self):
+        mock_logger = mock.Mock()
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments), logger=mock_logger)
+
+        client.send_odp_event(type='wow', action='great', identifiers={}, data={})
+        client.close()
+
+        mock_logger.error.assert_called_with('ODP events must have at least one key-value pair in identifiers.')
+
+    def test_send_odp_event__log_error_with_no_identifiers(self):
+        mock_logger = mock.Mock()
+        client = optimizely.Optimizely(json.dumps(self.config_dict_with_audience_segments), logger=mock_logger)
+
+        client.send_odp_event(type='wow', action='great', identifiers=None, data={})
+        client.close()
+
+        mock_logger.error.assert_called_with('ODP events must have at least one key-value pair in identifiers.')
+
     def test_send_odp_event__log_error_with_missing_integrations_data(self):
         mock_logger = mock.Mock()
         client = optimizely.Optimizely(json.dumps(self.config_dict_with_typed_audiences), logger=mock_logger)
-        client.send_odp_event(type='wow', action='great', identifiers={}, data={})
+        client.send_odp_event(type='wow', action='great', identifiers={'amazing': 'fantastic'}, data={})
 
         mock_logger.error.assert_called_with('ODP is not integrated.')
         client.close()


### PR DESCRIPTION
Summary
-------
-  Updated send_odp_events to require identifiers and contain at least one key


Test plan
---------
- updated test_optimizely.py

Ticket
------

-  [FSSDK-8946](https://jira.sso.episerver.net/browse/FSSDK-8946)
