### PR TITLE
[AI-FSSDK] [FSSDK-12368] Cleanup flag base setup (local holdouts)

### DIFF
--- a/optimizely/decision_service.py
+++ b/optimizely/decision_service.py
@@ -733,30 +733,7 @@ class DecisionService:
         reasons = decide_reasons.copy() if decide_reasons else []
         user_id = user_context.user_id
 
-        # Check holdouts
-        holdouts = project_config.get_holdouts_for_flag(feature_flag.key)
-        for holdout in holdouts:
-            holdout_decision = self.get_variation_for_holdout(holdout, user_context, project_config)
-            reasons.extend(holdout_decision['reasons'])
-
-            decision = holdout_decision['decision']
-            # Check if user was bucketed into holdout (has a variation)
-            if decision.variation is None:
-                continue
-
-            message = (
-                f"The user '{user_id}' is bucketed into holdout '{holdout.key}' "
-                f"for feature flag '{feature_flag.key}'."
-            )
-            self.logger.info(message)
-            reasons.append(message)
-            return {
-                'decision': holdout_decision['decision'],
-                'error': False,
-                'reasons': reasons
-            }
-
-        # If no holdout decision, check experiments then rollouts
+        # Check experiments then rollouts
         if feature_flag.experimentIds:
             for experiment_id in feature_flag.experimentIds:
                 experiment = project_config.get_experiment_from_id(experiment_id)

--- a/optimizely/entities.py
+++ b/optimizely/entities.py
@@ -222,8 +222,6 @@ class Holdout(BaseEntity):
         variations: list[VariationDict],
         trafficAllocation: list[TrafficAllocation],
         audienceIds: list[str],
-        includedFlags: Optional[list[str]] = None,
-        excludedFlags: Optional[list[str]] = None,
         audienceConditions: Optional[Sequence[str | list[str]]] = None,
         **kwargs: Any
     ):
@@ -234,8 +232,6 @@ class Holdout(BaseEntity):
         self.trafficAllocation = trafficAllocation
         self.audienceIds = audienceIds
         self.audienceConditions = audienceConditions
-        self.includedFlags = includedFlags or []
-        self.excludedFlags = excludedFlags or []
 
     def get_audience_conditions_or_ids(self) -> Sequence[str | list[str]]:
         """Returns audienceConditions if present, otherwise audienceIds.

--- a/optimizely/helpers/types.py
+++ b/optimizely/helpers/types.py
@@ -130,5 +130,3 @@ class HoldoutDict(ExperimentDict):
     Extends ExperimentDict with holdout-specific properties.
     """
     holdoutStatus: HoldoutStatus
-    includedFlags: list[str]
-    excludedFlags: list[str]

--- a/optimizely/project_config.py
+++ b/optimizely/project_config.py
@@ -93,10 +93,6 @@ class ProjectConfig:
         holdouts_data: list[types.HoldoutDict] = config.get('holdouts', [])
         self.holdouts: list[entities.Holdout] = []
         self.holdout_id_map: dict[str, entities.Holdout] = {}
-        self.global_holdouts: list[entities.Holdout] = []
-        self.included_holdouts: dict[str, list[entities.Holdout]] = {}
-        self.excluded_holdouts: dict[str, list[entities.Holdout]] = {}
-        self.flag_holdouts_map: dict[str, list[entities.Holdout]] = {}
 
         # Convert holdout dicts to Holdout entities
         for holdout_data in holdouts_data:
@@ -104,32 +100,12 @@ class ProjectConfig:
             holdout = entities.Holdout(**holdout_data)
             self.holdouts.append(holdout)
 
-            # Only process Running holdouts but doing it here for efficiency like the original Python implementation)
+            # Only process Running holdouts
             if not holdout.is_activated:
                 continue
 
             # Map by ID for quick lookup
             self.holdout_id_map[holdout.id] = holdout
-
-            # Categorize as global vs flag-specific
-            # Global holdouts: apply to all flags unless explicitly excluded
-            # Flag-specific holdouts: only apply to explicitly included flags
-            if not holdout.includedFlags:
-                # This is a global holdout
-                self.global_holdouts.append(holdout)
-
-                # Track which flags this global holdout excludes
-                if holdout.excludedFlags:
-                    for flag_id in holdout.excludedFlags:
-                        if flag_id not in self.excluded_holdouts:
-                            self.excluded_holdouts[flag_id] = []
-                        self.excluded_holdouts[flag_id].append(holdout)
-            else:
-                # This holdout applies to specific flags only
-                for flag_id in holdout.includedFlags:
-                    if flag_id not in self.included_holdouts:
-                        self.included_holdouts[flag_id] = []
-                    self.included_holdouts[flag_id].append(holdout)
 
         # Utility maps for quick lookup
         self.group_id_map: dict[str, entities.Group] = self._generate_key_map(self.groups, 'id', entities.Group)
@@ -262,22 +238,6 @@ class ProjectConfig:
                         self.variation_variable_usage_map[everyone_else_variation.id] = self._generate_key_map(
                             everyone_else_variation.variables, 'id', entities.Variation.VariableUsage
                         )
-
-            flag_id = feature.id
-            applicable_holdouts: list[entities.Holdout] = []
-
-            # Add global holdouts first, excluding any that are explicitly excluded for this flag
-            excluded_holdouts = self.excluded_holdouts.get(flag_id, [])
-            for holdout in self.global_holdouts:
-                if holdout not in excluded_holdouts:
-                    applicable_holdouts.append(holdout)
-
-            # Add flag-specific local holdouts AFTER global holdouts
-            if flag_id in self.included_holdouts:
-                applicable_holdouts.extend(self.included_holdouts[flag_id])
-
-            if applicable_holdouts:
-                self.flag_holdouts_map[feature.key] = applicable_holdouts
 
             rollout = None if len(feature.rolloutId) == 0 else self.rollout_id_map[feature.rolloutId]
             if rollout:
@@ -912,19 +872,6 @@ class ProjectConfig:
 
         return None
 
-    def get_holdouts_for_flag(self, flag_key: str) -> list[entities.Holdout]:
-        """ Helper method to get holdouts from an applied feature flag.
-
-        Args:
-            flag_key: Key of the feature flag.
-
-        Returns:
-            The holdouts that apply for a specific flag as Holdout entity objects.
-        """
-        if not self.holdouts:
-            return []
-
-        return self.flag_holdouts_map.get(flag_key, [])
 
     def get_holdout(self, holdout_id: str) -> Optional[entities.Holdout]:
         """ Helper method to get holdout from holdout ID.

--- a/tests/test_bucketing_holdout.py
+++ b/tests/test_bucketing_holdout.py
@@ -62,8 +62,6 @@ class BucketerHoldoutTest(base.BaseTest):
                 'id': 'holdout_1',
                 'key': 'test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -92,8 +90,6 @@ class BucketerHoldoutTest(base.BaseTest):
                 'id': 'holdout_empty_1',
                 'key': 'empty_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [],
                 'trafficAllocation': []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1395,9 +1395,7 @@ class HoldoutConfigTest(base.BaseTest):
                 'status': 'Running',
                 'variations': [],
                 'trafficAllocation': [],
-                'audienceIds': [],
-                'includedFlags': [],
-                'excludedFlags': [boolean_feature_id]
+                'audienceIds': []
             },
             {
                 'id': 'holdout_2',
@@ -1405,9 +1403,7 @@ class HoldoutConfigTest(base.BaseTest):
                 'status': 'Running',
                 'variations': [],
                 'trafficAllocation': [],
-                'audienceIds': [],
-                'includedFlags': [multi_variate_feature_id],
-                'excludedFlags': []
+                'audienceIds': []
             },
             {
                 'id': 'holdout_3',
@@ -1415,64 +1411,13 @@ class HoldoutConfigTest(base.BaseTest):
                 'status': 'Inactive',
                 'variations': [],
                 'trafficAllocation': [],
-                'audienceIds': [],
-                'includedFlags': [boolean_feature_id],
-                'excludedFlags': []
+                'audienceIds': []
             }
         ]
 
         self.config_json_with_holdouts = json.dumps(config_body_with_holdouts)
         opt_obj = optimizely.Optimizely(self.config_json_with_holdouts)
         self.config_with_holdouts = opt_obj.config_manager.get_config()
-
-    def test_get_holdouts_for_flag__non_existent_flag(self):
-        """ Test that get_holdouts_for_flag returns empty array for non-existent flag. """
-
-        holdouts = self.config_with_holdouts.get_holdouts_for_flag('non_existent_flag')
-        self.assertEqual([], holdouts)
-
-    def test_get_holdouts_for_flag__returns_global_and_specific_holdouts(self):
-        """ Test that get_holdouts_for_flag returns global holdouts that do not exclude the flag
-        and specific holdouts that include the flag. """
-
-        holdouts = self.config_with_holdouts.get_holdouts_for_flag('test_feature_in_experiment_and_rollout')
-        self.assertEqual(2, len(holdouts))
-
-        global_holdout = next((h for h in holdouts if h['key'] == 'global_holdout'), None)
-        self.assertIsNotNone(global_holdout)
-        self.assertEqual('holdout_1', global_holdout['id'])
-
-        specific_holdout = next((h for h in holdouts if h['key'] == 'specific_holdout'), None)
-        self.assertIsNotNone(specific_holdout)
-        self.assertEqual('holdout_2', specific_holdout['id'])
-
-    def test_get_holdouts_for_flag__excludes_global_holdouts_for_excluded_flags(self):
-        """ Test that get_holdouts_for_flag does not return global holdouts that exclude the flag. """
-
-        holdouts = self.config_with_holdouts.get_holdouts_for_flag('boolean_single_variable_feature')
-        self.assertEqual(0, len(holdouts))
-
-        global_holdout = next((h for h in holdouts if h['key'] == 'global_holdout'), None)
-        self.assertIsNone(global_holdout)
-
-    def test_get_holdouts_for_flag__caches_results(self):
-        """ Test that get_holdouts_for_flag caches results for subsequent calls. """
-
-        holdouts1 = self.config_with_holdouts.get_holdouts_for_flag('test_feature_in_experiment_and_rollout')
-        holdouts2 = self.config_with_holdouts.get_holdouts_for_flag('test_feature_in_experiment_and_rollout')
-
-        # Should be the same object (cached)
-        self.assertIs(holdouts1, holdouts2)
-        self.assertEqual(2, len(holdouts1))
-
-    def test_get_holdouts_for_flag__returns_only_global_for_non_targeted_flags(self):
-        """ Test that get_holdouts_for_flag returns only global holdouts for flags not specifically targeted. """
-
-        holdouts = self.config_with_holdouts.get_holdouts_for_flag('test_feature_in_rollout')
-
-        # Should only include global holdout (not excluded and no specific targeting)
-        self.assertEqual(1, len(holdouts))
-        self.assertEqual('global_holdout', holdouts[0]['key'])
 
     def test_get_holdout__returns_holdout_for_valid_id(self):
         """ Test that get_holdout returns holdout when valid ID is provided. """

--- a/tests/test_decision_service_holdout.py
+++ b/tests/test_decision_service_holdout.py
@@ -46,8 +46,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'holdout_1',
                 'key': 'test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -76,8 +74,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'holdout_2',
                 'key': 'excluded_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [test_feature_id],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -268,60 +264,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
 
     # get_variation_for_feature with holdouts tests
 
-    def test_user_bucketed_into_holdout_returns_before_experiments(self):
-        """
-        When user is bucketed into holdout, should return holdout decision
-        before checking experiments or rollouts.
-        """
-        feature_flag = self.config_with_holdouts.get_feature_from_key('test_feature_in_experiment')
-        self.assertIsNotNone(feature_flag)
-
-        user_context = self.opt_obj.create_user_context('testUserId', {})
-
-        # Mock get_holdouts_for_flag to return holdouts
-        holdout = self.config_with_holdouts.holdouts[0] if self.config_with_holdouts.holdouts else None
-        self.assertIsNotNone(holdout)
-
-        holdout_variation = holdout.variations[0]
-
-        # Create a holdout decision
-        mock_holdout_decision = decision_service.Decision(
-            experiment=holdout,
-            variation=holdout_variation,
-            source=enums.DecisionSources.HOLDOUT,
-            cmab_uuid=None
-        )
-
-        mock_holdout_result = {
-            'decision': mock_holdout_decision,
-            'error': False,
-            'reasons': []
-        }
-
-        # Mock get_holdouts_for_flag to return holdouts so the holdout path is taken
-        with mock.patch.object(
-            self.config_with_holdouts,
-            'get_holdouts_for_flag',
-            return_value=[holdout]
-        ):
-            with mock.patch.object(
-                self.opt_obj.decision_service,
-                'get_variation_for_holdout',
-                return_value=mock_holdout_result
-            ):
-                decision_result = self.opt_obj.decision_service.get_variation_for_feature(
-                    self.config_with_holdouts,
-                    feature_flag,
-                    user_context
-                )
-
-                self.assertIsNotNone(decision_result)
-
-                # Decision should be valid and from holdout
-                decision = decision_result['decision']
-                self.assertEqual(decision.source, enums.DecisionSources.HOLDOUT)
-                self.assertIsNotNone(decision.variation)
-
     def test_no_holdout_decision_falls_through_to_experiment_and_rollout(self):
         """When holdout returns no decision, should fall through to experiment and rollout evaluation."""
         feature_flag = self.config_with_holdouts.get_feature_from_key('test_feature_in_experiment')
@@ -375,42 +317,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
         )
 
         self.assertIsNotNone(decision_result)
-
-    def test_evaluates_global_holdouts_for_all_flags(self):
-        """Should evaluate global holdouts for all flags."""
-        feature_flag = self.config_with_holdouts.get_feature_from_key('test_feature_in_experiment')
-        self.assertIsNotNone(feature_flag)
-
-        # Get global holdouts
-        global_holdouts = [
-            h for h in self.config_with_holdouts.holdouts
-            if not h.includedFlags or len(h.includedFlags) == 0
-        ]
-
-        if global_holdouts:
-            user_context = self.opt_obj.create_user_context('testUserId', {})
-
-            result = self.decision_service_with_holdouts.get_variations_for_feature_list(
-                self.config_with_holdouts,
-                [feature_flag],
-                user_context,
-                []
-            )
-
-            self.assertIsNotNone(result)
-            self.assertIsInstance(result, list)
-
-    def test_respects_included_and_excluded_flags_configuration(self):
-        """Should respect included and excluded flags configuration."""
-        feature_flag = self.config_with_holdouts.get_feature_from_key('test_feature_in_experiment')
-
-        if feature_flag:
-            # Get holdouts for this flag
-            holdouts_for_flag = self.config_with_holdouts.get_holdouts_for_flag('test_feature_in_experiment')
-
-            # Should not include holdouts that exclude this flag
-            excluded_holdout = next((h for h in holdouts_for_flag if h.key == 'excluded_holdout'), None)
-            self.assertIsNone(excluded_holdout)
 
     # Holdout logging and error handling tests
 
@@ -618,8 +524,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'holdout_1',
                 'key': 'test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -727,8 +631,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'holdout_1',
                 'key': 'test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -801,8 +703,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'holdout_1',
                 'key': 'test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -930,8 +830,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'global_holdout',
                 'key': 'global_test_holdout',
                 'status': 'Running',
-                'includedFlags': [],  # Global - applies to all flags
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -977,8 +875,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'included_holdout',
                 'key': 'specific_holdout',
                 'status': 'Running',
-                'includedFlags': [feature1_id],  # Only applies to feature1
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1022,8 +918,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'excluded_holdout',
                 'key': 'global_except_one',
                 'status': 'Running',
-                'includedFlags': [],  # Global
-                'excludedFlags': [feature1_id],  # Except feature1
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1068,8 +962,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'global_holdout',
                 'key': 'global_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1091,8 +983,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'specific_holdout',
                 'key': 'specific_holdout',
                 'status': 'Running',
-                'includedFlags': [feature2_id],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1114,8 +1004,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'excluded_holdout',
                 'key': 'excluded_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [feature1_id],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1154,8 +1042,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'disabled_holdout',
                 'key': 'disabled_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1203,8 +1089,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'metadata_holdout',
                 'key': 'metadata_test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1257,8 +1141,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'send_flag_holdout',
                 'key': 'send_flag_test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1307,8 +1189,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'draft_holdout',
                 'key': 'draft_holdout',
                 'status': 'Draft',  # Not Running
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1347,8 +1227,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'concluded_holdout',
                 'key': 'concluded_holdout',
                 'status': 'Concluded',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1387,8 +1265,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'archived_holdout',
                 'key': 'archived_holdout',
                 'status': 'Archived',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': [],
                 'variations': [
                     {
@@ -1431,8 +1307,6 @@ class DecisionServiceHoldoutTest(base.BaseTest):
                 'id': 'audience_holdout',
                 'key': 'audience_test_holdout',
                 'status': 'Running',
-                'includedFlags': [],
-                'excludedFlags': [],
                 'audienceIds': ['11154'],  # Requires browser_type=chrome
                 'variations': [
                     {


### PR DESCRIPTION
## Summary

Removes legacy flag-level holdout fields from the SDK as cleanup after local holdouts (FSSDK-12369) implementation.

**Jira Ticket:** [FSSDK-12368](https://optimizely-ext.atlassian.net/browse/FSSDK-12368)

## Changes

### Step 1: Remove Legacy Fields ✅
- Removed `includedFlags` and `excludedFlags` from `Holdout.__init__()`
- Removed from `HoldoutDict` type definition

### Step 2: Remove Legacy Methods ✅
- Removed `get_holdouts_for_flag()` method from `ProjectConfig`
- Removed entire flag-level targeting infrastructure:
  - `global_holdouts` list
  - `included_holdouts` dict
  - `excluded_holdouts` dict
  - `flag_holdouts_map` dict
  - Flag-level population logic in `__init__`
- Removed flag-level holdout checking from `DecisionService.get_variation_for_feature()`

### Step 3: Update Tests ✅
- Removed `includedFlags` and `excludedFlags` from all test fixtures (41 occurrences)
- Removed 8 test methods testing deprecated functionality

## Verification

✅ Zero occurrences of `includedFlags`, `excludedFlags`, `getHoldoutsForFlag` in codebase
✅ All deprecated fields/methods removed
✅ Test fixtures updated to use new API

## Impact

- 7 files modified
- 272 lines removed, 5 lines added
- **Net: -267 lines** of legacy code eliminated

## Test Plan

- [ ] All existing tests pass
- [ ] No references to deprecated fields/methods remain
- [ ] Holdout functionality works using new local holdouts API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSSDK-12368]: https://optimizely-ext.atlassian.net/browse/FSSDK-12368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ