### PR TITLE
[FSSDK-12497] Fix return in finally block silently swallowing exceptions

### DIFF
--- a/optimizely/config_manager.py
+++ b/optimizely/config_manager.py
@@ -145,14 +145,14 @@ class StaticConfigManager(BaseConfigManager):
         except optimizely_exceptions.UnsupportedDatafileVersionException as error:
             error_msg = error.args[0]
             error_to_handle = error
-        except:
+        except Exception:
             error_msg = enums.Errors.INVALID_INPUT.format('datafile')
             error_to_handle = optimizely_exceptions.InvalidInputException(error_msg)
-        finally:
-            if error_msg or config is None:
-                self.logger.error(error_msg)
-                self.error_handler.handle_error(error_to_handle or Exception('Unknown Error'))
-                return
+
+        if error_msg or config is None:
+            self.logger.error(error_msg)
+            self.error_handler.handle_error(error_to_handle or Exception('Unknown Error'))
+            return
 
         previous_revision = self._config.get_revision() if self._config else None
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -200,6 +200,36 @@ class StaticConfigManagerTest(base.BaseTest):
         mock_logger.error.assert_called_once_with('Provided "datafile" is in an invalid format.')
         self.assertEqual(0, mock_notification_center.call_count)
 
+    def test_set_config__exception_in_except_block_is_not_swallowed(self):
+        """ Test that an exception raised inside the except block propagates
+        to the caller instead of being silently swallowed.
+
+        Per Python docs, a return inside a finally clause suppresses any
+        in-flight exception. The _set_config method must not use return in
+        finally, so that unexpected errors in the error-handling path are
+        surfaced rather than silently lost.
+        """
+        test_datafile = json.dumps(self.config_dict_with_features)
+        mock_logger = mock.Mock()
+
+        with mock.patch('optimizely.config_manager.BaseConfigManager._validate_instantiation_options'):
+            project_config_manager = config_manager.StaticConfigManager(
+                datafile=test_datafile, logger=mock_logger,
+            )
+
+        # Make ProjectConfig raise so we enter the bare except block,
+        # then make the except block itself raise by breaking INVALID_INPUT.
+        with mock.patch(
+            'optimizely.project_config.ProjectConfig.__init__',
+            side_effect=Exception('something broke'),
+        ), mock.patch.object(
+            enums.Errors, 'INVALID_INPUT', new=None,
+        ):
+            # The except block will raise AttributeError ('NoneType' has no 'format').
+            # Correct behavior: this exception must propagate to the caller.
+            with self.assertRaises(AttributeError):
+                project_config_manager._set_config(test_datafile)
+
     def test_get_config(self):
         """ Test get_config. """
         test_datafile = json.dumps(self.config_dict_with_features)


### PR DESCRIPTION
## Summary

Fixes a bug where a `return` statement inside a `finally` block in `_set_config` silently swallows exceptions. Per [Python docs](https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions), a `return` in `finally` suppresses any in-flight exception, meaning errors raised inside `except` blocks are completely lost with no traceback.

## Changes

- Moved error-handling logic out of `finally` into normal control flow after the try/except block
- Changed bare `except:` to `except Exception:` to avoid catching `KeyboardInterrupt` and `SystemExit`
- Added unit test verifying that exceptions in the `except` block propagate correctly

## Jira Ticket

[FSSDK-12497](https://optimizely-ext.atlassian.net/browse/FSSDK-12497)

## Issues

- Fixes https://github.com/optimizely/python-sdk/issues/439

[FSSDK-12497]: https://optimizely-ext.atlassian.net/browse/FSSDK-12497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ