### PR TITLE
Remove unused dependency and update core.txt

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,3 @@
 jsonschema>=3.2.0
-pyrsistent>=0.16.0
 requests>=2.21
 idna>=2.10


### PR DESCRIPTION
As part of our ongoing research on Python dependency management, we noticed a potential improvement in your project’s dependency list.

Specifically, the dependency `pyrsistent>=0.16.0` was declared in `requirements/core.txt`, but after analyzing the codebase, we found that it is **not imported or used anywhere**.

This PR removes it from the dependency file to simplify maintenance and let `pip` resolve only what is actually needed. Removing unused dependencies helps reduce potential attack surface, avoid unnecessary version pinning, and improve long-term maintainability.

The [pip documentation](https://pip.pypa.io/en/stable/user_guide/#requirements-files) also encourages auditing your top-level requirements and removing unused or transitive ones to simplify the dependency graph and minimize the risk of version conflicts.