### PR TITLE
[FSSDK-11362] Fix CSRF security warning

### DIFF
--- a/tests/testapp/application.py
+++ b/tests/testapp/application.py
@@ -16,15 +16,15 @@ import logging
 import types
 from os import environ
 
-from flask import Flask
-from flask import request
-
 import user_profile_service
-from optimizely import logger
-from optimizely import optimizely
+from flask import CSRFProtect, Flask, request
+
+from optimizely import logger, optimizely
 from optimizely.helpers import enums
 
 app = Flask(__name__)
+# Initialize CSRF protection
+csrf = CSRFProtect(app)
 
 datafile = open('datafile.json', 'r')
 datafile_content = datafile.read()

--- a/tests/testapp/application.py
+++ b/tests/testapp/application.py
@@ -75,7 +75,7 @@ def on_track(_event_key, _user_id, _attributes, _event_tags, event):
 @app.before_request
 def before_request():
     global user_profile_service_instance
-    global optimizely_instance  # noqa: F824
+    global optimizely_instance
 
     user_profile_service_instance = None
     optimizely_instance = None
@@ -118,7 +118,7 @@ def before_request():
 
 @app.after_request
 def after_request(response):
-    global optimizely_instance
+    global optimizely_instance  # noqa: F824
     global listener_return_maps
 
     optimizely_instance.notification_center.clear_all_notifications()

--- a/tests/testapp/application.py
+++ b/tests/testapp/application.py
@@ -75,7 +75,7 @@ def on_track(_event_key, _user_id, _attributes, _event_tags, event):
 @app.before_request
 def before_request():
     global user_profile_service_instance
-    global optimizely_instance
+    global optimizely_instance  # noqa: F824
 
     user_profile_service_instance = None
     optimizely_instance = None


### PR DESCRIPTION
Summary
-------

-  PRISMA is complaining about CSRF protections being disabled in a unit test for a flask app. While not really a vulnerability, good to show proper security even in an example/test. So update to enable CSRF.

Test plan
---------

Run tests.

Issues
------

-  [FSSDK-11362](https://jira.sso.episerver.net/browse/FSSDK-11362)
