### PR TITLE
[FSSDK-8954] chore: prep for 4.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Breaking Changes:
 * `PollingConfigManager` now requires `sdk_key` even when providing a url. ([#413](https://github.com/optimizely/python-sdk/pull/413))
 
+## 4.1.1
+March 10th, 2023
+
+We updated our README.md and other non-functional code to reflect that this SDK supports both Optimizely Feature Experimentation and Optimizely Full Stack.
+
 ## 4.1.0
 July 7th, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## 4.1.1
 March 10th, 2023
 
-We updated our README.md and other non-functional code to reflect that this SDK supports both Optimizely Feature Experimentation and Optimizely Full Stack.
+We updated our README.md and other non-functional code to reflect that this SDK supports both Optimizely Feature Experimentation and Optimizely Full Stack. ([#420](https://github.com/optimizely/python-sdk/pull/420))
 
 ## 4.1.0
 July 7th, 2022

--- a/optimizely/version.py
+++ b/optimizely/version.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020, 2022, Optimizely
+# Copyright 2016-2020, 2022-2023, Optimizely
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,5 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (4, 1, 0)
+version_info = (4, 1, 1)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
Summary
-------

-  Prepare for 4.1.1 release

Ticket
------

[FSSDK-8954](https://jira.sso.episerver.net/browse/FSSDK-8954)
