### PR TITLE
[AI-FSSDK] [FSSDK-12750] Use attribute id instead of key for CMAB prediction requests

### DIFF
--- a/optimizely/cmab/cmab_service.py
+++ b/optimizely/cmab/cmab_service.py
@@ -163,7 +163,7 @@ class DefaultCmabService:
         for attribute_id in cmab_attribute_ids:
             attribute = project_config.attribute_id_map.get(attribute_id)
             if attribute and attribute.key in user_attributes:
-                filtered_user_attributes[attribute.key] = user_attributes[attribute.key]
+                filtered_user_attributes[attribute.id] = user_attributes[attribute.key]
 
         return filtered_user_attributes
 

--- a/tests/test_cmab_service.py
+++ b/tests/test_cmab_service.py
@@ -51,7 +51,7 @@ class TestDefaultCmabService(unittest.TestCase):
 
     def test_returns_decision_from_cache_when_valid(self):
         expected_key = self.cmab_service._get_cache_key("user123", "exp1")
-        expected_attributes = {"age": 25, "location": "USA"}
+        expected_attributes = {"66": 25, "77": "USA"}
         expected_hash = self.cmab_service._hash_attributes(expected_attributes)
 
         self.mock_cmab_cache.lookup.return_value = {
@@ -70,7 +70,7 @@ class TestDefaultCmabService(unittest.TestCase):
 
     def test_ignores_cache_when_option_given(self):
         self.mock_cmab_client.fetch_decision.return_value = "varB"
-        expected_attributes = {"age": 25, "location": "USA"}
+        expected_attributes = {"66": 25, "77": "USA"}
 
         decision, _ = self.cmab_service.get_decision(
             self.mock_project_config,
@@ -124,7 +124,7 @@ class TestDefaultCmabService(unittest.TestCase):
         }
         self.mock_cmab_client.fetch_decision.return_value = "varE"
 
-        expected_attribute = {"age": 25, "location": "USA"}
+        expected_attribute = {"66": 25, "77": "USA"}
         expected_hash = self.cmab_service._hash_attributes(expected_attribute)
         expected_key = self.cmab_service._get_cache_key("user123", "exp1")
 
@@ -148,8 +148,8 @@ class TestDefaultCmabService(unittest.TestCase):
 
     def test_filter_attributes_returns_correct_subset(self):
         filtered = self.cmab_service._filter_attributes(self.mock_project_config, self.mock_user_context, "exp1")
-        self.assertEqual(filtered["age"], 25)
-        self.assertEqual(filtered["location"], "USA")
+        self.assertEqual(filtered["66"], 25)
+        self.assertEqual(filtered["77"], "USA")
 
     def test_filter_attributes_empty_when_no_cmab(self):
         self.mock_project_config.experiment_id_map["exp1"].cmab = None
@@ -178,11 +178,10 @@ class TestDefaultCmabService(unittest.TestCase):
             [OptimizelyDecideOption.IGNORE_CMAB_CACHE]
         )
 
-        # Verify only age and location are passed (attributes configured in setUp)
         self.mock_cmab_client.fetch_decision.assert_called_once_with(
             "exp1",
             self.mock_user_context.user_id,
-            {"age": 25, "location": "USA"},
+            {"66": 25, "77": "USA"},
             decision["cmab_uuid"]
         )
 


### PR DESCRIPTION
## Summary

The CMAB prediction service was incorrectly using attribute keys instead of attribute IDs when building the filtered attributes map for prediction requests. The prediction endpoint expects the attribute ID in the payload, but the code was sending the attribute key. This fix ensures the correct attribute ID is used as the dictionary key in the filtered attributes map.

## Changes

- Updated the attribute filtering logic in the CMAB service to use attribute ID instead of attribute key as the dictionary key
- Updated relevant test expectations to reflect the corrected behavior

## Jira Ticket
[FSSDK-12750](https://optimizely-ext.atlassian.net/browse/FSSDK-12750)

[FSSDK-12750]: https://optimizely-ext.atlassian.net/browse/FSSDK-12750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ