### PR TITLE
[FSSDK-10317] Remove PyOpenSSL and cryptography from requirements

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,6 +1,4 @@
 jsonschema>=3.2.0
 pyrsistent>=0.16.0
 requests>=2.21
-pyOpenSSL>=19.1.0
-cryptography>=2.8.0
 idna>=2.10


### PR DESCRIPTION
Summary
-------
PyOpenSSL and cryptography packages are no longer required and can potentially introduce a security risk as pointed out by PeterJCLaw in his reported [GitHub issue](https://github.com/optimizely/python-sdk/issues/434).

Sdk used to use requests extra option requests[security] that included PyOpenSSL and cryptography packages to enhance SSL/TLS support, particularly for older versions of Python that lacked certain security features.

The requests[security] extra was officially deprecated in version 2.25.0 of the requests library, released on November 11, 2020. The deprecation notice indicated that this extra would be removed in version 2.26.0. The primary reason for deprecation was the improved native SSL/TLS support in modern Python versions, making the extra dependencies redundant.

Based on the above we replaced requests[security] with its components including PyOpenSSL and cryptography. But it looks like we didn't need to do so. 

According to research, users are now encouraged to rely on the native SSL/TLS support provided by Python's standard library. The requests library itself continues to support secure HTTP requests (HTTPS) out of the box, leveraging the built-in ssl module in Python.

We removed Py v2.x and some older Py 3.x versions and so we can now use native SSL/TLS support in modern Python versions we're using. If all tests are passing then PyOpenSSL and cyptography can be safely removed.


Test plan
---------
- local unit test passing
- PR check passing specifically full stack compatibility test suite must pass as it has the most comprehensive test coverage

Issues
------
- GitHub issue: https://github.com/optimizely/python-sdk/issues/434 
-  Jira ticket: https://jira.sso.episerver.net/browse/FSSDK-10317 