### PR TITLE
No events

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Each method is described below.
           config_manager=custom_config_manager
         )
 
+
+### NoOpEventDispatcher
+
+If you are only interested in using Optimizely's [free feature flag](https://www.optimizely.com/products/feature-experimentation/free-feature-flagging/) feature you
+should configure the SDK to not send any event to Optimizely's servers:
+
+    from optimizely.event_dispatcher import NoOpEventDispatcher
+
+    optimizely_client = optimizely.Optimizely(
+        sdk_key='your-sdk-key-here',
+        event_dispatcher=NoOpEventDispatcher()
+    )
+
+
 ### PollingConfigManager
 
 The [PollingConfigManager](https://github.com/optimizely/python-sdk/blob/master/optimizely/config_manager.py#L150) asynchronously polls for

--- a/optimizely/event_dispatcher.py
+++ b/optimizely/event_dispatcher.py
@@ -36,6 +36,18 @@ class CustomEventDispatcher(Protocol):
         ...
 
 
+class NoOpEventDispatcher:
+    """Event dispatcher that doesn't send any events to Optimizely's servers."""
+
+    def dispatch_event(self, event: event_builder.Event) -> None:
+        """No-op implementation that silently discards events.
+
+        Args:
+            event: Event object that would normally be sent to Optimizely's servers.
+        """
+        pass
+
+
 class EventDispatcher:
 
     @staticmethod

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -509,7 +509,7 @@ class PollingConfigManagerTest(base.BaseTest):
         with mock.patch('requests.Session.get', return_value=test_response):
             project_config_manager = config_manager.PollingConfigManager(sdk_key=sdk_key,
                                                                          logger=mock_logger,
-                                                                         update_interval=12345678912345)
+                                                                         update_interval=300)
 
             project_config_manager.stop()
 

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -34,6 +34,11 @@ from optimizely.helpers import enums
 from optimizely.helpers.sdk_settings import OptimizelySdkSettings
 from . import base
 
+import warnings
+import urllib3
+# Suppress SystemTimeWarning from urllib3
+warnings.filterwarnings('ignore', category=urllib3.exceptions.SystemTimeWarning)
+
 
 class OptimizelyTest(base.BaseTest):
     strTest = None
@@ -3965,7 +3970,6 @@ class OptimizelyTest(base.BaseTest):
                 'source_info': {},
             },
         )
-
     def test_get_feature_variable__returns_none_if_none_feature_key(self):
         """ Test that get_feature_variable_* returns None for None feature key. """
 
@@ -5557,3 +5561,4 @@ class OptimizelyWithLoggingTest(base.BaseTest):
 
         mock_send_event.assert_called_with('fullstack', 'great', {'amazing': 'fantastic'}, {})
         mock_logger.error.assert_not_called()
+


### PR DESCRIPTION
Summary
-------

-  Adds support for a no op event dispatcher to avoid sending any event to Optimizely's servers.
- Fixes a couple of minor issues with the test suite that lead to errors and warnings in Python 3.11+

This fork of the SDK allows using Optimizely's free feature flags feature. The client needs to then use its own
approach to report the feature flag decisions to an analytics system. At Vio.com we use Segment to  deliver
events with such decisions to Snowflake and rely on Looker for dashboards that compare various KPIs for all
active feature flags.

