### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify event for single identifier

### DIFF
--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -267,9 +267,28 @@ class OdpEventManager:
         except Full:
             self.logger.warning(Errors.ODP_EVENT_FAILED.format("Queue is full"))
 
-    def identify_user(self, user_id: str) -> None:
+    def identify_user(self, identifiers: dict[str, str]) -> None:
+        """Send an identify event to ODP if there are multiple valid identifiers.
+
+        An identify event is only useful when there are two or more identifiers
+        to link together in the ODP user profile. Sending a single identifier
+        provides no linking value and wastes a network call.
+
+        Args:
+            identifiers: A dictionary of identifier key-value pairs
+                (e.g. {"fs_user_id": "abc", "email": "a@b.com"}).
+        """
+        # Filter out identifiers with None or empty string values.
+        valid_identifiers = {k: v for k, v in identifiers.items() if v}
+
+        if len(valid_identifiers) < 2:
+            self.logger.debug(
+                'ODP identify event is not dispatched (only one identifier provided).'
+            )
+            return
+
         self.send_event(OdpManagerConfig.EVENT_TYPE, 'identified',
-                        {OdpManagerConfig.KEY_FOR_USER_ID: user_id}, {})
+                        valid_identifiers, {})
 
     def update_config(self) -> None:
         """Adds update config signal to event_queue."""

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -283,7 +283,7 @@ class OdpEventManager:
 
         if len(valid_identifiers) < 2:
             self.logger.debug(
-                'ODP identify event is not dispatched (only one identifier provided).'
+                'ODP identify event is not dispatched (fewer than 2 valid identifiers).'
             )
             return
 

--- a/optimizely/odp/odp_event_manager.py
+++ b/optimizely/odp/odp_event_manager.py
@@ -281,6 +281,8 @@ class OdpEventManager:
         # Filter out identifiers with None or empty string values.
         valid_identifiers = {k: v for k, v in identifiers.items() if v}
 
+        # Identify requires 2+ identifiers to link (e.g., vuid + fs_user_id).
+        # A single identifier has no cross-reference value and generates unnecessary traffic.
         if len(valid_identifiers) < 2:
             self.logger.debug(
                 'ODP identify event is not dispatched (fewer than 2 valid identifiers).'

--- a/optimizely/odp/odp_manager.py
+++ b/optimizely/odp/odp_manager.py
@@ -73,7 +73,7 @@ class OdpManager:
 
         return self.segment_manager.fetch_qualified_segments(user_key, user_value, options)
 
-    def identify_user(self, user_id: str) -> None:
+    def identify_user(self, identifiers: dict[str, str]) -> None:
         if not self.enabled or not self.event_manager:
             self.logger.debug('ODP identify event is not dispatched (ODP disabled).')
             return
@@ -81,7 +81,7 @@ class OdpManager:
             self.logger.debug('ODP identify event is not dispatched (ODP not integrated).')
             return
 
-        self.event_manager.identify_user(user_id)
+        self.event_manager.identify_user(identifiers)
 
     def send_event(self, type: str, action: str, identifiers: dict[str, str], data: dict[str, Any]) -> None:
         """

--- a/optimizely/optimizely.py
+++ b/optimizely/optimizely.py
@@ -1541,7 +1541,7 @@ class Optimizely:
             config.all_segments
         )
 
-    def _identify_user(self, user_id: str) -> None:
+    def _identify_user(self, identifiers: dict[str, str]) -> None:
         if not self.is_valid:
             self.logger.error(enums.Errors.INVALID_OPTIMIZELY.format('identify_user'))
             return
@@ -1551,7 +1551,7 @@ class Optimizely:
             self.logger.error(enums.Errors.INVALID_PROJECT_CONFIG.format('identify_user'))
             return
 
-        self.odp_manager.identify_user(user_id)
+        self.odp_manager.identify_user(identifiers)
 
     def _fetch_qualified_segments(self, user_id: str, options: Optional[list[str]] = None) -> Optional[list[str]]:
         if not self.is_valid:

--- a/optimizely/optimizely_user_context.py
+++ b/optimizely/optimizely_user_context.py
@@ -19,6 +19,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Callable, Optional, NewType, Dict
 
 from optimizely.decision import optimizely_decision
+from optimizely.helpers.enums import OdpManagerConfig
 
 if TYPE_CHECKING:
     # prevent circular dependency by skipping import at runtime
@@ -73,7 +74,8 @@ class OptimizelyUserContext:
         ] = {}
 
         if self.client and identify:
-            self.client._identify_user(user_id)
+            identifiers = {OdpManagerConfig.KEY_FOR_USER_ID: user_id}
+            self.client._identify_user(identifiers)
 
     class OptimizelyDecisionContext:
         """ Using class with attributes here instead of namedtuple because

--- a/tests/test_odp_manager.py
+++ b/tests/test_odp_manager.py
@@ -48,7 +48,7 @@ class OdpManagerTest(base.BaseTest):
         mock_logger.reset_mock()
 
         # these call should be dropped gracefully with None
-        manager.identify_user('user1')
+        manager.identify_user({'fs_user_id': 'user1'})
 
         manager.send_event('t1', 'a1', {}, {})
         mock_logger.error.assert_called_once_with('ODP is not enabled.')
@@ -126,10 +126,11 @@ class OdpManagerTest(base.BaseTest):
 
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
 
+        identifiers = {'fs_user_id': 'user1', 'email': 'test@example.com'}
         with mock.patch.object(event_manager, 'identify_user') as mock_identify_user:
-            manager.identify_user('user1')
+            manager.identify_user(identifiers)
 
-        mock_identify_user.assert_called_once_with('user1')
+        mock_identify_user.assert_called_once_with(identifiers)
         mock_logger.error.assert_not_called()
 
     def test_identify_user_odp_integrated(self):
@@ -139,13 +140,14 @@ class OdpManagerTest(base.BaseTest):
         manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config('key1', 'host1', [])
 
+        identifiers = {'fs_user_id': 'user1', 'email': 'test@example.com'}
         with mock.patch.object(event_manager, 'dispatch') as mock_dispatch_event:
-            manager.identify_user('user1')
+            manager.identify_user(identifiers)
 
         mock_dispatch_event.assert_called_once_with({
             'type': 'fullstack',
             'action': 'identified',
-            'identifiers': {'fs_user_id': 'user1'},
+            'identifiers': {'fs_user_id': 'user1', 'email': 'test@example.com'},
             'data': {
                 'idempotence_id': mock.ANY,
                 'data_source_type': 'sdk',
@@ -161,8 +163,9 @@ class OdpManagerTest(base.BaseTest):
         manager = OdpManager(False, CustomCache(), event_manager=event_manager, logger=mock_logger)
         manager.update_odp_config(None, None, [])
 
+        identifiers = {'fs_user_id': 'user1', 'email': 'test@example.com'}
         with mock.patch.object(event_manager, 'dispatch') as mock_dispatch_event:
-            manager.identify_user('user1')
+            manager.identify_user(identifiers)
 
         mock_dispatch_event.assert_not_called()
         mock_logger.error.assert_not_called()
@@ -175,12 +178,55 @@ class OdpManagerTest(base.BaseTest):
         manager = OdpManager(False, OptimizelySegmentsCache, event_manager=event_manager, logger=mock_logger)
         manager.enabled = False
 
+        identifiers = {'fs_user_id': 'user1', 'email': 'test@example.com'}
         with mock.patch.object(event_manager, 'identify_user') as mock_identify_user:
-            manager.identify_user('user1')
+            manager.identify_user(identifiers)
 
         mock_identify_user.assert_not_called()
         mock_logger.error.assert_not_called()
         mock_logger.debug.assert_called_with('ODP identify event is not dispatched (ODP disabled).')
+
+    def test_identify_user_single_identifier_skipped(self):
+        """Identify event should not be sent when only one identifier is provided."""
+        mock_logger = mock.MagicMock()
+        event_manager = OdpEventManager(mock_logger, OdpEventApiManager())
+
+        manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
+        manager.update_odp_config('key1', 'host1', [])
+
+        with mock.patch.object(event_manager, 'dispatch') as mock_dispatch_event:
+            manager.identify_user({'fs_user_id': 'user1'})
+
+        mock_dispatch_event.assert_not_called()
+
+    def test_identify_user_empty_values_not_counted(self):
+        """Identifiers with empty or None values should not count toward the minimum."""
+        mock_logger = mock.MagicMock()
+        event_manager = OdpEventManager(mock_logger, OdpEventApiManager())
+
+        manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
+        manager.update_odp_config('key1', 'host1', [])
+
+        with mock.patch.object(event_manager, 'dispatch') as mock_dispatch_event:
+            manager.identify_user({'fs_user_id': 'user1', 'email': '', 'vuid': None})
+
+        mock_dispatch_event.assert_not_called()
+
+    def test_identify_user_multiple_identifiers_sent(self):
+        """Identify event should be sent when two or more valid identifiers are provided."""
+        mock_logger = mock.MagicMock()
+        event_manager = OdpEventManager(mock_logger, OdpEventApiManager())
+
+        manager = OdpManager(False, LRUCache(10, 20), event_manager=event_manager, logger=mock_logger)
+        manager.update_odp_config('key1', 'host1', [])
+
+        identifiers = {'fs_user_id': 'user1', 'vuid': 'vuid123', 'email': 'a@b.com'}
+        with mock.patch.object(event_manager, 'dispatch') as mock_dispatch_event:
+            manager.identify_user(identifiers)
+
+        mock_dispatch_event.assert_called_once()
+        event = mock_dispatch_event.call_args[0][0]
+        self.assertEqual(event.identifiers, identifiers)
 
     def test_send_event_datafile_not_ready(self):
         mock_logger = mock.MagicMock()

--- a/tests/test_optimizely.py
+++ b/tests/test_optimizely.py
@@ -5343,7 +5343,7 @@ class OptimizelyWithLoggingTest(base.BaseTest):
         with mock.patch.object(client, '_identify_user') as identify:
             client.create_user_context('user-id')
 
-        identify.assert_called_once_with('user-id')
+        identify.assert_called_once_with({'fs_user_id': 'user-id'})
         mock_logger.error.assert_not_called()
         client.close()
 

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -2094,7 +2094,7 @@ class UserContextTest(base.BaseTest):
         with mock.patch.object(client, '_identify_user') as identify:
             OptimizelyUserContext(client, mock_logger, 'user-id')
 
-        identify.assert_called_once_with('user-id')
+        identify.assert_called_once_with({'fs_user_id': 'user-id'})
         mock_logger.error.assert_not_called()
         client.close()
 
@@ -2104,7 +2104,7 @@ class UserContextTest(base.BaseTest):
         with mock.patch.object(client, '_identify_user') as identify:
             user_context = OptimizelyUserContext(client, mock_logger, 'user-id')
 
-        identify.assert_called_once_with('user-id')
+        identify.assert_called_once_with({'fs_user_id': 'user-id'})
         mock_logger.error.assert_not_called()
 
         with mock.patch.object(client, '_identify_user') as identify:


### PR DESCRIPTION
## Summary

Fixes ODP identify event to only send when multiple identifiers exist. Previously, the SDK always sent an identify event when creating a user context, even with just a single `fs_user_id`. This wastes network calls and pollutes ODP identity graphs with single-identifier records that provide no linking value.

## Changes
- Changed `identify_user` method signature across the identify chain to accept an identifiers dict instead of a single user_id string
- Added identifier count check in `OdpEventManager.identify_user` to skip sending when fewer than 2 valid identifiers are present
- Filters out identifiers with None or empty string values before counting
- Added debug-level logging when the identify event is skipped due to single identifier
- Updated existing tests and added new tests for single-identifier blocking and empty-value filtering

## Jira Ticket
[FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ