### PR TITLE
[FSSDK-12521] chore: preparing for release v5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@ April 29th, 2026
 
 - Added event retry support for reliable event dispatching. ([#475](https://github.com/optimizely/python-sdk/pull/475))
 - Excluded CMAB experiments from UserProfileService to prevent stale cached decisions. ([#474](https://github.com/optimizely/python-sdk/pull/474))
-- Replaced flake8 with ruff for faster, more comprehensive linting. ([#492](https://github.com/optimizely/python-sdk/pull/492))
 - Cleaned up flag-level holdout fields for simplified configuration. ([#507](https://github.com/optimizely/python-sdk/pull/507))
-- Resolved Arnica code risk warnings. ([#498](https://github.com/optimizely/python-sdk/pull/498))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Optimizely Python SDK Changelog
 
+## 5.5.0
+April 29th, 2026
+
+### New Features
+
+#### **Feature Rollout Support**
+
+- Added support for Feature Rollouts, a new rule type that combines Targeted Delivery simplicity with A/B test measurement capabilities. During project config parsing, the "everyone else" variation from the flag's rollout is automatically injected into feature rollout experiments, enabling correct evaluation without changes to decision logic. ([#499](https://github.com/optimizely/python-sdk/pull/499))
+- Removed experiment type validation from config parsing to support flexible rule types. ([#500](https://github.com/optimizely/python-sdk/pull/500))
+
+---
+
+### Enhancements
+
+- Added event retry support for reliable event dispatching. ([#475](https://github.com/optimizely/python-sdk/pull/475))
+- Excluded CMAB experiments from UserProfileService to prevent stale cached decisions. ([#474](https://github.com/optimizely/python-sdk/pull/474))
+- Replaced flake8 with ruff for faster, more comprehensive linting. ([#492](https://github.com/optimizely/python-sdk/pull/492))
+- Cleaned up flag-level holdout fields for simplified configuration. ([#507](https://github.com/optimizely/python-sdk/pull/507))
+- Resolved Arnica code risk warnings. ([#498](https://github.com/optimizely/python-sdk/pull/498))
+
+---
+
+### Bug Fixes
+
+- Fixed `return` in `finally` block silently swallowing exceptions. ([#505](https://github.com/optimizely/python-sdk/pull/505))
+- Fixed `PollingConfigManager` rejecting valid URL-only configuration. ([#497](https://github.com/optimizely/python-sdk/pull/497))
+
+---
+
+
 ## 5.4.0
 December 19th, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Optimizely Python SDK Changelog
 
 ## 5.5.0
-April 29th, 2026
+April 30th, 2026
 
 ### New Features
 

--- a/optimizely/version.py
+++ b/optimizely/version.py
@@ -11,5 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (5, 4, 0)
+version_info = (5, 5, 0)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
## Summary

- Bumped version from 5.4.0 to 5.5.0 in `optimizely/version.py`
- Updated CHANGELOG with all changes since v5.4.0, including:
  - **Feature Rollout support** (#499, #500)
  - **Event retry support** (#475)
  - **CMAB/UPS exclusion fix** (#474)
  - **Ruff linter migration** (#492)
  - **Holdout cleanup** (#507)
  - **Bug fixes**: finally block exception fix (#505), PollingConfigManager URL fix (#497)

Preparing for the Python SDK v5.5.0 release with Feature Rollout as the headline feature.

## Test plan

- All 923 existing unit tests pass on Python 3.12
- No code changes in this PR — only version bump and changelog

## Issues

- [FSSDK-12521](https://optimizely-ext.atlassian.net/browse/FSSDK-12521)

[FSSDK-12521]: https://optimizely-ext.atlassian.net/browse/FSSDK-12521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ