### PR TITLE
[FSSDK-11017] update: experiment_id and variation_id added to payloads

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,5 +4,5 @@
 # Line break before operand needs to be ignored for line lengths
 # greater than max-line-length. Best practice shows W504
 ignore = E722, W504
-exclude = optimizely/lib/pymmh3.py,*virtualenv*
+exclude = optimizely/lib/pymmh3.py,*virtualenv*,tests/testapp/application.py
 max-line-length = 120

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1203,18 +1203,6 @@ class Optimizely:
             else None
         )
 
-        # rollout_id = None
-        # if decision_source == DecisionSources.ROLLOUT and feature_flag is not None:
-        #     rollout_id = feature_flag.rolloutId
-        # experiment_id = None
-        # if rule_key is not None:
-        #     experiment_id = project_config.get_experiment_id_by_key_or_rollout_id(rule_key, rollout_id)
-        # variation_id = None
-        # if experiment_id and variation_key:
-        #     variation = project_config.get_variation_from_key_by_experiment_id(experiment_id, variation_key)
-        #     if variation:
-        #         variation_id = variation.id
-
         experiment_id = None
         variation_id = None
 

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1203,17 +1203,32 @@ class Optimizely:
             else None
         )
 
-        rollout_id = None
-        if decision_source == DecisionSources.ROLLOUT and feature_flag is not None:
-            rollout_id = feature_flag.rolloutId
+        # rollout_id = None
+        # if decision_source == DecisionSources.ROLLOUT and feature_flag is not None:
+        #     rollout_id = feature_flag.rolloutId
+        # experiment_id = None
+        # if rule_key is not None:
+        #     experiment_id = project_config.get_experiment_id_by_key_or_rollout_id(rule_key, rollout_id)
+        # variation_id = None
+        # if experiment_id and variation_key:
+        #     variation = project_config.get_variation_from_key_by_experiment_id(experiment_id, variation_key)
+        #     if variation:
+        #         variation_id = variation.id
+
         experiment_id = None
-        if rule_key is not None:
-            experiment_id = project_config.get_experiment_id_by_key_or_rollout_id(rule_key, rollout_id)
         variation_id = None
-        if experiment_id and variation_key:
-            variation = project_config.get_variation_from_key_by_experiment_id(experiment_id, variation_key)
-            if variation:
-                variation_id = variation.id
+
+        try:
+            if flag_decision.experiment is not None:
+                experiment_id = flag_decision.experiment.id
+        except AttributeError:
+            self.logger.warning("flag_decision.experiment has no attribute 'id'")
+
+        try:
+            if flag_decision.variation is not None:
+                variation_id = flag_decision.variation.id
+        except AttributeError:
+            self.logger.warning("flag_decision.variation has no attribute 'id'")
 
         # Send notification
         self.notification_center.send_notifications(

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -340,9 +340,7 @@ class Optimizely:
         user_context = OptimizelyUserContext(self, self.logger, user_id, attributes, False)
 
         decision, _ = self.decision_service.get_variation_for_feature(project_config, feature_flag, user_context)
-        experiment_id = decision.experiment.id if decision.experiment else None
-        variation_id = decision.variation.id if decision.variation else None
-    
+
         if decision.variation:
 
             feature_enabled = decision.variation.featureEnabled
@@ -388,8 +386,6 @@ class Optimizely:
                 'variable_value': actual_value,
                 'variable_type': variable_type,
                 'source_info': source_info,
-                'experiment_id': experiment_id,
-                'variation_id': variation_id
             },
         )
         return actual_value
@@ -431,9 +427,7 @@ class Optimizely:
         user_context = OptimizelyUserContext(self, self.logger, user_id, attributes, False)
 
         decision, _ = self.decision_service.get_variation_for_feature(project_config, feature_flag, user_context)
-        experiment_id = decision.experiment.id if decision.experiment else None
-        variation_id = decision.variation.id if decision.variation else None
-    
+
         if decision.variation:
 
             feature_enabled = decision.variation.featureEnabled
@@ -486,8 +480,6 @@ class Optimizely:
                 'variable_values': all_variables,
                 'source': decision.source,
                 'source_info': source_info,
-                'experiment_id': experiment_id,
-                'variation_id': variation_id
             },
         )
         return all_variables
@@ -654,10 +646,7 @@ class Optimizely:
             decision_notification_type = enums.DecisionNotificationTypes.FEATURE_TEST
         else:
             decision_notification_type = enums.DecisionNotificationTypes.AB_TEST
-            
-        experiment_id = experiment.id if experiment else None
-        variation_id = variation.id if variation else None
-        
+
         self.notification_center.send_notifications(
             enums.NotificationTypes.DECISION,
             decision_notification_type,
@@ -666,8 +655,6 @@ class Optimizely:
             {
                 'experiment_key': experiment_key,
                 'variation_key': variation_key,
-                'experiment_id': experiment_id,
-                'variation_id': variation_id
             },
         )
 
@@ -754,8 +741,6 @@ class Optimizely:
                 'feature_enabled': feature_enabled,
                 'source': decision.source,
                 'source_info': source_info,
-                'experiment_id': decision.experiment.id,
-                'variation_id': decision.variation.id
             },
         )
 
@@ -1220,15 +1205,19 @@ class Optimizely:
             if flag_decision is not None and flag_decision.variation is not None
             else None
         )
-        
-        rollout_id = feature_flag.rolloutId if decision_source == DecisionSources.ROLLOUT else None
-        experiment_id = project_config.get_experiment_id_by_key_or_rollout_id(rule_key, rollout_id)
+
+        rollout_id = None
+        if decision_source == DecisionSources.ROLLOUT and feature_flag is not None:
+            rollout_id = feature_flag.rolloutId
+        experiment_id = None
+        if rule_key is not None:
+            experiment_id = project_config.get_experiment_id_by_key_or_rollout_id(rule_key, rollout_id)
         variation_id = None
-        if variation_key:
+        if experiment_id and variation_key:
             variation = project_config.get_variation_from_key_by_experiment_id(experiment_id, variation_key)
             if variation:
-                variation_id = variation.id     
-        
+                variation_id = variation.id
+
         # Send notification
         self.notification_center.send_notifications(
             enums.NotificationTypes.DECISION,

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -652,10 +652,7 @@ class Optimizely:
             decision_notification_type,
             user_id,
             attributes or {},
-            {
-                'experiment_key': experiment_key,
-                'variation_key': variation_key,
-            },
+            {'experiment_key': experiment_key, 'variation_key': variation_key},
         )
 
         return variation_key

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -723,7 +723,7 @@ class ProjectConfig:
 
         Args:
             key: The key associated with the experiment rule. It can be experiment key or rule key.
-            rollout_id: The ID of the rollout to be searched if the key is not found in the experiment key map.
+            rollout_id: The ID of the rollout to be searched if the experiment if from a rollout.
 
         Returns:
             Optional[str]: The experiment ID if found, otherwise None.
@@ -733,9 +733,9 @@ class ProjectConfig:
             rollout = self.get_rollout_from_id(rollout_id)
             if rollout:
                 for experiment_data in rollout.experiments:
-                    experiment = entities.Experiment(**experiment_data)
-                    if experiment.key == key:
-                        return experiment.id
+                    rollout_experiment = entities.Experiment(**experiment_data)
+                    if rollout_experiment.key == key:
+                        return rollout_experiment.id
 
         # Try getting the experiment from experiment_key_map
         if key:

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -728,13 +728,7 @@ class ProjectConfig:
         Returns:
             Optional[str]: The experiment ID if found, otherwise None.
         """
-        # Try getting the experiment from experiment_key_map first
-        if key:
-            experiment = self.get_experiment_from_key(key)
-            if experiment:
-                return experiment.id
-
-        # If key is not found in experiment_key_map, check a specific rollout (if provided)
+        # Check a specific rollout (if provided)
         if rollout_id:
             rollout = self.get_rollout_from_id(rollout_id)
             if rollout:
@@ -742,5 +736,11 @@ class ProjectConfig:
                     experiment = entities.Experiment(**experiment_data)
                     if experiment.key == key:
                         return experiment.id
+
+        # Try getting the experiment from experiment_key_map
+        if key:
+            experiment = self.get_experiment_from_key(key)
+            if experiment:
+                return experiment.id
 
         return None

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -716,31 +716,3 @@ class ProjectConfig:
                     return variation
 
         return None
-
-    def get_experiment_id_by_key_or_rollout_id(self, key: str, rollout_id: Optional[str] = None) -> Optional[str]:
-        """
-        Retrieves the experiment ID associated with a given rule key or a specific rollout.
-
-        Args:
-            key: The key associated with the experiment rule. It can be experiment key or rule key.
-            rollout_id: The ID of the rollout to be searched if the experiment if from a rollout.
-
-        Returns:
-            Optional[str]: The experiment ID if found, otherwise None.
-        """
-        # Check a specific rollout (if provided)
-        if rollout_id:
-            rollout = self.get_rollout_from_id(rollout_id)
-            if rollout:
-                for experiment_data in rollout.experiments:
-                    rollout_experiment = entities.Experiment(**experiment_data)
-                    if rollout_experiment.key == key:
-                        return rollout_experiment.id
-
-        # Try getting the experiment from experiment_key_map
-        if key:
-            experiment = self.get_experiment_from_key(key)
-            if experiment:
-                return experiment.id
-
-        return None

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -716,3 +716,31 @@ class ProjectConfig:
                     return variation
 
         return None
+
+    def get_experiment_id_by_key_or_rollout_id(self, key: str, rollout_id: Optional[str] = None) -> Optional[str]:
+        """
+        Retrieves the experiment ID associated with a given rule key or a specific rollout.
+
+        Args:
+            key: The key associated with the experiment rule.
+            rollout_id: The ID of the rollout to search if the key is not found.
+
+        Returns:
+            Optional[str]: The experiment ID if found, otherwise None.
+        """
+        # Try getting the experiment from experiment_key_map first
+        if key:
+            experiment = self.get_experiment_from_key(key)
+            if experiment:
+                return experiment.id
+
+        # If key is not found in experiment_key_map, check a specific rollout (if provided)
+        if rollout_id:
+            rollout = self.get_rollout_from_id(rollout_id)
+            if rollout:
+                for experiment in rollout.experiments:
+                    experiment = entities.Experiment(**experiment)
+                    if experiment.key == key:
+                        return experiment.id  
+
+        return None

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -722,8 +722,8 @@ class ProjectConfig:
         Retrieves the experiment ID associated with a given rule key or a specific rollout.
 
         Args:
-            key: The key associated with the experiment rule.
-            rollout_id: The ID of the rollout to search if the key is not found.
+            key: The key associated with the experiment rule. It can be experiment key or rule key.
+            rollout_id: The ID of the rollout to be searched if the key is not found in the experiment key map.
 
         Returns:
             Optional[str]: The experiment ID if found, otherwise None.
@@ -738,9 +738,9 @@ class ProjectConfig:
         if rollout_id:
             rollout = self.get_rollout_from_id(rollout_id)
             if rollout:
-                for experiment in rollout.experiments:
-                    experiment = entities.Experiment(**experiment)
+                for experiment_data in rollout.experiments:
+                    experiment = entities.Experiment(**experiment_data)
                     if experiment.key == key:
-                        return experiment.id  
+                        return experiment.id
 
         return None

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -283,6 +283,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': True,
                 'variables': expected.variables,
+                'experiment_id': mock_experiment.id,
+                'variation_id': mock_variation.id
             },
         )
 
@@ -391,6 +393,24 @@ class UserContextTest(base.BaseTest):
 
         self.compare_opt_decisions(expected, actual)
 
+        # assert event count
+        self.assertEqual(1, mock_send_event.call_count)
+
+        # assert event payload
+        expected_experiment = project_config.get_experiment_from_key(expected.rule_key)
+        expected_var = project_config.get_variation_from_key(expected.rule_key, expected.variation_key)
+        mock_send_event.assert_called_with(
+            project_config,
+            expected_experiment,
+            expected_var,
+            expected.flag_key,
+            expected.rule_key,
+            'rollout',
+            expected.enabled,
+            'test_user',
+            user_attributes
+        )
+
         # assert notification count
         self.assertEqual(1, mock_broadcast_decision.call_count)
 
@@ -408,25 +428,9 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': True,
                 'variables': expected.variables,
+                'experiment_id': expected_experiment.id,
+                'variation_id': expected_var.id
             },
-        )
-
-        # assert event count
-        self.assertEqual(1, mock_send_event.call_count)
-
-        # assert event payload
-        expected_experiment = project_config.get_experiment_from_key(expected.rule_key)
-        expected_var = project_config.get_variation_from_key(expected.rule_key, expected.variation_key)
-        mock_send_event.assert_called_with(
-            project_config,
-            expected_experiment,
-            expected_var,
-            expected.flag_key,
-            expected.rule_key,
-            'rollout',
-            expected.enabled,
-            'test_user',
-            user_attributes
         )
 
     def test_decide_feature_rollout__send_flag_decision_false(self):
@@ -467,6 +471,8 @@ class UserContextTest(base.BaseTest):
         self.assertEqual(1, mock_broadcast_decision.call_count)
 
         # assert notification
+        expected_experiment = project_config.get_experiment_from_key(expected.rule_key)
+        expected_var = project_config.get_variation_from_key(expected.rule_key, expected.variation_key)
         mock_broadcast_decision.assert_called_with(
             enums.NotificationTypes.DECISION,
             'flag',
@@ -480,6 +486,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': False,
                 'variables': expected.variables,
+                'experiment_id': expected_experiment.id,
+                'variation_id': expected_var.id
             },
         )
 
@@ -549,7 +557,9 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': True,
                 'variables': expected.variables,
-            },
+                'experiment_id': None,
+                'variation_id': None
+            }
         )
 
         # assert event count
@@ -632,6 +642,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': False,
                 'variables': expected.variables,
+                'experiment_id': None,
+                'variation_id': None
             },
         )
 
@@ -701,6 +713,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': False,
                 'variables': expected.variables,
+                'experiment_id': mock_experiment.id,
+                'variation_id': mock_variation.id,
             },
         )
 
@@ -773,6 +787,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': False,
                 'variables': expected.variables,
+                'experiment_id': mock_experiment.id,
+                'variation_id': mock_variation.id
             },
         )
 
@@ -834,6 +850,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': True,
                 'variables': expected.variables,
+                'experiment_id': mock_experiment.id,
+                'variation_id': mock_variation.id,
             },
         )
 
@@ -948,6 +966,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': True,
                 'variables': expected.variables,
+                'experiment_id': expected_experiment.id,
+                'variation_id': expected_var.id,
             },
         )
 
@@ -1006,7 +1026,7 @@ class UserContextTest(base.BaseTest):
             enabled=True,
             variables=expected_variables,
             flag_key='test_feature_in_experiment',
-            user_context=user_context
+            user_context=user_context,
         )
 
         self.compare_opt_decisions(expected, actual)
@@ -1025,6 +1045,8 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': False,
                 'variables': expected.variables,
+                'experiment_id': mock_experiment.id,
+                'variation_id': mock_variation.id
             },
         )
 
@@ -1490,6 +1512,9 @@ class UserContextTest(base.BaseTest):
                      'User "test_user" is in variation "control" of experiment test_experiment.']
         )
 
+        expected_experiment = project_config.get_experiment_from_key(expected.rule_key)
+        expected_var = project_config.get_variation_from_key('test_experiment', expected.variation_key)
+
         # assert notification count
         self.assertEqual(1, mock_broadcast_decision.call_count)
 
@@ -1507,11 +1532,10 @@ class UserContextTest(base.BaseTest):
                 'reasons': expected.reasons,
                 'decision_event_dispatched': True,
                 'variables': expected.variables,
+                'experiment_id': expected_experiment.id,
+                'variation_id': expected_var.id
             },
         )
-
-        expected_experiment = project_config.get_experiment_from_key(expected.rule_key)
-        expected_var = project_config.get_variation_from_key('test_experiment', expected.variation_key)
 
         mock_send_event.assert_called_with(
             project_config,


### PR DESCRIPTION
**Summary**
----------

- Added `experiment_id` and `variation_id` to the decision notification listener payload in the Python SDK.
- Ensured that these IDs are included in all decision notifications sent via the notification center.
- Updated unit tests to validate the presence of `experiment_id` and `variation_id` in the payload.

**Why**
-------

To support data warehouse-native customers who rely on SDK notification listeners to send experiment data to their data warehouse, we need to include `experiment_id` and `variation_id` in the payload. This ensures that the stats engine can correctly compute experiment results based on warehouse data.

**Test Plan**
------------

- Modify existing or add unit tests to check for the presence of `experiment_id` and `variation_id` in the notification payload.
- Run all tests to confirm that the changes do not introduce regressions.

**Issues**
---------

- [FSSDK-11017](https://jira.sso.episerver.net/browse/FSSDK-11017)
