### PR TITLE
[FSSDK-10763] Implement UPS request batching for decideForKeys

### DIFF
--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -303,7 +303,6 @@ class DecisionService:
 
         # Check to see if user has a decision available for the given experiment
         if user_profile_tracker is not None and not ignore_user_profile:
-            # user_profile_tracker.load_user_profile()
             variation = self.get_stored_variation(project_config, experiment, user_profile_tracker.get_user_profile())
             if variation:
                 message = f'Returning previously activated variation ID "{variation}" of experiment ' \

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -307,7 +307,7 @@ class DecisionService:
             variation = self.get_stored_variation(project_config, experiment, user_profile_tracker.get_user_profile())
             if variation:
                 message = f'Returning previously activated variation ID "{variation}" of experiment ' \
-                            f'"{experiment}" for user "{user_id}" from user profile.'
+                          f'"{experiment}" for user "{user_id}" from user profile.'
                 self.logger.info(message)
                 decide_reasons.append(message)
                 return variation, decide_reasons

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -248,7 +248,7 @@ class DecisionService:
         experiment: entities.Experiment,
         user_context: OptimizelyUserContext,
         user_profile_tracker: UserProfileTracker,
-        reasons: list[str],
+        reasons: list[str] = [],
         options: Optional[Sequence[str]] = None
     ) -> tuple[Optional[entities.Variation], list[str]]:
         """ Top-level function to help determine variation user should be put in.

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -341,8 +341,6 @@ class DecisionService:
             if user_profile_tracker is not None and not ignore_user_profile:
                 try:
                     user_profile_tracker.update_user_profile(experiment, variation)
-                    if self.user_profile_service is not None:
-                        self.user_profile_service.save(user_profile_tracker.get_user_profile().__dict__)
                 except:
                     self.logger.exception(f'Unable to save user profile for user "{user_id}".')
             return variation, decide_reasons

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -611,7 +611,7 @@ class DecisionService:
             # Only process rollout if no experiment decision was found
             if not experiment_decision_found:
                 rollout_decision, rollout_reasons = self.get_variation_for_rollout(project_config, feature, user_context)
-                feature_reasons.extend(rollout_reasons)
+                feature_reasons.append(rollout_reasons)
                 
                 if rollout_decision:
                     self.logger.debug(f'User "{user_context.user_id}" bucketed into rollout for feature "{feature.key}".')

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -302,7 +302,7 @@ class DecisionService:
             return variation, decide_reasons
 
         # Check to see if user has a decision available for the given experiment
-        if user_profile_tracker is not None:
+        if user_profile_tracker is not None and not ignore_user_profile:
             user_profile_tracker.load_user_profile()
             variation = self.get_stored_variation(project_config, experiment, user_profile_tracker.get_user_profile())
             if variation:
@@ -338,7 +338,7 @@ class DecisionService:
             self.logger.info(message)
             decide_reasons.append(message)
             # Store this new decision and return the variation for the user
-            if user_profile_tracker is not None:
+            if user_profile_tracker is not None and not ignore_user_profile:
                 try:
                     user_profile_tracker.update_user_profile(experiment, variation)
                     self.user_profile_service.save(user_profile_tracker.get_user_profile().__dict__)

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -602,8 +602,8 @@ class DecisionService:
 
                         if decision_variation:
                             self.logger.debug(
-                                'User "{}" bucketed into experiment "{}" of feature "{}".'.format(
-                                    user_context.user_id, experiment.key, feature.key)
+                                f'User "{user_context.user_id}" '
+                                f'bucketed into experiment "{experiment.key}" of feature "{feature.key}".'
                             )
                             decision = Decision(experiment, decision_variation, enums.DecisionSources.FEATURE_TEST)
                             decisions.append((decision, feature_reasons))

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -303,7 +303,7 @@ class DecisionService:
 
         # Check to see if user has a decision available for the given experiment
         if user_profile_tracker is not None and not ignore_user_profile:
-            user_profile_tracker.load_user_profile()
+            # user_profile_tracker.load_user_profile()
             variation = self.get_stored_variation(project_config, experiment, user_profile_tracker.get_user_profile())
             if variation:
                 message = f'Returning previously activated variation ID "{variation}" of experiment ' \

--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -22,7 +22,7 @@ from .helpers import enums
 from .helpers import experiment as experiment_helper
 from .helpers import validator
 from .optimizely_user_context import OptimizelyUserContext, UserAttributes
-from .user_profile import UserProfile, UserProfileService
+from .user_profile import UserProfile, UserProfileService, UserProfileTracker
 
 if TYPE_CHECKING:
     # prevent circular dependenacy by skipping import at runtime
@@ -247,6 +247,8 @@ class DecisionService:
         project_config: ProjectConfig,
         experiment: entities.Experiment,
         user_context: OptimizelyUserContext,
+        user_profile_tracker: UserProfileTracker,
+        reasons: list[str],
         options: Optional[Sequence[str]] = None
     ) -> tuple[Optional[entities.Variation], list[str]]:
         """ Top-level function to help determine variation user should be put in.
@@ -260,7 +262,9 @@ class DecisionService:
         Args:
           project_config: Instance of ProjectConfig.
           experiment: Experiment for which user variation needs to be determined.
-          user_context: contains user id and attributes
+          user_context: contains user id and attributes.
+          user_profile_tracker: tracker for reading and updating user profile of the user.
+          reasons: Decision reasons.
           options: Decide options.
 
         Returns:

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1315,8 +1315,8 @@ class Optimizely:
                 decisions[key] = OptimizelyDecision(None, False, None, None, key, user_context, [])
                 continue
             valid_keys.append(key)
-            # decision_reasons = []
-            # decision_reasons_dict[key] = decision_reasons
+            decision_reasons = []
+            decision_reasons_dict[key] = decision_reasons
             
             optimizely_decision_context = OptimizelyUserContext.OptimizelyDecisionContext(flag_key=key, rule_key=None)
             forced_decision_response = self.decision_service.validated_forced_decision(project_config,

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1133,6 +1133,10 @@ class Optimizely:
         
         return decision
         
+    def _fix_nested_decision_reasons_list(self, decision_reasons)->list:
+        if len(decision_reasons)==1 and type(decision_reasons[0])==type(list()):
+            decision_reasons = decision_reasons[0]
+        return decision_reasons
         
     def _create_optimizely_decision(
             self,
@@ -1155,7 +1159,7 @@ class Optimizely:
         attributes = user_context.get_user_attributes()
         rule_key = flag_decision.experiment.key if flag_decision.experiment else None
         all_variables = {}
-        decision_source = DecisionSources.ROLLOUT
+        decision_source = flag_decision.source
         decision_event_dispatched = False
     
         feature_flag = project_config.feature_key_map.get(flag_key)
@@ -1352,10 +1356,11 @@ class Optimizely:
             flag_decisions[flag_key] = decision
             decision_reasons_dict[flag_key] += reasons
             
-            
+        print(decision_reasons_dict)
         for key in valid_keys:
             flag_decision = flag_decisions[key]
             decision_reasons = decision_reasons_dict[key]
+            decision_reasons = self._fix_nested_decision_reasons_list(decision_reasons)
             optimizely_decision = self._create_optimizely_decision(
                 user_context,
                 key,
@@ -1367,7 +1372,7 @@ class Optimizely:
             
             if (OptimizelyDecideOption.ENABLED_FLAGS_ONLY not in merged_decide_options) or (optimizely_decision.enabled):
                 decisions[key] = optimizely_decision
-            
+        
         return decisions
 
     def _setup_odp(self, sdk_key: Optional[str]) -> None:

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -633,10 +633,12 @@ class Optimizely:
 
         user_context = OptimizelyUserContext(self, self.logger, user_id, attributes, False)
         user_profile_tracker = user_profile.UserProfileTracker(user_id, self.user_profile_service, self.logger)
+        user_profile_tracker.load_user_profile()
         variation, _ = self.decision_service.get_variation(project_config,
                                                            experiment,
                                                            user_context,
                                                            user_profile_tracker)
+        user_profile_tracker.save_user_profile()
         if variation:
             variation_key = variation.key
 

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1348,8 +1348,13 @@ class Optimizely:
                 #                                                                             user_context, decide_options)
                 flags_without_forced_decision.append(feature_flag)
 
-        #needs to be implemented
-        decisionList = self.decision_service.get_variation_for_feature_list(flags_without_forced_decision, user_context, project_config, merged_decide_options)
+        
+        decisionList = self.decision_service.get_variations_for_feature_list(
+            project_config,
+            flags_without_forced_decision,
+            user_context,
+            merged_decide_options
+        )
             
             
             

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1291,16 +1291,9 @@ class Optimizely:
             self.logger.debug('Provided decide options is not an array. Using default decide options.')
             merged_decide_options = self.default_decide_options
 
-        # enabled_flags_only = OptimizelyDecideOption.ENABLED_FLAGS_ONLY in merged_decide_options
-
         decisions: dict[str, OptimizelyDecision] = {}
         valid_keys = []
         decision_reasons_dict = {}
-        # for key in keys:
-        #     decision = self._decide(user_context, key, decide_options)
-        #     if enabled_flags_only and not decision.enabled:
-        #         continue
-        #     decisions[key] = decision
 
         project_config = self.config_manager.get_config()
         flags_without_forced_decision: list[entities.FeatureFlag] = []
@@ -1344,7 +1337,6 @@ class Optimizely:
             flag_decisions[flag_key] = decision
             decision_reasons_dict[flag_key] += reasons
 
-        print(decision_reasons_dict)
         for key in valid_keys:
             flag_decision = flag_decisions[key]
             decision_reasons = decision_reasons_dict[key]

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 from typing import Any, Optional
 from sys import version_info
-from .helpers.validator import is_user_profile_valid
 from .entities import Experiment, Variation
 from .decision_service import Decision
 from optimizely.error_handler import BaseErrorHandler
@@ -117,8 +116,6 @@ class UserProfileTracker:
             if user_profile is None:
                 message = reasons.append("Unable to get a user profile from the UserProfileService.")
                 self.logger.info(message)
-            elif is_user_profile_valid(user_profile):
-                self.user_profile = user_profile
             else:
                 message = reasons.append("The UserProfileService returned an invalid user_profile.")
                 self.logger.warning(message)

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -114,7 +114,7 @@ class UserProfileTracker:
         self.profile_updated = False
         self.user_profile = UserProfile(user_id, {})
     
-    def get_user_profile(self) -> None:
+    def get_user_profile(self) -> UserProfile:
         return self.user_profile
 
     def load_user_profile(self, reasons: Optional[list[str]]=[], error_handler: Optional[BaseErrorHandler]=None) -> None:

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -119,7 +119,8 @@ class UserProfileTracker:
 
     def load_user_profile(self, reasons: Optional[list[str]] = [],
                           error_handler: Optional[BaseErrorHandler] = None) -> None:
-        reasons = reasons if reasons else []
+        if reasons is None:
+            reasons = []
         try:
             user_profile = self.user_profile_service.lookup(self.user_id) if self.user_profile_service else None
             if user_profile is None:
@@ -139,27 +140,12 @@ class UserProfileTracker:
         except Exception as exception:
             message = str(exception)
             reasons.append(message)
-            self.logger.exception(f'Unable to retrieve user profile for user "{self.user_id}"as lookup failed.')
-
-        if self.user_profile is None:
-            self.user_profile = UserProfile(self.user_id, {})
+            self.logger.exception(f'Unable to retrieve user profile for user "{self.user_id}" as lookup failed.')
 
     def update_user_profile(self, experiment: Experiment, variation: Variation) -> None:
         variation_id = variation.id
         experiment_id = experiment.id
         self.user_profile.save_variation_for_experiment(experiment_id, variation_id)
-        # if experiment.id in self.user_profile.experiment_bucket_map:
-        #     decision = self.user_profile.experiment_bucket_map[experiment.id]
-        #     if isinstance(decision, decision_service.Decision):
-        #         decision = decision_service.Decision(
-        #             experiment=decision.experiment,
-        #             variation=variation,
-        #             source=decision.source
-        #         )
-        # else:
-        #     decision = decision_service.Decision(experiment=None, variation=variation, source=None)
-
-        # self.user_profile.experiment_bucket_map[experiment.id] = decision
         self.profile_updated = True
 
     def save_user_profile(self, error_handler: Optional[BaseErrorHandler] = None) -> None:

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -126,7 +126,6 @@ class UserProfileTracker:
             if user_profile is None:
                 message = "Unable to get a user profile from the UserProfileService."
                 reasons.append(message)
-                # self.logger.info(message)
             else:
                 if 'user_id' in user_profile and 'experiment_bucket_map' in user_profile:
                     self.user_profile = UserProfile(
@@ -142,8 +141,6 @@ class UserProfileTracker:
             message = str(exception)
             reasons.append(message)
             self.logger.exception(f'Unable to retrieve user profile for user "{self.user_id}"as lookup failed.')
-            # Todo: add error handler
-            # error_handler.handle_error()
 
         if self.user_profile is None:
             self.user_profile = UserProfile(self.user_id, {})
@@ -173,4 +170,3 @@ class UserProfileTracker:
         except Exception as exception:
             self.logger.warning(f'Failed to save user profile of user "{self.user_profile.user_id}" '
                                 f'for exception:{exception}".')
-            # error_handler.handle_error(exception)

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -99,7 +99,7 @@ class UserProfileTracker:
     def __init__(self, user_id: str, user_profile_service: UserProfileService, logger=None):
         self.user_id = user_id
         self.user_profile_service = user_profile_service
-        # self.logger = logger or logging.getLogger(__name__)
+        self.logger = logger
         self.profile_updated = False
         self.user_profile = None
     

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Any, Optional, Union
+from typing import Any, Optional
 from sys import version_info
 from . import logger as _logging
 from . import decision_service
@@ -24,7 +24,6 @@ else:
     if TYPE_CHECKING:
         # prevent circular dependenacy by skipping import at runtime
         from .entities import Experiment, Variation
-        from .decision_service import Decision
         from optimizely.error_handler import BaseErrorHandler
 
 

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -114,10 +114,10 @@ class UserProfileTracker:
         self.profile_updated = False
         self.user_profile = UserProfile(user_id, {})
     
-    def get_user_profile(self):
+    def get_user_profile(self) -> None:
         return self.user_profile
 
-    def load_user_profile(self, reasons: Optional[list[str]]=[], error_handler: Optional[BaseErrorHandler]=None):
+    def load_user_profile(self, reasons: Optional[list[str]]=[], error_handler: Optional[BaseErrorHandler]=None) -> None:
         reasons = reasons if reasons else []
         try:
             user_profile = self.user_profile_service.lookup(self.user_id) if self.user_profile_service else None
@@ -146,7 +146,7 @@ class UserProfileTracker:
         if self.user_profile is None:
             self.user_profile = UserProfile(self.user_id, {})
             
-    def update_user_profile(self, experiment: Experiment, variation: Variation):
+    def update_user_profile(self, experiment: Experiment, variation: Variation) -> None:
         if experiment.id in self.user_profile.experiment_bucket_map:
             decision = self.user_profile.experiment_bucket_map[experiment.id]
             if isinstance(decision, decision_service.Decision):
@@ -163,7 +163,7 @@ class UserProfileTracker:
         # self.logger.info(f'Updated variation "{variation.id}" of experiment "{experiment.id}" for user "{self.user_profile.user_id}".')
         
         
-    def save_user_profile(self, error_handler: Optional[BaseErrorHandler] = None):
+    def save_user_profile(self, error_handler: Optional[BaseErrorHandler] = None) -> None:
         if not self.profile_updated:
             return
         try:

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -46,7 +46,7 @@ class UserProfile:
     def __init__(
         self,
         user_id: str,
-        experiment_bucket_map: Optional[dict[str, dict[str, Optional[str]]]] = None,
+        experiment_bucket_map: Optional[dict[str, Decision]] = None,
         **kwargs: Any
     ):
         self.user_id = user_id
@@ -131,7 +131,7 @@ class UserProfileTracker:
                     reasons.append(message)
         except Exception as exception:
             message = reasons.append(str(exception))
-            self.logger.error(message)
+            self.logger.exception(f'Unable to retrieve user profile for user "{self.user_id}"as lookup failed.')
             # Todo: add error handler
             # error_handler.handle_error()
         

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -14,9 +14,7 @@
 from __future__ import annotations
 from typing import Any, Optional
 from sys import version_info
-from .entities import Experiment, Variation
-from .decision_service import Decision
-from optimizely.error_handler import BaseErrorHandler
+
 
 if version_info < (3, 8):
     from typing_extensions import Final
@@ -27,6 +25,9 @@ else:
         # prevent circular dependenacy by skipping import at runtime
         from .project_config import ProjectConfig
         from .logger import Logger
+        from .entities import Experiment, Variation
+        from .decision_service import Decision
+        from optimizely.error_handler import BaseErrorHandler
 
 
 class UserProfile:
@@ -100,7 +101,7 @@ class UserProfileService:
         pass
 
 class UserProfileTracker:
-    def __init__(self, user_id: str, user_profile_service: UserProfileService, logger=Logger):
+    def __init__(self, user_id: str, user_profile_service: UserProfileService, logger:Logger):
         self.user_id = user_id
         self.user_profile_service = user_profile_service
         self.logger = logger

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -22,7 +22,12 @@ from optimizely.error_handler import BaseErrorHandler
 if version_info < (3, 8):
     from typing_extensions import Final
 else:
-    from typing import Final  # type: ignore
+    from typing import Final, TYPE_CHECKING  # type: ignore
+    
+    if TYPE_CHECKING:
+        # prevent circular dependenacy by skipping import at runtime
+        from .project_config import ProjectConfig
+        from .logger import Logger
 
 
 class UserProfile:
@@ -96,7 +101,7 @@ class UserProfileService:
         pass
 
 class UserProfileTracker:
-    def __init__(self, user_id: str, user_profile_service: UserProfileService, logger=None):
+    def __init__(self, user_id: str, user_profile_service: UserProfileService, logger=Logger):
         self.user_id = user_id
         self.user_profile_service = user_profile_service
         self.logger = logger

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Any, Optional
 from sys import version_info
 from . import logger as _logging
-from . import decision_service
+
 if version_info < (3, 8):
     from typing_extensions import Final
 else:
@@ -60,14 +60,7 @@ class UserProfile:
     Returns:
       Variation ID corresponding to the experiment. None if no decision available.
     """
-        experiment_data = self.experiment_bucket_map.get(experiment_id)
-
-        if isinstance(experiment_data, decision_service.Decision):
-            return experiment_data.variation.id if experiment_data.variation is not None else None
-        elif isinstance(experiment_data, dict):
-            return experiment_data.get(self.VARIATION_ID_KEY)
-
-        return None
+        return self.experiment_bucket_map.get(experiment_id, {self.VARIATION_ID_KEY: None}).get(self.VARIATION_ID_KEY)
 
     def save_variation_for_experiment(self, experiment_id: str, variation_id: str) -> None:
         """ Helper method to save new experiment/variation as part of the user's profile.

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -119,8 +119,16 @@ class UserProfileTracker:
                 message = reasons.append("Unable to get a user profile from the UserProfileService.")
                 self.logger.info(message)
             else:
-                message = reasons.append("The UserProfileService returned an invalid user_profile.")
-                self.logger.warning(message)
+                if 'user_id' in user_profile and 'experiment_bucket_map' in user_profile:
+                    self.user_profile = UserProfile(
+                        user_profile['user_id'], 
+                        user_profile['experiment_bucket_map']
+                    )
+                    self.logger.info("User profile loaded successfully.")
+                else:
+                    missing_keys = [key for key in ['user_id', 'experiment_bucket_map'] if key not in user_profile]
+                    message = f"User profile is missing keys: {', '.join(missing_keys)}"
+                    reasons.append(message)
         except Exception as exception:
             message = reasons.append(str(exception))
             self.logger.error(message)

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -134,6 +134,8 @@ class UserProfileTracker:
             message = str(exception)
             reasons.append(message)
             self.logger.exception(f'Unable to retrieve user profile for user "{self.user_id}" as lookup failed.')
+            if error_handler:
+                error_handler.handle_error(exception)
 
     def update_user_profile(self, experiment: Experiment, variation: Variation) -> None:
         variation_id = variation.id
@@ -151,3 +153,5 @@ class UserProfileTracker:
         except Exception as exception:
             self.logger.warning(f'Failed to save user profile of user "{self.user_profile.user_id}" '
                                 f'for exception:{exception}".')
+            if error_handler:
+                error_handler.handle_error(exception)

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -14,7 +14,8 @@
 from __future__ import annotations
 from typing import Any, Optional
 from sys import version_info
-
+from . import logger as _logging
+from . import decision_service
 
 if version_info < (3, 8):
     from typing_extensions import Final
@@ -101,17 +102,17 @@ class UserProfileService:
         pass
 
 class UserProfileTracker:
-    def __init__(self, user_id: str, user_profile_service: UserProfileService, logger:Logger):
+    def __init__(self, user_id: str, user_profile_service: UserProfileService, logger:Optional[_logging.Logger] = None):
         self.user_id = user_id
         self.user_profile_service = user_profile_service
-        self.logger = logger
+        self.logger = _logging.adapt_logger(logger or _logging.NoOpLogger())
         self.profile_updated = False
         self.user_profile = None
     
     def get_user_profile(self):
         return self.user_profile
 
-    def load_user_profile(self, reasons: Optional[list[str]], error_handler: Optional[BaseErrorHandler]):
+    def load_user_profile(self, reasons: Optional[list[str]]=[], error_handler: Optional[BaseErrorHandler]=None):
         try:
             user_profile = self.user_profile_service.lookup(self.user_id)
             if user_profile is None:
@@ -135,14 +136,14 @@ class UserProfileTracker:
             decision = self.user_profile.experiment_bucket_map[experiment.id]
             decision.variation = variation
         else:
-            decision = Decision(experiment=None, variation=variation, source=None)
+            decision = decision_service.Decision(experiment=None, variation=variation, source=None)
          
         self.user_profile.experiment_bucket_map[experiment.id] = decision
         self.profile_updated = True
         # self.logger.info(f'Updated variation "{variation.id}" of experiment "{experiment.id}" for user "{self.user_profile.user_id}".')
         
         
-    def save_user_profile(self, error_handler: Optional[BaseErrorHandler]):
+    def save_user_profile(self, error_handler: Optional[BaseErrorHandler] = None):
         if not self.profile_updated:
             return
 

--- a/optimizely/user_profile.py
+++ b/optimizely/user_profile.py
@@ -43,7 +43,7 @@ class UserProfile:
     def __init__(
         self,
         user_id: str,
-        experiment_bucket_map: Optional[dict[str, Union[Decision, dict[str, str]]]] = None,
+        experiment_bucket_map: Optional[dict[str, dict[str, Optional[str]]]] = None,
         **kwargs: Any
     ):
         self.user_id = user_id
@@ -146,18 +146,21 @@ class UserProfileTracker:
             self.user_profile = UserProfile(self.user_id, {})
 
     def update_user_profile(self, experiment: Experiment, variation: Variation) -> None:
-        if experiment.id in self.user_profile.experiment_bucket_map:
-            decision = self.user_profile.experiment_bucket_map[experiment.id]
-            if isinstance(decision, decision_service.Decision):
-                decision = decision_service.Decision(
-                    experiment=decision.experiment,
-                    variation=variation,
-                    source=decision.source
-                )
-        else:
-            decision = decision_service.Decision(experiment=None, variation=variation, source=None)
+        variation_id = variation.id
+        experiment_id = experiment.id
+        self.user_profile.save_variation_for_experiment(experiment_id, variation_id)
+        # if experiment.id in self.user_profile.experiment_bucket_map:
+        #     decision = self.user_profile.experiment_bucket_map[experiment.id]
+        #     if isinstance(decision, decision_service.Decision):
+        #         decision = decision_service.Decision(
+        #             experiment=decision.experiment,
+        #             variation=variation,
+        #             source=decision.source
+        #         )
+        # else:
+        #     decision = decision_service.Decision(experiment=None, variation=variation, source=None)
 
-        self.user_profile.experiment_bucket_map[experiment.id] = decision
+        # self.user_profile.experiment_bucket_map[experiment.id] = decision
         self.profile_updated = True
 
     def save_user_profile(self, error_handler: Optional[BaseErrorHandler] = None) -> None:

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -856,6 +856,7 @@ class DecisionServiceTest(base.BaseTest):
                                                              logger=None,
                                                              user_id="test_user",
                                                              user_attributes={})
+        user_profile_tracker = user_profile.UserProfileTracker(user.user_id, self.decision_service.user_profile_service)
         experiment = self.project_config.get_experiment_from_key("test_experiment")
         with mock.patch.object(
                 self.decision_service, "logger"
@@ -876,7 +877,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.user_profile.UserProfileService.save"
         ) as mock_save:
             variation, _ = self.decision_service.get_variation(
-                self.project_config, experiment, user, None
+                self.project_config, experiment, user, user_profile_tracker
             )
             self.assertEqual(
                 entities.Variation("111129", "variation"),
@@ -1473,7 +1474,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             self.project_config.get_experiment_from_key("test_experiment"),
             user,
             None,
-            [],
+            [[]],
             None
         )
 
@@ -1501,7 +1502,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             )
 
         mock_decision.assert_called_once_with(
-            self.project_config, self.project_config.get_experiment_from_id("32222"), user, None, [], False
+            self.project_config, self.project_config.get_experiment_from_id("32222"), user, None, [[]], False
         )
 
     def test_get_variation_for_feature__returns_variation_for_feature_in_mutex_group_bucket_less_than_2500(

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -588,8 +588,6 @@ class DecisionServiceTest(base.BaseTest):
                 entities.Variation("111128", "control"),
                 variation,
             )
-            print("Actual UserProfile argument:", mock_get_stored_variation.call_args[0][2].__dict__)
-            print("Expected UserProfile argument:", user_profile.UserProfile("test_user", {"111127": {"variation_id": "111128"}}).__dict__)
         # Assert that stored variation is returned and bucketing service is not involved
         mock_get_whitelisted_variation.assert_called_once_with(
             self.project_config, experiment, "test_user"
@@ -651,8 +649,8 @@ class DecisionServiceTest(base.BaseTest):
             self.project_config, experiment, user.user_id
         )
         expected_decision = decision_service.Decision(
-            experiment=None, 
-            variation=entities.Variation("111129", "variation"), 
+            experiment=None,
+            variation=entities.Variation("111129", "variation"),
             source=None
         )
         mock_lookup.assert_called_once_with("test_user")
@@ -788,7 +786,7 @@ class DecisionServiceTest(base.BaseTest):
 
     def test_get_variation__user_profile_in_invalid_format(self):
         """ Test that get_variation handles invalid user profile gracefully. """
- 
+
         user = optimizely_user_context.OptimizelyUserContext(optimizely_client=None,
                                                              logger=None,
                                                              user_id="test_user",
@@ -825,22 +823,22 @@ class DecisionServiceTest(base.BaseTest):
                 entities.Variation("111129", "variation"),
                 variation,
             )
- 
+
         # Assert that user is bucketed and new decision is stored
         mock_get_whitelisted_variation.assert_called_once_with(
             self.project_config, experiment, "test_user"
         )
         mock_lookup.assert_called_once_with("test_user")
- 
+
         # Stored decision is not consulted as user profile is invalid
         mock_get_stored_variation.assert_called_once_with(
             self.project_config,
             experiment,
             user_profile_tracker.get_user_profile()  # Get the actual UserProfile object
         )
- 
+
         # self.assertEqual(0, mock_get_stored_variation.call_count)
- 
+
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
@@ -858,10 +856,9 @@ class DecisionServiceTest(base.BaseTest):
         mock_save.assert_called_once_with({
             "user_id": "test_user",
             "experiment_bucket_map": {
-                "111127": mock.ANY 
+                "111127": mock.ANY
             }
         })
- 
 
     def test_get_variation__user_profile_lookup_fails(self):
         """ Test that get_variation acts gracefully when lookup fails. """
@@ -880,7 +877,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_get_whitelisted_variation, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation",
             return_value=None
-        ) as mock_get_stored_variation, mock.patch(
+        ), mock.patch(
             "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=[True, []]
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
@@ -904,7 +901,7 @@ class DecisionServiceTest(base.BaseTest):
             self.project_config, experiment, "test_user"
         )
         mock_lookup.assert_called_once_with("test_user")
-        
+
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
@@ -913,7 +910,7 @@ class DecisionServiceTest(base.BaseTest):
             user,
             mock_decision_service_logging
         )
-        
+
         mock_bucket.assert_called_once_with(
             self.project_config, experiment, "test_user", "test_user"
         )
@@ -946,7 +943,7 @@ class DecisionServiceTest(base.BaseTest):
         ) as mock_get_whitelisted_variation, mock.patch(
             "optimizely.decision_service.DecisionService.get_stored_variation",
             return_value=None
-        ) as mock_get_stored_variation, mock.patch(
+        ), mock.patch(
             "optimizely.helpers.audience.does_user_meet_audience_conditions", return_value=[True, []]
         ) as mock_audience_check, mock.patch(
             "optimizely.bucketer.Bucketer.bucket",
@@ -970,7 +967,7 @@ class DecisionServiceTest(base.BaseTest):
             self.project_config, experiment, "test_user"
         )
         mock_lookup.assert_called_once_with("test_user")
-        
+
         mock_audience_check.assert_called_once_with(
             self.project_config,
             experiment.get_audience_conditions_or_ids(),
@@ -991,7 +988,7 @@ class DecisionServiceTest(base.BaseTest):
             "experiment_bucket_map": {
                 "111127": decision_service.Decision(
                     experiment=None,
-                    variation=mock.ANY, 
+                    variation=mock.ANY,
                     source=None
                 )
             }
@@ -1611,7 +1608,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
         with mock.patch(
             'optimizely.bucketer.Bucketer._generate_bucket_value', return_value=6500) as mock_generate_bucket_value, \
                 mock.patch.object(self.project_config, 'logger') as mock_config_logging:
-            
+
             variation_received, _ = self.decision_service.get_variation_for_feature(
                 self.project_config, feature, user
             )
@@ -1829,8 +1826,6 @@ class FeatureFlagDecisionTests(base.BaseTest):
                                                              user_id="test_user",
                                                              user_attributes={
                                                                  "experiment_attr": "group_experiment_invalid"})
-        user_profile_service = user_profile.UserProfileService()
-        user_profile_tracker = user_profile.UserProfileTracker(user.user_id, user_profile_service)
         feature = self.project_config.get_feature_from_key("test_feature_in_multiple_experiments")
         expected_experiment = self.project_config.get_experiment_from_id("211147")
         expected_variation = self.project_config.get_variation_from_id(
@@ -1845,10 +1840,10 @@ class FeatureFlagDecisionTests(base.BaseTest):
             )
             print(f"variation received is: {variation_received}")
             x = decision_service.Decision(
-                    expected_experiment,
-                    expected_variation,
-                    enums.DecisionSources.ROLLOUT,
-                )
+                expected_experiment,
+                expected_variation,
+                enums.DecisionSources.ROLLOUT,
+            )
             print(f"need to be:{x}")
             self.assertEqual(
                 decision_service.Decision(
@@ -1858,7 +1853,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
                 ),
                 variation_received,
             )
-           
+
         mock_config_logging.debug.assert_called_with(
             'Assigned bucket 4000 to user with bucketing ID "test_user".')
         mock_generate_bucket_value.assert_called_with("test_user211147")

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -616,6 +616,8 @@ class DecisionServiceTest(base.BaseTest):
                                                              logger=None,
                                                              user_id="test_user",
                                                              user_attributes={})
+        user_profile_service = user_profile.UserProfileService()
+        user_profile_tracker = user_profile.UserProfileTracker(user.user_id, user_profile_service)
         experiment = self.project_config.get_experiment_from_key("test_experiment")
         with mock.patch.object(
                 self.decision_service, "logger"
@@ -637,7 +639,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.user_profile.UserProfileService.save"
         ) as mock_save:
             variation, _ = self.decision_service.get_variation(
-                self.project_config, experiment, user, None
+                self.project_config, experiment, user, user_profile_tracker
             )
             self.assertEqual(
                 entities.Variation("111129", "variation"),

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -1495,7 +1495,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             self.project_config.get_experiment_from_key("test_experiment"),
             user,
             None,
-            [[]],
+            [],
             None
         )
 
@@ -1523,7 +1523,7 @@ class FeatureFlagDecisionTests(base.BaseTest):
             )
 
         mock_decision.assert_called_once_with(
-            self.project_config, self.project_config.get_experiment_from_id("32222"), user, None, [[]], False
+            self.project_config, self.project_config.get_experiment_from_id("32222"), user, None, [], False
         )
 
     def test_get_variation_for_feature__returns_variation_for_feature_in_mutex_group_bucket_less_than_2500(

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -650,6 +650,11 @@ class DecisionServiceTest(base.BaseTest):
         mock_get_whitelisted_variation.assert_called_once_with(
             self.project_config, experiment, user.user_id
         )
+        expected_decision = decision_service.Decision(
+            experiment=None, 
+            variation=entities.Variation("111129", "variation"), 
+            source=None
+        )
         mock_lookup.assert_called_once_with("test_user")
         self.assertEqual(1, mock_get_stored_variation.call_count)
         mock_audience_check.assert_called_once_with(
@@ -666,7 +671,7 @@ class DecisionServiceTest(base.BaseTest):
         mock_save.assert_called_once_with(
             {
                 "user_id": "test_user",
-                "experiment_bucket_map": {"111127": {"variation_id": "111129"}},
+                "experiment_bucket_map": {"111127": expected_decision},
             }
         )
 
@@ -735,6 +740,7 @@ class DecisionServiceTest(base.BaseTest):
                                                              logger=None,
                                                              user_id="test_user",
                                                              user_attributes={})
+        user_profile_tracker = user_profile.UserProfileTracker(user.user_id, self.decision_service.user_profile_service)
         experiment = self.project_config.get_experiment_from_key("test_experiment")
         with mock.patch.object(
                 self.decision_service, "logger"
@@ -755,7 +761,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.user_profile.UserProfileService.save"
         ) as mock_save:
             variation, _ = self.decision_service.get_variation(
-                self.project_config, experiment, user, None
+                self.project_config, experiment, user, user_profile_tracker
             )
             self.assertIsNone(
                 variation
@@ -787,6 +793,7 @@ class DecisionServiceTest(base.BaseTest):
                                                              logger=None,
                                                              user_id="test_user",
                                                              user_attributes={})
+        user_profile_tracker = user_profile.UserProfileTracker(user.user_id, self.decision_service.user_profile_service)
         experiment = self.project_config.get_experiment_from_key("test_experiment")
         with mock.patch.object(
                 self.decision_service, "logger"
@@ -807,7 +814,7 @@ class DecisionServiceTest(base.BaseTest):
             "optimizely.user_profile.UserProfileService.save"
         ) as mock_save:
             variation, _ = self.decision_service.get_variation(
-                self.project_config, experiment, user, None
+                self.project_config, experiment, user, user_profile_tracker
             )
             self.assertEqual(
                 entities.Variation("111129", "variation"),

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -372,7 +372,8 @@ class OptimizelyTest(base.BaseTest):
         user_profile_tracker = mock_decision.call_args[0][3]
 
         mock_decision.assert_called_once_with(
-            self.project_config, self.project_config.get_experiment_from_key('test_experiment'), user_context, user_profile_tracker
+            self.project_config, self.project_config.get_experiment_from_key('test_experiment'),
+            user_context, user_profile_tracker
         )
         self.assertEqual(1, mock_process.call_count)
 

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -369,9 +369,10 @@ class OptimizelyTest(base.BaseTest):
 
         log_event = EventFactory.create_log_event(mock_process.call_args[0][0], self.optimizely.logger)
         user_context = mock_decision.call_args[0][2]
+        user_profile_tracker = mock_decision.call_args[0][3]
 
         mock_decision.assert_called_once_with(
-            self.project_config, self.project_config.get_experiment_from_key('test_experiment'), user_context
+            self.project_config, self.project_config.get_experiment_from_key('test_experiment'), user_context, user_profile_tracker
         )
         self.assertEqual(1, mock_process.call_count)
 
@@ -766,11 +767,13 @@ class OptimizelyTest(base.BaseTest):
 
         log_event = EventFactory.create_log_event(mock_process.call_args[0][0], self.optimizely.logger)
         user_context = mock_get_variation.call_args[0][2]
+        user_profile_tracker = mock_get_variation.call_args[0][3]
 
         mock_get_variation.assert_called_once_with(
             self.project_config,
             self.project_config.get_experiment_from_key('test_experiment'),
-            user_context
+            user_context,
+            user_profile_tracker
         )
         self.assertEqual(1, mock_process.call_count)
         self._validate_event_object(
@@ -1120,11 +1123,12 @@ class OptimizelyTest(base.BaseTest):
 
         log_event = EventFactory.create_log_event(mock_process.call_args[0][0], self.optimizely.logger)
         user_context = mock_get_variation.call_args[0][2]
-
+        user_profile_tracker = mock_get_variation.call_args[0][3]
         mock_get_variation.assert_called_once_with(
             self.project_config,
             self.project_config.get_experiment_from_key('test_experiment'),
-            user_context
+            user_context,
+            user_profile_tracker
         )
         self.assertEqual(1, mock_process.call_count)
         self._validate_event_object(

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -228,9 +228,9 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.FEATURE_TEST), [])]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -303,9 +303,9 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.FEATURE_TEST), [])]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -478,9 +478,9 @@ class UserContextTest(base.BaseTest):
         mock_variation = None
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.ROLLOUT), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.ROLLOUT), [])],
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -553,9 +553,9 @@ class UserContextTest(base.BaseTest):
         mock_variation = None
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.ROLLOUT), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.ROLLOUT), [])],
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -614,9 +614,9 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.FEATURE_TEST), [])],
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -679,8 +679,8 @@ class UserContextTest(base.BaseTest):
 
         with mock.patch(
                 'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=([decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), []]),
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.FEATURE_TEST), [])]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -739,9 +739,9 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.FEATURE_TEST), [])],
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -835,9 +835,9 @@ class UserContextTest(base.BaseTest):
         expected_var = project_config.get_variation_from_key('211127', '211229')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(expected_experiment, expected_var,
-                                                        enums.DecisionSources.ROLLOUT), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(expected_experiment, expected_var,
+                                                        enums.DecisionSources.ROLLOUT), [])],
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -914,9 +914,9 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variation_for_feature',
-                return_value=(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), []),
+                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
+                                                        enums.DecisionSources.FEATURE_TEST), [])],
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -1026,19 +1026,24 @@ class UserContextTest(base.BaseTest):
             options = ['ENABLED_FLAGS_ONLY']
             decisions = user_context.decide_for_keys(flags, options)
 
-        self.assertEqual(1, len(decisions))
+        self.assertEqual(2, len(decisions))
 
         mock_decide.assert_any_call(
             user_context,
-            'test_feature_in_experiment',
+            ['test_feature_in_rollout', 'test_feature_in_experiment'],
             options
         )
+        # mock_decide.assert_any_call(
+        #     user_context,
+        #     'test_feature_in_experiment',
+        #     options
+        # )
 
-        mock_decide.assert_any_call(
-            user_context,
-            'test_feature_in_rollout',
-            options
-        )
+        # mock_decide.assert_any_call(
+        #     user_context,
+        #     'test_feature_in_rollout',
+        #     options
+        # )
 
         self.assertEqual(mocked_decision_1, decisions['test_feature_in_experiment'])
 
@@ -1638,6 +1643,8 @@ class UserContextTest(base.BaseTest):
         self.assertEqual(decide_decision.user_context.get_user_attributes(), {})
 
         expected_reasons = [
+            'Invalid variation is mapped to flag (test_feature_in_experiment), rule (test_experiment) '
+            'and user (test_user) in the forced decision map.',
             'Invalid variation is mapped to flag (test_feature_in_experiment), rule (test_experiment) '
             'and user (test_user) in the forced decision map.',
             'Evaluating audiences for experiment "test_experiment": [].',

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -1105,18 +1105,6 @@ class UserContextTest(base.BaseTest):
             ['test_feature_in_rollout', 'test_feature_in_experiment'],
             options
         )
-        # mock_decide.assert_any_call(
-        #     user_context,
-        #     'test_feature_in_experiment',
-        #     options
-        # )
-
-        # mock_decide.assert_any_call(
-        #     user_context,
-        #     'test_feature_in_rollout',
-        #     options
-        # )
-
         self.assertEqual(mocked_decision_1, decisions['test_feature_in_experiment'])
 
     def test_decide_for_keys__default_options__with__options(self):

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -228,9 +228,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), [])]
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.FEATURE_TEST
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -303,9 +311,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), [])]
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.FEATURE_TEST
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -478,9 +494,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = None
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.ROLLOUT), [])],
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.ROLLOUT
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -553,9 +577,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = None
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.ROLLOUT), [])],
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.ROLLOUT
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -614,9 +646,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), [])],
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.FEATURE_TEST
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -678,9 +718,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), [])]
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.FEATURE_TEST
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -739,9 +787,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), [])],
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.FEATURE_TEST
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -835,9 +891,17 @@ class UserContextTest(base.BaseTest):
         expected_var = project_config.get_variation_from_key('211127', '211229')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(expected_experiment, expected_var,
-                                                        enums.DecisionSources.ROLLOUT), [])],
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        expected_experiment,
+                        expected_var,
+                        enums.DecisionSources.ROLLOUT
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -914,9 +978,17 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
 
         with mock.patch(
-                'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-                return_value=[(decision_service.Decision(mock_experiment, mock_variation,
-                                                        enums.DecisionSources.FEATURE_TEST), [])],
+            'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.FEATURE_TEST
+                    ),
+                    []
+                )
+            ]
         ), mock.patch(
             'optimizely.notification_center.NotificationCenter.send_notifications'
         ) as mock_broadcast_decision, mock.patch(
@@ -972,7 +1044,7 @@ class UserContextTest(base.BaseTest):
             res = {}
             for flag in flags:
                 if flag == 'test_feature_in_experiment':
-                    res[flag] =  mocked_decision_1
+                    res[flag] = mocked_decision_1
                 else:
                     res[flag] = mocked_decision_2
             return res
@@ -1010,7 +1082,7 @@ class UserContextTest(base.BaseTest):
             res = {}
             for flag in flags:
                 if flag == 'test_feature_in_experiment':
-                    res[flag] =  mocked_decision_1
+                    res[flag] = mocked_decision_1
                 else:
                     res[flag] = mocked_decision_2
             return res
@@ -1064,18 +1136,18 @@ class UserContextTest(base.BaseTest):
 
             flags = ['test_feature_in_experiment']
             options = ['EXCLUDE_VARIABLES']
-            
+
             mock_decision = mock.MagicMock()
-            mock_decision.experiment = mock.MagicMock(key = 'test_experiment')
-            mock_decision.variation = mock.MagicMock(key = 'variation')
+            mock_decision.experiment = mock.MagicMock(key='test_experiment')
+            mock_decision.variation = mock.MagicMock(key='variation')
             mock_decision.source = enums.DecisionSources.FEATURE_TEST
-            
-            mock_get_variations.return_value = [(mock_decision,[])]
-            
+
+            mock_get_variations.return_value = [(mock_decision, [])]
+
             user_context.decide_for_keys(flags, options)
 
         mock_get_variations.assert_called_with(
-            mock.ANY,  # ProjectConfig 
+            mock.ANY,  # ProjectConfig
             mock.ANY,  # FeatureFlag list
             user_context,  # UserContext object
             ['EXCLUDE_VARIABLES', 'ENABLED_FLAGS_ONLY']
@@ -1336,8 +1408,16 @@ class UserContextTest(base.BaseTest):
         mock_variation = project_config.get_variation_from_id('test_experiment', '111129')
         with mock.patch(
             'optimizely.decision_service.DecisionService.get_variations_for_feature_list',
-            return_value=[(decision_service.Decision(mock_experiment,
-                                                    mock_variation, enums.DecisionSources.FEATURE_TEST), []),]
+            return_value=[
+                (
+                    decision_service.Decision(
+                        mock_experiment,
+                        mock_variation,
+                        enums.DecisionSources.FEATURE_TEST
+                    ),
+                    []
+                ),
+            ]
         ):
             user_context = opt_obj.create_user_context('test_user')
             decision = user_context.decide('test_feature_in_experiment', [DecideOption.DISABLE_DECISION_EVENT])


### PR DESCRIPTION
Summary
-------
- Currently, decideForKeys loops over the list of flags and calls decide for each, which in turn calls ups. So for decideForKeys, there is two calls per flag to UPS. This PR batches UPS calls when using decideForKeys.

Test plan
---------

- Existing tests are updated to work with the new change. New tests will be added for batching.

Issues
------

-  FSSDK-10763
