### PR TITLE
[FSSDK-12871] chore: preparing for release v5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Optimizely Python SDK Changelog
 
+## 5.6.0
+July 10th, 2026
+
+### New Features
+
+#### **Local Holdouts Support**
+
+- Added local holdouts support to the Python SDK, enabling flag-level traffic exclusion from experiments. ([#512](https://github.com/optimizely/python-sdk/pull/512))
+- Added `localHoldouts` datafile section parsing for backward compatibility with older datafile formats. ([#517](https://github.com/optimizely/python-sdk/pull/517))
+
+---
+
+### Bug Fixes
+
+- Fixed invalid IDs in holdout decision events by normalizing `campaign_id`, `variation_id`, and `entity_id` fields. ([#518](https://github.com/optimizely/python-sdk/pull/518))
+- Fixed CMAB prediction requests to use attribute ID instead of attribute key. ([#520](https://github.com/optimizely/python-sdk/pull/520))
+- Fixed ODP identify events being sent with a single identifier, which is a no-op. ([#513](https://github.com/optimizely/python-sdk/pull/513))
+
+---
+
+
 ## 5.5.0
 April 30th, 2026
 

--- a/optimizely/version.py
+++ b/optimizely/version.py
@@ -11,5 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_info = (5, 5, 0)
+version_info = (5, 6, 0)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
## Summary

- Bumped version from 5.5.0 to 5.6.0
- Added CHANGELOG entry for v5.6.0 covering:
  - **New Features**: Local holdouts support (#512, #517)
  - **Bug Fixes**: Holdout event ID normalization (#518), CMAB attribute id fix (#520), ODP single-identifier guard (#513)

## Test plan
- [ ] Verify FSC (Full Suite of Checks) passes
- [ ] Verify changelog accuracy against merged PRs
- [ ] Verify version bump in `optimizely/version.py`


[FSSDK-12871](https://optimizely-ext.atlassian.net/browse/FSSDK-12871)

[FSSDK-12871]: https://optimizely-ext.atlassian.net/browse/FSSDK-12871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ