### PR TITLE
[FSSDK-9510]: Implements a warning log for polling interval below 30s

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -323,6 +323,11 @@ class PollingConfigManager(StaticConfigManager):
             )
             update_interval = enums.ConfigManager.DEFAULT_UPDATE_INTERVAL
 
+        if update_interval < 30:
+            self.logger.warning(
+                f'Polling intervals below 30 seconds are not recommended.'
+            )
+
         self.update_interval = update_interval
 
     def set_blocking_timeout(self, blocking_timeout: Optional[int | float]) -> None:

--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -325,7 +325,7 @@ class PollingConfigManager(StaticConfigManager):
 
         if update_interval < 30:
             self.logger.warning(
-                f'Polling intervals below 30 seconds are not recommended.'
+                'Polling intervals below 30 seconds are not recommended.'
             )
 
         self.update_interval = update_interval


### PR DESCRIPTION
Summary
-------
-  Implements a warning log for polling interval below 30s

Test plan
---------
- All tests should pass

Issues
------

-  -  [FSSDK-9510](https://jira.sso.episerver.net/browse/FSSDK-9510)
