### PR TITLE
[FSSDK-11362] Import CSRFProtect from a better spot so prisma picks it up

### DIFF
--- a/tests/testapp/application.py
+++ b/tests/testapp/application.py
@@ -17,7 +17,8 @@ import types
 from os import environ
 
 import user_profile_service
-from flask import CSRFProtect, Flask, request
+from flask import Flask, request
+from flask_wtf.csrf import CSRFProtect
 
 from optimizely import logger, optimizely
 from optimizely.helpers import enums

--- a/tests/testapp/requirements.txt
+++ b/tests/testapp/requirements.txt
@@ -1,1 +1,2 @@
-Flask==2.2.5
+Flask==3.1.0
+flask-wtf==1.2.2


### PR DESCRIPTION
Summary
-------

-  CSRF is imported incorrectly. This fixes it.

Test plan
---------

Issues
------

-  [FSSDK-11362](https://jira.sso.episerver.net/browse/FSSDK-11362)
