### PR TITLE
[FSSDK-10317] Remove dependency mentions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,6 @@ This software incorporates code from the following open source projects:
 
 requests (Apache-2.0 License: https://github.com/psf/requests/blob/master/LICENSE)
 
-pyOpenSSL (Apache-2.0 License https://github.com/pyca/pyopenssl/blob/main/LICENSE)
-
-cryptography (Apache-2.0 https://github.com/pyca/cryptography/blob/main/LICENSE.APACHE)
-
 idna (BSD 3-Clause License https://github.com/kjd/idna/blob/master/LICENSE.md)
 
 ### Other Optimizely SDKs


### PR DESCRIPTION
Summary
-------
-  Addition to https://github.com/optimizely/python-sdk/pull/435 
- removing mentions of license dependencies for PyOpenSSL and cryptography

Test plan
---------
No code change involved. All tests passing.

Issues
------

-  https://jira.sso.episerver.net/browse/FSSDK-10317 
